### PR TITLE
[codex] fix resource useSearch API inconsistency

### DIFF
--- a/.changeset/gentle-eagles-thank.md
+++ b/.changeset/gentle-eagles-thank.md
@@ -1,0 +1,5 @@
+---
+"litzjs": patch
+---
+
+Remove the unused `replace` option from resource-scoped `useSearch()` so its public signature matches the request-local behavior implemented by the runtime.

--- a/README.md
+++ b/README.md
@@ -544,6 +544,9 @@ function UserCard() {
 }
 ```
 
+Unlike route-scoped search state, `resource.useSearch()` only updates the resource request.
+It does not push or replace browser history entries.
+
 ### View-Based Resource
 
 Resources can also return `view(...)` from the server and consume it with `resource.useView()`:
@@ -684,6 +687,7 @@ The main split to keep in mind:
 - `useLoaderData()` / `useLoaderView()` / `useLoaderError()` read loader-only state
 - `useActionData()` / `useActionView()` / `useActionError()` / `useInvalid()` read action-only state
 - `useData()` / `useView()` / `useError()` read the latest settled merged value for the resource
+- `useSearch()` updates the resource request only and never mutates browser history
 
 Loader-only hooks keep the last loader result until you call `useReload()`. A later successful
 action can clear merged `useError()` and return `useStatus()` to `idle` while

--- a/src/client/bindings.ts
+++ b/src/client/bindings.ts
@@ -36,12 +36,7 @@ export type LitzClientBindings = {
   useRequiredResourceLocation(resourcePath: string): {
     params: Record<string, string>;
     search: URLSearchParams;
-    setSearch(
-      params: Record<string, string | string[] | null | undefined>,
-      options?: {
-        replace?: boolean;
-      },
-    ): void;
+    setSearch(params: Record<string, string | string[] | null | undefined>): void;
   };
   useRequiredResourceStatus(resourcePath: string): {
     status: unknown;

--- a/src/client/resources.tsx
+++ b/src/client/resources.tsx
@@ -7,7 +7,7 @@ import type {
   ResourceRequest,
   RouteFormProps,
   RouteStatus,
-  SetSearchParams,
+  SetResourceSearchParams,
   SubmitOptions,
 } from "../index";
 
@@ -31,11 +31,7 @@ export type ResourceLocationState = {
   id: string;
   params: Record<string, string>;
   search: URLSearchParams;
-  setSearch(
-    this: void,
-    params: Parameters<SetSearchParams>[0],
-    options?: Parameters<SetSearchParams>[1],
-  ): void;
+  setSearch(this: void, params: Parameters<SetResourceSearchParams>[0]): void;
 };
 
 export type ResourceStatusState = {
@@ -368,7 +364,7 @@ function useResourceRuntime(resourcePath: string, request?: ResourceRequest): Re
         return;
       }
 
-      const nextUrl = new URL(result.href);
+      const nextUrl = new URL(result.href, "https://litz.local");
       React.startTransition(() => {
         setSearchState(new URLSearchParams(nextUrl.search));
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,8 @@ export type SetSearchParams = (
   },
 ) => void;
 
+export type SetResourceSearchParams = (params: SearchParamsUpdate) => void;
+
 export type RouteFormProps = Omit<React.ComponentPropsWithoutRef<"form">, "action" | "method"> & {
   replace?: boolean;
   revalidate?: boolean | string[];
@@ -750,7 +752,7 @@ export type LitzResource<
     component: TComponent;
     Component: React.ComponentType<ResourceComponentProps<TPath>>;
     useParams(): PathParams<TPath>;
-    useSearch(): [URLSearchParams, SetSearchParams];
+    useSearch(): [URLSearchParams, SetResourceSearchParams];
     useStatus(): RouteStatus;
     usePending(): boolean;
   } & ([TLoaderResult] extends [never]
@@ -1318,9 +1320,9 @@ export function defineResource(path: any, options: any): any {
     useParams: () => getRequiredResourceLocation(path).params as PathParams<string>,
     useSearch: () => {
       const location = getRequiredResourceLocation(path);
-      return [location.search, (params, options) => location.setSearch(params, options)] as [
+      return [location.search, (params) => location.setSearch(params)] as [
         URLSearchParams,
-        SetSearchParams,
+        SetResourceSearchParams,
       ];
     },
     useReload: () => {

--- a/tests/resource-runtime.test.tsx
+++ b/tests/resource-runtime.test.tsx
@@ -20,13 +20,20 @@ import {
   useRequiredRouteLocation,
   useRequiredRouteStatus,
 } from "../src/client/route-runtime";
-import { data, defineResource, server } from "../src/index";
+import { data, defineResource, server, type SetResourceSearchParams } from "../src/index";
 import { flushDom, installTestDom } from "./test-dom";
 
 type Deferred<T> = {
   promise: Promise<T>;
   resolve(value: T): void;
 };
+
+type IsExact<T, U> =
+  (<Value>() => Value extends T ? 1 : 2) extends <Value>() => Value extends U ? 1 : 2
+    ? (<Value>() => Value extends U ? 1 : 2) extends <Value>() => Value extends T ? 1 : 2
+      ? true
+      : false
+    : false;
 
 function createDeferred<T>(): Deferred<T> {
   let resolve!: (value: T) => void;
@@ -122,6 +129,33 @@ const overlapResource = defineResource("/resource/overlap/:id", {
   loader: server(async ({ params }) => data({ id: params.id, count: 1 })),
   action: server(async ({ params }) => data({ id: params.id, count: 2 })),
 });
+
+const searchResource = defineResource("/resource/search/:id", {
+  component: function SearchResource() {
+    const [searchParams, setSearch] = searchResource.useSearch();
+    const details = searchResource.useData() as { id: string; tab: string } | null;
+
+    return (
+      <section>
+        <div className="search-resource-tab" data-value={searchParams.get("tab") ?? "(none)"} />
+        <div className="search-resource-data-tab" data-value={details?.tab ?? "(none)"} />
+        <button
+          type="button"
+          className="search-resource-update"
+          onClick={() => setSearch({ tab: "security" })}
+        >
+          Update search
+        </button>
+      </section>
+    );
+  },
+  loader: server(async ({ params }) => data({ id: params.id, tab: params.id })),
+});
+
+const _resourceSearchSetterMatchesPublicType: IsExact<
+  ReturnType<typeof searchResource.useSearch>[1],
+  SetResourceSearchParams
+> = true;
 
 const loaderErrorActionResource = defineResource("/resource/error-action/:id", {
   component: function LoaderErrorActionResource() {
@@ -393,6 +427,73 @@ describe("resource runtime", () => {
     expect(loaderBodies.map((body) => JSON.parse(body).request.search)).toEqual([
       { tag: ["framework", "bun"] },
       { tag: "bun" },
+    ]);
+  });
+
+  test("resource.useSearch() updates request-scoped search state without touching browser history", async () => {
+    const loaderBodies: string[] = [];
+
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const body = init?.body as string;
+
+      if (!body) {
+        throw new Error("Expected loader request body.");
+      }
+
+      loaderBodies.push(body);
+      const request = JSON.parse(body).request as {
+        params: { id: string };
+        search: { tab?: string };
+      };
+
+      return Response.json({
+        kind: "data",
+        data: {
+          id: request.params.id,
+          tab: request.search.tab ?? "profile",
+        },
+      });
+    }) as typeof fetch;
+
+    await act(async () => {
+      root?.render(
+        <searchResource.Component params={{ id: "user-004" }} search={{ tab: "profile" }} />,
+      );
+      await flushDom();
+    });
+
+    const updateButton = document.querySelector(".search-resource-update");
+
+    expect(window.location.pathname).toBe("/dashboard");
+    expect(window.location.search).toBe("");
+    expect(window.history.length).toBe(1);
+    expect(document.querySelector(".search-resource-tab")?.getAttribute("data-value")).toBe(
+      "profile",
+    );
+    expect(document.querySelector(".search-resource-data-tab")?.getAttribute("data-value")).toBe(
+      "profile",
+    );
+    expect(loaderBodies.map((body) => JSON.parse(body).request.search)).toEqual([
+      { tab: "profile" },
+    ]);
+
+    await act(async () => {
+      (updateButton as HTMLButtonElement).click();
+      await flushDom();
+    });
+
+    expect(window.location.pathname).toBe("/dashboard");
+    expect(window.location.search).toBe("");
+    expect(window.history.length).toBe(1);
+    expect(document.querySelector(".search-resource-tab")?.getAttribute("data-value")).toBe(
+      "security",
+    );
+    expect(document.querySelector(".search-resource-data-tab")?.getAttribute("data-value")).toBe(
+      "security",
+    );
+    expect(loaderBodies.map((body) => JSON.parse(body).request.search)).toEqual([
+      { tab: "profile" },
+      { tab: "security" },
     ]);
   });
 


### PR DESCRIPTION
## Summary
Fixes #29.

This aligns resource-scoped `useSearch()` with its actual runtime semantics. Resources now expose a params-only setter instead of reusing the route setter signature that advertised a `{ replace }` history option the resource runtime never honored.

## What changed
- introduced a dedicated `SetResourceSearchParams` type for resource-scoped search updates
- narrowed `resource.useSearch()` and the resource runtime bindings to accept search param updates only
- documented that `resource.useSearch()` updates the resource request and does not push or replace browser history
- added regression coverage for the resource setter signature and for request-scoped search updates in the resource runtime
- fixed resource search updates to parse the generated href against a base URL so state updates no longer throw on relative `/?...` results

## Root cause
Resources and routes were sharing the same `SetSearchParams` type even though only routes have navigation history semantics. That made the resource API imply support for `{ replace }` while the implementation simply ignored it. The new regression test also exposed that resource search updates were trying to construct a `URL` from a relative href without a base.

## Impact
Consumers now get an API that matches real behavior: resource search updates remain request-local and do not suggest browser-history control that does not exist.

## Validation
- `bun run fmt`
- `bun run lint:fix` (one unrelated pre-existing warning remains in `tests/transport-headers.test.ts:72`)
- `bun run typecheck`
- `bun run test`
