### PR TITLE
fix: wire dev server AbortController to HTTP request lifecycle

### DIFF
--- a/.changeset/abort-signal-lifecycle.md
+++ b/.changeset/abort-signal-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"litzjs": patch
+---
+
+Wire dev server AbortController to the HTTP request lifecycle so that handler signals abort when the client disconnects. Previously, resource, route, and API handlers received a disconnected AbortSignal that was never aborted, causing long-running handlers to continue executing after the client navigated away. The fix listens for the Node.js IncomingMessage `close` event and calls `controller.abort()`, matching the production server behavior that uses `request.signal`.

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -941,7 +941,9 @@ export async function handleLitzResourceRequest(
       body.request,
       body.payload,
     );
-    const signal = new AbortController().signal;
+    const controller = new AbortController();
+    request.once("close", () => controller.abort());
+    const signal = controller.signal;
     const result = await runDevMiddlewareChain({
       middleware: resource.middleware ?? [],
       request: normalizedRequest.request,
@@ -1083,7 +1085,9 @@ export async function handleLitzRouteRequest(
       body.request,
       body.payload,
     );
-    const signal = new AbortController().signal;
+    const controller = new AbortController();
+    request.once("close", () => controller.abort());
+    const signal = controller.signal;
     const result = await runDevMiddlewareChain({
       middleware: chain.slice(0, targetIndex + 1).flatMap((candidate) => candidate.middleware),
       request: normalizedRequest.request,
@@ -1219,7 +1223,9 @@ export async function handleLitzApiRequest(
 
     const apiRequest = await createNodeRequest(request, requestUrl);
 
-    const signal = new AbortController().signal;
+    const controller = new AbortController();
+    request.once("close", () => controller.abort());
+    const signal = controller.signal;
     const apiResponse = await runDevMiddlewareChain({
       middleware: api?.middleware ?? [],
       request: apiRequest,

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -132,6 +132,11 @@ function createMockResponse(): ServerResponse & { getBody(): string } {
     setHeader(key: string, value: string) {
       headers[key] = value;
     },
+    write(data?: string | Buffer) {
+      if (data) {
+        body += typeof data === "string" ? data : data.toString();
+      }
+    },
     end(data?: string) {
       if (data) {
         body += data;
@@ -142,6 +147,132 @@ function createMockResponse(): ServerResponse & { getBody(): string } {
     },
   } as unknown as ServerResponse & { getBody(): string };
 }
+
+describe("dev server abort signal lifecycle", () => {
+  test("resource handler signal aborts when client disconnects", async () => {
+    let capturedSignal: AbortSignal | undefined;
+    const server = createMockViteDevServer(async () => ({
+      resource: {
+        async loader({ signal }: { signal: AbortSignal }) {
+          capturedSignal = signal;
+          return { data: "ok" };
+        },
+      },
+    }));
+    const internalMetadata = JSON.stringify({
+      path: "/resources/config",
+      operation: "loader",
+      request: {},
+    });
+    const request = createMockRequest({
+      url: "/_litzjs/resource",
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: internalMetadata,
+    });
+    const response = createMockResponse();
+    const next = mock(() => {});
+
+    await handleLitzResourceRequest(
+      server,
+      [
+        {
+          path: "/resources/config",
+          modulePath: "src/resources/config.ts",
+          hasLoader: true,
+          hasAction: false,
+          hasComponent: false,
+        },
+      ],
+      request,
+      response,
+      next,
+    );
+
+    expect(capturedSignal).toBeDefined();
+    expect(capturedSignal!.aborted).toBe(false);
+
+    (request as unknown as PassThrough).emit("close");
+
+    expect(capturedSignal!.aborted).toBe(true);
+  });
+
+  test("route handler signal aborts when client disconnects", async () => {
+    let capturedSignal: AbortSignal | undefined;
+    const server = createMockViteDevServer(async () => ({
+      route: {
+        async loader({ signal }: { signal: AbortSignal }) {
+          capturedSignal = signal;
+          return { data: "ok" };
+        },
+      },
+    }));
+    const internalMetadata = JSON.stringify({
+      path: "/secrets/:id",
+      target: "secrets.show",
+      operation: "loader",
+      request: { params: { id: "1" } },
+    });
+    const request = createMockRequest({
+      url: "/_litzjs/route",
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: internalMetadata,
+    });
+    const response = createMockResponse();
+    const next = mock(() => {});
+
+    await handleLitzRouteRequest(
+      server,
+      [{ id: "secrets.show", path: "/secrets/:id", modulePath: "src/routes/secrets.ts" }],
+      request,
+      response,
+      next,
+    );
+
+    expect(capturedSignal).toBeDefined();
+    expect(capturedSignal!.aborted).toBe(false);
+
+    (request as unknown as PassThrough).emit("close");
+
+    expect(capturedSignal!.aborted).toBe(true);
+  });
+
+  test("API handler signal aborts when client disconnects", async () => {
+    let capturedSignal: AbortSignal | undefined;
+    const server = createMockViteDevServer(async () => ({
+      api: {
+        methods: {
+          GET: async ({ signal }: { signal: AbortSignal }) => {
+            capturedSignal = signal;
+            return new Response("ok");
+          },
+        },
+      },
+    }));
+    const request = createMockRequest({
+      url: "/api/test",
+      method: "GET",
+    });
+    const response = createMockResponse();
+    const next = mock(() => {});
+
+    await handleLitzApiRequest(
+      server,
+      [{ path: "/api/test", modulePath: "src/api/test.ts" }],
+      request,
+      response,
+      next,
+    );
+
+    expect(capturedSignal).toBeDefined();
+    expect(capturedSignal!.aborted).toBe(false);
+
+    (request as unknown as PassThrough).emit("close");
+
+    expect(capturedSignal!.aborted).toBe(true);
+  });
+});
 
 describe("dev server error masking", () => {
   test("does not expose raw error messages from resource handlers", async () => {


### PR DESCRIPTION
## Summary

- Wire `AbortController` to the Node.js `IncomingMessage` `close` event in all three dev server handlers (`handleLitzResourceRequest`, `handleLitzRouteRequest`, `handleLitzApiRequest`) so the abort signal fires when clients disconnect
- Previously, handlers received a disconnected `AbortSignal` that was never aborted, causing long-running loaders/actions to continue executing after client navigation
- Matches production server behavior which uses `request.signal` directly

## Test plan

- [x] Added regression tests for all three handler types verifying the signal aborts on request close
- [x] All 84 existing tests pass
- [x] TypeScript type check passes
- [x] Linting and formatting pass

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)