### PR TITLE
[codex] Add explicit JSON submit helpers for FormData payloads

### DIFF
--- a/.changeset/sixty-paws-arrive.md
+++ b/.changeset/sixty-paws-arrive.md
@@ -1,0 +1,5 @@
+---
+"litzjs": minor
+---
+
+Add an explicit `formJson(...)` helper for structured submit payload fields and reject implicit object/null coercion in `FormData` submissions.

--- a/README.md
+++ b/README.md
@@ -279,6 +279,10 @@ function SaveToolbar() {
 }
 ```
 
+Imperative submit payloads now use an explicit `FormData` contract. Primitive values and
+`Blob`/`File` values append directly, arrays expand into repeated fields, and structured values
+must be wrapped with `formJson(value)` so their JSON encoding is intentional.
+
 `useStatus()` returns one of:
 
 - `idle`
@@ -657,6 +661,9 @@ function QuickActions() {
   );
 }
 ```
+
+Use `formJson(value)` here as well when a field should be JSON-encoded instead of appended as a
+plain scalar.
 
 ### Available Resource Hooks
 

--- a/fixtures/rsc-smoke/src/typechecks.ts
+++ b/fixtures/rsc-smoke/src/typechecks.ts
@@ -1,4 +1,4 @@
-import { data, defineApiRoute, defineResource, defineRoute, fault, server } from "litzjs";
+import { data, defineApiRoute, defineResource, defineRoute, fault, formJson, server } from "litzjs";
 
 const clientOnlyRoute = defineRoute("/typechecks/client-only", {
   component: ClientOnlyRoute,
@@ -45,10 +45,13 @@ function ActionRoute() {
 
 const submit = actionRoute.useSubmit();
 void submit;
+void submit({ metadata: formJson({ ok: true }) });
 // @ts-expect-error action-only routes should not expose loader hooks
 void actionRoute.useLoaderResult;
 // @ts-expect-error action-only routes should not expose loader error hooks
 void actionRoute.useLoaderError;
+// @ts-expect-error structured payload values must be wrapped explicitly
+void submit({ metadata: { ok: true } });
 
 const loaderResource = defineResource("/typechecks/resource/:id", {
   component() {

--- a/src/client/bindings.ts
+++ b/src/client/bindings.ts
@@ -1,5 +1,7 @@
 import type * as React from "react";
 
+import type { SubmitPayload } from "../form-data";
+
 export type LitzClientBindings = {
   usePathname(): string;
   useLocation(): {
@@ -31,7 +33,7 @@ export type LitzClientBindings = {
   };
   useRequiredRouteActions(routeId: string): {
     reload(): void;
-    submit(payload: FormData | Record<string, unknown>, options?: unknown): Promise<void>;
+    submit(payload: SubmitPayload, options?: unknown): Promise<void>;
   };
   useRequiredResourceLocation(resourcePath: string): {
     params: Record<string, string>;
@@ -51,7 +53,7 @@ export type LitzClientBindings = {
   };
   useRequiredResourceActions(resourcePath: string): {
     reload(): void;
-    submit(payload: FormData | Record<string, unknown>, options?: unknown): Promise<void>;
+    submit(payload: SubmitPayload, options?: unknown): Promise<void>;
   };
   useMatches(): Array<{
     id: string;

--- a/src/client/resources.tsx
+++ b/src/client/resources.tsx
@@ -11,7 +11,7 @@ import type {
   SubmitOptions,
 } from "../index";
 
-import { createFormDataPayload } from "../form-data";
+import { createFormDataPayload, type SubmitPayload } from "../form-data";
 import { createInternalActionRequestInit, LITZ_RESULT_ACCEPT } from "../internal-transport";
 import {
   createSearchParamRecord,
@@ -51,11 +51,7 @@ export type ResourceDataState = {
 
 export type ResourceActionsState = {
   id: string;
-  submit(
-    this: void,
-    payload: FormData | Record<string, unknown>,
-    options?: SubmitOptions,
-  ): Promise<void>;
+  submit(this: void, payload: SubmitPayload, options?: SubmitOptions): Promise<void>;
   reload(this: void): void;
 };
 
@@ -247,13 +243,12 @@ export function createResourceFormComponent(
   const LitzResourceForm = function LitzResourceForm(props: RouteFormProps): React.ReactElement {
     const actions = useRequiredResourceActions(resourcePath);
     const { children, onSubmit, replace, revalidate, ...rest } = props;
-    const submitRef = React.useRef(
-      (payload: FormData | Record<string, unknown>, options?: SubmitOptions) =>
-        actions.submit(payload, options),
+    const submitRef = React.useRef((payload: SubmitPayload, options?: SubmitOptions) =>
+      actions.submit(payload, options),
     );
 
     React.useEffect(() => {
-      submitRef.current = (payload: FormData | Record<string, unknown>, options?: SubmitOptions) =>
+      submitRef.current = (payload: SubmitPayload, options?: SubmitOptions) =>
         actions.submit(payload, options);
     }, [actions.submit]);
 
@@ -444,7 +439,7 @@ async function performPreparedResourceRequest(
   resourcePath: string,
   operation: "loader" | "action",
   preparedRequest: PreparedResourceRequest,
-  payload?: FormData | Record<string, unknown>,
+  payload?: SubmitPayload,
   mode: "loading" | "revalidating" | "submitting" = "loading",
 ): Promise<NonNullable<ActionHookResult> | LoaderHookResult | void> {
   const { key, normalizedRequest } = preparedRequest;

--- a/src/client/route-runtime.tsx
+++ b/src/client/route-runtime.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import type { SubmitPayload } from "../form-data";
 import type {
   ActionHookResult,
   LoaderHookResult,
@@ -38,11 +39,7 @@ export type RouteDataState = {
 
 export type RouteActionsState = {
   id: string;
-  submit(
-    this: void,
-    payload: FormData | Record<string, unknown>,
-    options?: SubmitOptions,
-  ): Promise<void>;
+  submit(this: void, payload: SubmitPayload, options?: SubmitOptions): Promise<void>;
   reload(this: void): void;
 };
 
@@ -194,13 +191,12 @@ export function createRouteFormComponent(routeId: string): React.ComponentType<R
   const LitzRouteForm = function LitzRouteForm(props: RouteFormProps): React.ReactElement {
     const actions = useRequiredRouteActions(routeId);
     const { children, onSubmit, replace, revalidate, ...rest } = props;
-    const submitRef = React.useRef(
-      (payload: FormData | Record<string, unknown>, options?: SubmitOptions) =>
-        actions.submit(payload, options),
+    const submitRef = React.useRef((payload: SubmitPayload, options?: SubmitOptions) =>
+      actions.submit(payload, options),
     );
 
     React.useEffect(() => {
-      submitRef.current = (payload: FormData | Record<string, unknown>, options?: SubmitOptions) =>
+      submitRef.current = (payload: SubmitPayload, options?: SubmitOptions) =>
         actions.submit(payload, options);
     }, [actions.submit]);
 

--- a/src/client/runtime.tsx
+++ b/src/client/runtime.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import type { SubmitPayload } from "../form-data";
 import type { ActionHookResult, LoaderHookResult, ResourceRequest } from "../index";
 
 import { createInternalActionRequestInit, LITZ_RESULT_ACCEPT } from "../internal-transport";
@@ -42,7 +43,7 @@ export async function fetchRouteLoader(
 export async function fetchRouteAction(
   path: string,
   request: ResourceRequest,
-  payload: FormData | Record<string, unknown>,
+  payload: SubmitPayload,
 ): Promise<ActionHookResult> {
   const actionRequest = createInternalActionRequestInit(
     {

--- a/src/form-data.ts
+++ b/src/form-data.ts
@@ -1,4 +1,33 @@
-export function createFormDataPayload(payload?: FormData | Record<string, unknown>): FormData {
+const FORM_JSON_VALUE_KIND = "json";
+
+export interface FormJsonValue<T = unknown> {
+  readonly kind: typeof FORM_JSON_VALUE_KIND;
+  readonly value: T;
+}
+
+export type FormDataPayloadValue =
+  | Blob
+  | string
+  | number
+  | boolean
+  | bigint
+  | FormJsonValue
+  | readonly FormDataPayloadValue[];
+
+export interface FormDataPayloadRecord {
+  readonly [key: string]: FormDataPayloadValue;
+}
+
+export type SubmitPayload = FormData | FormDataPayloadRecord;
+
+export function formJson<T>(value: T): FormJsonValue<T> {
+  return {
+    kind: FORM_JSON_VALUE_KIND,
+    value,
+  };
+}
+
+export function createFormDataPayload(payload?: SubmitPayload): FormData {
   if (payload instanceof FormData) {
     return cloneFormData(payload);
   }
@@ -39,13 +68,8 @@ function appendFormDataValue(formData: FormData, key: string, value: unknown): v
     return;
   }
 
-  if (value == null) {
-    formData.append(key, "");
-    return;
-  }
-
-  if (typeof value === "object") {
-    formData.append(key, JSON.stringify(value));
+  if (isFormJsonValue(value)) {
+    formData.append(key, JSON.stringify(value.value));
     return;
   }
 
@@ -58,4 +82,43 @@ function appendFormDataValue(formData: FormData, key: string, value: unknown): v
     formData.append(key, String(value));
     return;
   }
+
+  throw createUnsupportedFormDataValueError(key, value);
+}
+
+function isFormJsonValue(value: unknown): value is FormJsonValue {
+  return (
+    value !== null &&
+    value !== undefined &&
+    typeof value === "object" &&
+    "kind" in value &&
+    "value" in value &&
+    (value as { kind?: unknown }).kind === FORM_JSON_VALUE_KIND
+  );
+}
+
+function createUnsupportedFormDataValueError(key: string, value: unknown): TypeError {
+  return new TypeError(
+    `[litzjs] Unsupported FormData value for "${key}": ${describeFormDataValue(value)}. ` +
+      "Pass strings, numbers, booleans, bigints, Blob/File values, arrays of supported values, " +
+      "or wrap structured values with formJson(value).",
+  );
+}
+
+function describeFormDataValue(value: unknown): string {
+  if (value === null) {
+    return "null";
+  }
+
+  if (value === undefined) {
+    return "undefined";
+  }
+
+  if (typeof value === "object") {
+    const constructorName = value.constructor?.name;
+
+    return constructorName ? `${constructorName} instance` : "object";
+  }
+
+  return typeof value;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 import * as React from "react";
 
+import type { SubmitPayload } from "./form-data";
+
 import { getClientBindings } from "./client/bindings";
 import { interpolatePath } from "./path-matching";
 import {
@@ -8,6 +10,13 @@ import {
   type SearchParamsInput,
 } from "./search-params";
 
+export {
+  formJson,
+  type FormDataPayloadRecord,
+  type FormDataPayloadValue,
+  type FormJsonValue,
+  type SubmitPayload,
+} from "./form-data";
 export type { SearchParamRecord, SearchParamValue } from "./search-params";
 
 export type MiddlewareOverrides<TContext = unknown> = {
@@ -667,9 +676,7 @@ type RouteActionClientHooks<TActionResult extends ServerResult> = {
   useActionView(): ActionViewValueFor<TActionResult>;
   useActionError(): ActionExplicitErrorValueFor<TActionResult>;
   useInvalid(): ActionInvalidValueFor<TActionResult>;
-  useSubmit(
-    opts?: SubmitOptions<TActionResult>,
-  ): (payload: FormData | Record<string, unknown>) => Promise<void>;
+  useSubmit(opts?: SubmitOptions<TActionResult>): (payload: SubmitPayload) => Promise<void>;
   Form: React.ComponentType<RouteFormProps>;
 };
 
@@ -774,9 +781,7 @@ export type LitzResource<
           useActionView(): ActionViewValueFor<TActionResult>;
           useActionError(): ActionExplicitErrorValueFor<TActionResult>;
           useInvalid(): ActionInvalidValueFor<TActionResult>;
-          useSubmit(
-            opts?: SubmitOptions<TActionResult>,
-          ): (payload: FormData | Record<string, unknown>) => Promise<void>;
+          useSubmit(opts?: SubmitOptions<TActionResult>): (payload: SubmitPayload) => Promise<void>;
           Form: React.ComponentType<RouteFormProps>;
         }) &
     ([TLoaderResult] extends [never]
@@ -1055,7 +1060,7 @@ export function defineRoute(path: string, options: DefineRouteOptions<any, any, 
     },
     useSubmit: (opts?: SubmitOptions<ServerResult>) => {
       const actions = getRequiredRouteActions(path);
-      return (payload: FormData | Record<string, unknown>) => actions.submit(payload, opts);
+      return (payload: SubmitPayload) => actions.submit(payload, opts);
     },
     Form(props: RouteFormProps) {
       const bindings = getClientBindings();
@@ -1331,7 +1336,7 @@ export function defineResource(path: any, options: any): any {
     },
     useSubmit: (opts?: SubmitOptions<ServerResult>) => {
       const actions = getRequiredResourceActions(path);
-      return (payload: FormData | Record<string, unknown>) => actions.submit(payload, opts);
+      return (payload: SubmitPayload) => actions.submit(payload, opts);
     },
     Form(props: RouteFormProps) {
       const bindings = getClientBindings();

--- a/src/internal-transport.ts
+++ b/src/internal-transport.ts
@@ -1,6 +1,6 @@
 import type { SearchParamRecord } from "./search-params";
 
-import { createFormDataPayload } from "./form-data";
+import { createFormDataPayload, type SubmitPayload } from "./form-data";
 
 export type InternalPayloadEntry = [string, FormDataEntryValue];
 
@@ -33,7 +33,7 @@ export const LITZ_RESULT_ACCEPT = "application/vnd.litzjs.result+json, text/x-co
 
 export function createInternalActionRequestInit(
   metadata: InternalRequestMetadata,
-  payload?: FormData | Record<string, unknown>,
+  payload?: SubmitPayload,
 ): { headers: Headers; body: FormData } {
   return {
     headers: new Headers({

--- a/tests/internal-requests.test.ts
+++ b/tests/internal-requests.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { formJson } from "../src";
 import {
   createInternalActionRequestInit,
   parseInternalRequestBody,
@@ -48,7 +49,7 @@ describe("internal action requests", () => {
     expect(await (receivedUpload as File).text()).toBe("hello litz");
   });
 
-  test("serializes object payload values consistently for internal actions", async () => {
+  test("serializes explicit JSON payload values consistently for internal actions", async () => {
     const actionRequest = createInternalActionRequestInit(
       {
         path: "/projects",
@@ -56,10 +57,10 @@ describe("internal action requests", () => {
       },
       {
         name: "Litz",
-        metadata: {
+        metadata: formJson({
           published: false,
           tags: ["framework"],
-        },
+        }),
       },
     );
 
@@ -75,5 +76,35 @@ describe("internal action requests", () => {
       ["name", "Litz"],
       ["metadata", JSON.stringify({ published: false, tags: ["framework"] })],
     ]);
+  });
+
+  test("rejects implicit object payload values for internal actions", () => {
+    expect(() =>
+      createInternalActionRequestInit(
+        {
+          path: "/projects",
+          operation: "action",
+        },
+        {
+          metadata: {
+            published: false,
+          } as never,
+        },
+      ),
+    ).toThrow(/formJson/);
+  });
+
+  test("rejects null payload values instead of coercing them to empty strings", () => {
+    expect(() =>
+      createInternalActionRequestInit(
+        {
+          path: "/projects",
+          operation: "action",
+        },
+        {
+          nickname: null as never,
+        },
+      ),
+    ).toThrow(/null/);
   });
 });


### PR DESCRIPTION
## Summary
- add a public `formJson(...)` helper plus explicit `SubmitPayload` types for imperative route/resource submits
- stop implicitly coercing plain objects and `null` into `FormData`, and throw a clear error instead
- document the new contract and cover it with transport regression tests plus smoke typechecks

## Why
`createFormDataPayload(...)` previously made broad implicit conversions for imperative submits. Plain objects were JSON-stringified automatically, `null` became an empty string, and unsupported values could slip through unclearly. That made payload intent harder to reason about and harder to debug in production.

## Root Cause
The `FormData` payload builder accepted `Record<string, unknown>` and converted several non-`FormData` value shapes implicitly instead of enforcing an explicit contract for structured values.

## Impact
Imperative submit payloads now have a clearer contract:
- scalars and `Blob`/`File` values append directly
- arrays still expand into repeated fields
- structured values must be wrapped with `formJson(value)`
- implicit object and `null` coercions now fail fast with a descriptive error

## Validation
- `bun run fmt`
- `bun run lint:fix`
- `bun run lint`
- `bun run typecheck`
- `bun run test`

Closes #31
