### PR TITLE
fix: preserve repeated query params across route, resource, and api transport

### DIFF
--- a/.changeset/four-cobras-prove.md
+++ b/.changeset/four-cobras-prove.md
@@ -1,0 +1,5 @@
+---
+"litzjs": patch
+---
+
+Preserve repeated query parameters across API fetches, internal route/resource transport, and cache keys.

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -11,6 +11,7 @@ import {
   matchPathname,
   sortByPathSpecificity,
 } from "../path-matching";
+import { createSearchParamRecord, type SearchParamRecord } from "../search-params";
 import { installClientBindings } from "./bindings";
 import { createLinkComponent } from "./link";
 import { fetchRouteLoadersInParallel, processLoaderResults } from "./loader-fetch";
@@ -1193,7 +1194,7 @@ function buildActiveMatches(
 ): ActiveMatch[] {
   const routeParams = extractRouteParams(route.path, pathname) ?? {};
   const layouts = getLayoutChain(route.options?.layout);
-  const sortedSearch = sortRecord(Object.fromEntries(search.entries()));
+  const sortedSearch = sortRecord(createSearchParamRecord(search));
   const layoutMatches = layouts.map((layout) => {
     const params =
       extractRouteParams(layout.path, pathname) ?? filterParamsForPath(routeParams, layout.path);
@@ -1271,7 +1272,7 @@ function filterParamsForPath(
 function createRouteCacheKey(
   path: string,
   params: Record<string, string>,
-  sortedSearch: Record<string, string>,
+  sortedSearch: SearchParamRecord,
 ): string {
   return JSON.stringify({
     path,

--- a/src/client/resources.tsx
+++ b/src/client/resources.tsx
@@ -13,6 +13,11 @@ import type {
 
 import { createFormDataPayload } from "../form-data";
 import { createInternalActionRequestInit, LITZ_RESULT_ACCEPT } from "../internal-transport";
+import {
+  createSearchParamRecord,
+  createSearchParams,
+  type SearchParamRecord,
+} from "../search-params";
 import { applySearchParams } from "./navigation";
 import { sortRecord } from "./sort-record";
 import {
@@ -81,7 +86,7 @@ type ResourceStoreEntry = {
 
 type NormalizedResourceRequest = {
   params: Record<string, string>;
-  search: Record<string, string>;
+  search: SearchParamRecord;
 };
 
 type PreparedResourceRequest = {
@@ -307,16 +312,14 @@ export function createResourceComponent<
 function useResourceRuntime(resourcePath: string, request?: ResourceRequest): ResourceRuntimeState {
   const params = React.useMemo(() => request?.params ?? {}, [request?.params]);
   const incomingSearchKey = React.useMemo(
-    () => createUrlSearchParams(request?.search).toString(),
+    () => createSearchParams(request?.search).toString(),
     [request?.search],
   );
-  const [searchState, setSearchState] = React.useState(() =>
-    createUrlSearchParams(request?.search),
-  );
+  const [searchState, setSearchState] = React.useState(() => createSearchParams(request?.search));
 
   React.useEffect(() => {
     setSearchState((current) =>
-      current.toString() === incomingSearchKey ? current : createUrlSearchParams(request?.search),
+      current.toString() === incomingSearchKey ? current : createSearchParams(request?.search),
     );
   }, [incomingSearchKey, request?.search]);
 
@@ -575,21 +578,9 @@ async function performPreparedResourceRequest(
   return entry.inFlight;
 }
 
-function createUrlSearchParams(search?: ResourceRequest["search"]): URLSearchParams {
-  if (!search) {
-    return new URLSearchParams();
-  }
-
-  if (search instanceof URLSearchParams) {
-    return new URLSearchParams(search);
-  }
-
-  return new URLSearchParams(search);
-}
-
 function normalizeResourceRequest(request?: ResourceRequest): NormalizedResourceRequest {
   const params = request?.params ?? {};
-  const search = Object.fromEntries(createUrlSearchParams(request?.search).entries());
+  const search = createSearchParamRecord(createSearchParams(request?.search));
 
   return {
     params,

--- a/src/client/runtime.tsx
+++ b/src/client/runtime.tsx
@@ -4,6 +4,11 @@ import type { ActionHookResult, LoaderHookResult, ResourceRequest } from "../ind
 
 import { createInternalActionRequestInit, LITZ_RESULT_ACCEPT } from "../internal-transport";
 import {
+  createSearchParamRecord,
+  createSearchParams,
+  type SearchParamRecord,
+} from "../search-params";
+import {
   isRedirectSignal,
   isRouteLikeError,
   parseActionResponse,
@@ -59,14 +64,11 @@ export async function fetchRouteAction(
 
 function normalizeRequest(request: ResourceRequest): {
   params: Record<string, string>;
-  search: Record<string, string>;
+  search: SearchParamRecord;
 } {
   return {
     params: request.params ?? {},
-    search:
-      request.search instanceof URLSearchParams
-        ? Object.fromEntries(request.search.entries())
-        : (request.search ?? {}),
+    search: createSearchParamRecord(createSearchParams(request.search)),
   };
 }
 

--- a/src/client/sort-record.ts
+++ b/src/client/sort-record.ts
@@ -1,4 +1,4 @@
-export function sortRecord(record: Record<string, string>): Record<string, string> {
+export function sortRecord<TValue>(record: Record<string, TValue>): Record<string, TValue> {
   return Object.fromEntries(
     Object.entries(record).sort(([left], [right]) => left.localeCompare(right)),
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,13 @@ import * as React from "react";
 
 import { getClientBindings } from "./client/bindings";
 import { interpolatePath } from "./path-matching";
+import {
+  createSearchParams,
+  type SearchParamRecord,
+  type SearchParamsInput,
+} from "./search-params";
+
+export type { SearchParamRecord, SearchParamValue } from "./search-params";
 
 export type MiddlewareOverrides<TContext = unknown> = {
   context?: TContext;
@@ -245,7 +252,7 @@ type PathRequestParams<TPath extends string> = string extends TPath
       };
 
 type SearchRequest = {
-  search?: URLSearchParams | Record<string, string>;
+  search?: SearchParamsInput;
 };
 
 type HasRequiredPathParams<TPath extends string> = string extends TPath
@@ -1447,14 +1454,10 @@ export function error<TData = unknown>(
 function buildApiHref(
   pathPattern: string,
   params?: Record<string, string>,
-  search?: URLSearchParams | Record<string, string>,
+  search?: SearchParamsInput,
 ): string {
   const pathname = interpolatePath(pathPattern, params ?? {}, "API");
-
-  const searchParams =
-    search instanceof URLSearchParams
-      ? new URLSearchParams(search)
-      : new URLSearchParams(search ?? {});
+  const searchParams = createSearchParams(search);
   const searchString = searchParams.toString();
 
   return searchString ? `${pathname}?${searchString}` : pathname;

--- a/src/internal-transport.ts
+++ b/src/internal-transport.ts
@@ -1,3 +1,5 @@
+import type { SearchParamRecord } from "./search-params";
+
 import { createFormDataPayload } from "./form-data";
 
 export type InternalPayloadEntry = [string, FormDataEntryValue];
@@ -18,7 +20,7 @@ export type InternalRequestMetadata = {
   operation?: "loader" | "action";
   request?: {
     params?: Record<string, string>;
-    search?: Record<string, string>;
+    search?: SearchParamRecord;
   };
 };
 

--- a/src/search-params.ts
+++ b/src/search-params.ts
@@ -1,0 +1,51 @@
+export type SearchParamValue = string | string[];
+export type SearchParamRecord = Record<string, SearchParamValue>;
+export type SearchParamsInput = URLSearchParams | SearchParamRecord;
+
+export function createSearchParams(search?: SearchParamsInput): URLSearchParams {
+  if (!search) {
+    return new URLSearchParams();
+  }
+
+  if (search instanceof URLSearchParams) {
+    return new URLSearchParams(search);
+  }
+
+  const searchParams = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(search)) {
+    if (Array.isArray(value)) {
+      for (const entry of value) {
+        searchParams.append(key, entry);
+      }
+
+      continue;
+    }
+
+    searchParams.append(key, value);
+  }
+
+  return searchParams;
+}
+
+export function createSearchParamRecord(search: URLSearchParams): SearchParamRecord {
+  const record: SearchParamRecord = {};
+
+  for (const [key, value] of search.entries()) {
+    const currentValue = record[key];
+
+    if (currentValue === undefined) {
+      record[key] = value;
+      continue;
+    }
+
+    if (Array.isArray(currentValue)) {
+      record[key] = [...currentValue, value];
+      continue;
+    }
+
+    record[key] = [currentValue, value];
+  }
+
+  return record;
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -6,6 +6,7 @@ import {
   matchPathname,
   trimPathSegments,
 } from "../path-matching";
+import { createSearchParams, type SearchParamRecord } from "../search-params";
 import { parseInternalRequestBody, type InternalRequestBody } from "./internal-requests";
 import { createInternalHandlerHeaders } from "./request-headers";
 
@@ -611,7 +612,7 @@ function normalizeInternalRequest(
   requestData:
     | {
         params?: Record<string, string>;
-        search?: Record<string, string>;
+        search?: SearchParamRecord;
       }
     | undefined,
   payload: InternalRequestBody["payload"],
@@ -620,7 +621,7 @@ function normalizeInternalRequest(
   params: Record<string, string>;
 } {
   const params = requestData?.params ?? {};
-  const search = new URLSearchParams(requestData?.search ?? {});
+  const search = createSearchParams(requestData?.search);
   const url = new URL(originalRequest.url);
   url.pathname = interpolatePath(pathPattern, params);
   url.search = search.toString();

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -27,6 +27,7 @@ import {
   matchPathname,
   sortByPathSpecificity,
 } from "./path-matching";
+import { createSearchParams, type SearchParamRecord } from "./search-params";
 import { parseInternalRequestBody, type InternalRequestBody } from "./server/internal-requests";
 import { createInternalHandlerHeaders } from "./server/request-headers";
 
@@ -1647,7 +1648,7 @@ function normalizeInternalResourceRequest(
   requestData:
     | {
         params?: Record<string, string>;
-        search?: Record<string, string>;
+        search?: SearchParamRecord;
       }
     | undefined,
   payload: InternalRequestBody["payload"],
@@ -1656,7 +1657,7 @@ function normalizeInternalResourceRequest(
   params: Record<string, string>;
 } {
   const params = requestData?.params ?? {};
-  const search = new URLSearchParams(requestData?.search ?? {});
+  const search = createSearchParams(requestData?.search);
   const url = new URL(originalRequest.url);
   url.pathname = interpolatePath(resourcePath, params, "resource");
   url.search = search.toString();

--- a/tests/api-route-fetch.test.ts
+++ b/tests/api-route-fetch.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { defineApiRoute } from "../src/index";
+
+describe("defineApiRoute().fetch", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("preserves repeated query params from object search input", async () => {
+    let capturedInput: RequestInfo | URL | undefined;
+
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      capturedInput = input;
+      return new Response(null, { status: 204 });
+    }) as typeof fetch;
+
+    const api = defineApiRoute("/api/projects", {
+      GET() {
+        return new Response(null, { status: 204 });
+      },
+    });
+
+    await api.fetch({
+      search: {
+        tag: ["framework", "bun"],
+        term: "litz",
+      },
+    });
+
+    expect(capturedInput).toBe("/api/projects?tag=framework&tag=bun&term=litz");
+  });
+});

--- a/tests/resource-runtime.test.tsx
+++ b/tests/resource-runtime.test.tsx
@@ -262,4 +262,42 @@ describe("resource runtime", () => {
     expect(loaderCalls).toBe(1);
     expect(document.querySelector(".resource-count")?.getAttribute("data-value")).toBe("1");
   });
+
+  test("treats repeated query params as part of the resource cache key", async () => {
+    const loaderBodies: string[] = [];
+
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const body = init?.body as string;
+
+      if (!body) {
+        throw new Error("Expected loader request body.");
+      }
+
+      loaderBodies.push(body);
+
+      return Response.json({
+        kind: "data",
+        data: { id: "user-003", count: loaderBodies.length },
+      });
+    }) as typeof fetch;
+
+    await act(async () => {
+      root?.render(
+        <>
+          <accountResource.Component
+            params={{ id: "user-003" }}
+            search={new URLSearchParams("tag=framework&tag=bun")}
+          />
+          <accountResource.Component params={{ id: "user-003" }} search={{ tag: "bun" }} />
+        </>,
+      );
+      await flushDom();
+    });
+
+    expect(loaderBodies).toHaveLength(2);
+    expect(loaderBodies.map((body) => JSON.parse(body).request.search)).toEqual([
+      { tag: ["framework", "bun"] },
+      { tag: "bun" },
+    ]);
+  });
 });

--- a/tests/search-params.test.ts
+++ b/tests/search-params.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+
+import { createSearchParamRecord, createSearchParams } from "../src/search-params";
+
+describe("search params helpers", () => {
+  test("serializes repeated values from object input into repeated URL search params", () => {
+    const search = createSearchParams({
+      tag: ["framework", "bun"],
+      term: "litz",
+    });
+
+    expect(Array.from(search.entries())).toEqual([
+      ["tag", "framework"],
+      ["tag", "bun"],
+      ["term", "litz"],
+    ]);
+  });
+
+  test("normalizes repeated URL search params into array values", () => {
+    const record = createSearchParamRecord(new URLSearchParams("tag=framework&tag=bun&term=litz"));
+
+    expect(record).toEqual({
+      tag: ["framework", "bun"],
+      term: "litz",
+    });
+  });
+});

--- a/tests/server-security.test.ts
+++ b/tests/server-security.test.ts
@@ -144,6 +144,75 @@ describe("server security", () => {
     expect(body.data.sameSignal).toBe(true);
   });
 
+  test("preserves repeated query params when rebuilding internal route requests", async () => {
+    const server = createServer({
+      manifest: {
+        routes: [
+          {
+            id: "projects.show",
+            path: "/projects/:id",
+            route: {
+              loader(context: unknown) {
+                const { request } = context as { request: Request };
+                const url = new URL(request.url);
+
+                return {
+                  kind: "data",
+                  data: {
+                    href: request.url,
+                    tags: url.searchParams.getAll("tag"),
+                    term: url.searchParams.get("term"),
+                  },
+                };
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const routeRequest = createInternalActionRequestInit(
+      {
+        path: "/projects/:id",
+        target: "projects.show",
+        operation: "loader",
+        request: {
+          params: { id: "42" },
+          search: {
+            tag: ["framework", "bun"],
+            term: "litz",
+          },
+        },
+      },
+      {
+        reload: true,
+      },
+    );
+    const response = await server.fetch(
+      new Request("https://app.example.com/_litzjs/route", {
+        method: "POST",
+        headers: routeRequest.headers,
+        body: routeRequest.body,
+      }),
+    );
+    const body = (await response.json()) as {
+      kind: "data";
+      data: {
+        href: string;
+        tags: string[];
+        term: string | null;
+      };
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.kind).toBe("data");
+    expect(body.data.href).toBe(
+      "https://app.example.com/projects/42?tag=framework&tag=bun&term=litz",
+    );
+    expect(body.data.tags).toEqual(["framework", "bun"]);
+    expect(body.data.term).toBe("litz");
+  });
+
   test("does not expose unhandled server error messages from api routes", async () => {
     const server = createServer({
       manifest: {

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -293,6 +293,64 @@ function createMockResponse(): ServerResponse & { getBody(): string } {
 }
 
 describe("dev server abort signal lifecycle", () => {
+  test("rebuilds repeated query params for internal resource requests", async () => {
+    let capturedTags: string[] = [];
+    let capturedHref = "";
+    const server = createMockViteDevServer(async () => ({
+      resource: {
+        async loader({ request }: { request: Request }) {
+          const url = new URL(request.url);
+          capturedHref = request.url;
+          capturedTags = url.searchParams.getAll("tag");
+
+          return {
+            kind: "data",
+            data: {
+              ok: true,
+            },
+          };
+        },
+      },
+    }));
+    const internalMetadata = JSON.stringify({
+      path: "/resources/config",
+      operation: "loader",
+      request: {
+        search: {
+          tag: ["framework", "bun"],
+        },
+      },
+    });
+    const request = createMockRequest({
+      url: "/_litzjs/resource",
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: internalMetadata,
+    });
+    const response = createMockResponse();
+    const next = mock(() => {});
+
+    await handleLitzResourceRequest(
+      server,
+      [
+        {
+          path: "/resources/config",
+          modulePath: "src/resources/config.ts",
+          hasLoader: true,
+          hasAction: false,
+          hasComponent: false,
+        },
+      ],
+      request,
+      response,
+      next,
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(capturedHref).toBe("http://localhost:5173/resources/config?tag=framework&tag=bun");
+    expect(capturedTags).toEqual(["framework", "bun"]);
+  });
+
   test("resource handler signal aborts when client disconnects", async () => {
     let capturedSignal: AbortSignal | undefined;
     const server = createMockViteDevServer(async () => ({


### PR DESCRIPTION
## Summary
- preserve repeated query params end to end by treating search input as a multimap instead of collapsing it into a plain `Record<string, string>`
- reuse a shared search params helper across API href construction, client route/resource normalization, internal transport metadata, and server/dev request reconstruction
- keep repeated query params in route/resource cache keys and widen the public/internal search types to support `string[]` values

## Testing
- `bun run fmt`
- `bun run lint:fix`
- `bun run typecheck`
- `bun test`
- `bun run build`

Closes #26
