### PR TITLE
[codex] Fix mountApp wrapper docs and warning

### DIFF
--- a/.changeset/flat-books-care.md
+++ b/.changeset/flat-books-care.md
@@ -1,0 +1,5 @@
+---
+"litzjs": patch
+---
+
+Warn when `mountApp(...)` receives the removed positional wrapper API and update the README wrapper examples to the current options-object form.

--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ You can optionally provide a wrapper component around the app root:
 import { StrictMode } from "react";
 import { mountApp } from "litzjs/client";
 
-mountApp(root, StrictMode);
+mountApp(root, { component: StrictMode });
 ```
 
-For providers or wrappers with props, pass a component:
+For providers or wrappers with props, pass your component through the same options object:
 
 ```tsx
 import { mountApp } from "litzjs/client";
@@ -95,7 +95,7 @@ function AppProviders({ children }: React.PropsWithChildren) {
   return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
 }
 
-mountApp(root, AppProviders);
+mountApp(root, { component: AppProviders });
 ```
 
 `index.html`

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -124,6 +124,11 @@ const routeModulePrefetchCache = new Map<string, Promise<void>>();
 const layoutChainCache = new WeakMap<LoadedLayout, LoadedLayout[]>();
 const pathParamNamesCache = new Map<string, string[]>();
 
+interface MountAppOptions {
+  readonly component?: React.JSXElementConstructor<{ children: React.ReactNode }>;
+  readonly layout?: LayoutReference;
+}
+
 for (const entry of manifest) {
   if (hasPatternSegments(entry.path)) {
     dynamicManifestEntries.push(entry);
@@ -214,22 +219,29 @@ function getLocationContext(): React.Context<{
   return locationContext;
 }
 
-export function mountApp(
-  element: Element,
-  options?: {
-    component?: React.JSXElementConstructor<{ children: React.ReactNode }>;
-    layout?: LayoutReference;
-  },
-): void {
+export function mountApp(element: Element, options?: MountAppOptions): void {
+  const resolvedOptions = normalizeMountAppOptions(options);
+
   void import("react-dom/client").then(({ createRoot }) => {
     const root = createRoot(element);
     root.render(
       React.createElement(LitzApp, {
-        component: options?.component,
-        layout: options?.layout,
+        component: resolvedOptions?.component,
+        layout: resolvedOptions?.layout,
       }),
     );
   });
+}
+
+function normalizeMountAppOptions(options?: MountAppOptions): MountAppOptions | undefined {
+  if (typeof options === "function") {
+    console.warn(
+      "[litzjs] mountApp(root, Wrapper) is no longer supported. Pass mountApp(root, { component: Wrapper }) instead.",
+    );
+    return undefined;
+  }
+
+  return options;
 }
 
 export function useNavigate(): (href: string, options?: { replace?: boolean }) => void {

--- a/tests/client-wildcard-route-runtime.test.tsx
+++ b/tests/client-wildcard-route-runtime.test.tsx
@@ -117,4 +117,53 @@ describe("client wildcard route runtime", () => {
     );
     expect(loadDocsRoute).toHaveBeenCalledTimes(1);
   });
+
+  test("mounts wrapper components from the options object", async () => {
+    clientModule = await import("../src/client/index");
+
+    function TestWrapper({ children }: React.PropsWithChildren): React.ReactElement {
+      return <div data-wrapper="options-object">{children}</div>;
+    }
+
+    await act(async () => {
+      clientModule?.mountApp(container!, { component: TestWrapper });
+      await flushApp();
+    });
+
+    expect(container?.querySelector('[data-wrapper="options-object"]')).not.toBeNull();
+    expect(document.getElementById("route-state")?.getAttribute("data-value")).toBe("home-route");
+  });
+
+  test("warns when passed a wrapper component instead of the options object", async () => {
+    clientModule = await import("../src/client/index");
+
+    const originalConsoleWarn = console.warn;
+    const warnings: string[] = [];
+
+    function LegacyWrapper({ children }: React.PropsWithChildren): React.ReactElement {
+      return <div data-wrapper="legacy">{children}</div>;
+    }
+
+    console.warn = (message?: unknown) => {
+      warnings.push(String(message));
+    };
+
+    try {
+      await act(async () => {
+        clientModule?.mountApp(
+          container!,
+          LegacyWrapper as unknown as Parameters<ClientModule["mountApp"]>[1],
+        );
+        await flushApp();
+      });
+    } finally {
+      console.warn = originalConsoleWarn;
+    }
+
+    expect(document.getElementById("route-state")?.getAttribute("data-value")).toBe("home-route");
+    expect(container?.querySelector('[data-wrapper="legacy"]')).toBeNull();
+    expect(warnings).toEqual([
+      "[litzjs] mountApp(root, Wrapper) is no longer supported. Pass mountApp(root, { component: Wrapper }) instead.",
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- update the README `mountApp(...)` wrapper examples to the current options-object API
- warn when `mountApp(root, Wrapper)` is passed directly so JavaScript callers no longer fail silently
- add client runtime coverage for both the supported wrapper path and the legacy warning path

## Why
Issue #30 reported that the README still documented `mountApp(root, StrictMode)` and `mountApp(root, AppProviders)`, even though the runtime expects `mountApp(root, { component: Wrapper })`. That mismatch made the documented examples easy to copy and hard to debug because the wrapper was ignored at runtime.

## Root Cause
The public runtime API had already moved to an options object, but the README examples were never updated to match it. JavaScript callers who copied the old form received no signal that the second argument was being ignored.

## User Impact
New users now see the correct wrapper API in the README, and anyone still calling the removed positional form gets an explicit warning that points them to the supported shape.

## Validation
- `bun fmt`
- `bun lint:fix`
- `bun typecheck`
- `bun test`

Closes #30
