### PR TITLE
fix: correct header name prefix mismatch between server and client

### DIFF
--- a/.changeset/fix-header-prefix-mismatch.md
+++ b/.changeset/fix-header-prefix-mismatch.md
@@ -1,0 +1,5 @@
+---
+"litzjs": patch
+---
+
+Fix header name mismatch between server and client that broke RSC view status codes and revalidation targets. The client was reading `x-litz-status` and `x-litz-revalidate` headers instead of the correct `x-litzjs-status` and `x-litzjs-revalidate` set by the server.

--- a/src/client/transport.tsx
+++ b/src/client/transport.tsx
@@ -144,7 +144,7 @@ export async function createViewResult(
 
   return {
     kind: "view",
-    status: Number(response.headers.get("x-litz-status") ?? response.status),
+    status: Number(response.headers.get("x-litzjs-status") ?? response.status),
     headers: publicHeaders,
     stale: false,
     node: node as import("react").ReactNode,
@@ -187,7 +187,7 @@ export function isRedirectSignal(value: unknown): value is {
 }
 
 export function getRevalidateTargets(headers: Headers): string[] {
-  const value = headers.get("x-litz-revalidate");
+  const value = headers.get("x-litzjs-revalidate");
 
   if (!value) {
     return [];

--- a/tests/transport-headers.test.ts
+++ b/tests/transport-headers.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test, mock } from "bun:test";
+
+import { createViewResult, getRevalidateTargets } from "../src/client/transport";
+
+void mock.module("@vitejs/plugin-rsc/browser", () => ({
+  createFromReadableStream: () => Promise.resolve(null),
+}));
+
+describe("transport header reading", () => {
+  test("createViewResult reads status from x-litzjs-status header", async () => {
+    const response = new Response(new ReadableStream(), {
+      status: 200,
+      headers: {
+        "content-type": "text/x-component",
+        "x-litzjs-kind": "view",
+        "x-litzjs-status": "404",
+        "x-litzjs-view-id": "test-view",
+      },
+    });
+
+    const result = await createViewResult(response);
+
+    expect(result.status).toBe(404);
+  });
+
+  test("createViewResult falls back to response.status when header is absent", async () => {
+    const response = new Response(new ReadableStream(), {
+      status: 201,
+      headers: {
+        "content-type": "text/x-component",
+        "x-litzjs-kind": "view",
+        "x-litzjs-view-id": "test-view",
+      },
+    });
+
+    const result = await createViewResult(response);
+
+    expect(result.status).toBe(201);
+  });
+
+  test("getRevalidateTargets reads from x-litzjs-revalidate header", () => {
+    const headers = new Headers({
+      "x-litzjs-revalidate": "/projects,/dashboard",
+    });
+
+    const targets = getRevalidateTargets(headers);
+
+    expect(targets).toEqual(["/projects", "/dashboard"]);
+  });
+
+  test("getRevalidateTargets returns empty array when header is absent", () => {
+    const headers = new Headers();
+
+    const targets = getRevalidateTargets(headers);
+
+    expect(targets).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes `x-litz-status` → `x-litzjs-status` in `createViewResult()` so custom status codes on RSC view responses are correctly read
- Fixes `x-litz-revalidate` → `x-litzjs-revalidate` in `getRevalidateTargets()` so revalidation targets on view responses are no longer silently dropped
- Adds regression tests covering both header reads and their fallback behavior

Closes #1

## Test plan

- [x] Regression tests confirm `createViewResult` reads custom status from `x-litzjs-status` header
- [x] Regression tests confirm `getRevalidateTargets` reads targets from `x-litzjs-revalidate` header
- [x] Fallback behavior (absent headers) is tested
- [x] All 58 existing tests pass
- [x] Lint, format, and typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)