### PR TITLE
[codex] fix(router): guard path matching against malformed percent-encoding

### DIFF
--- a/.changeset/calm-carrots-repair.md
+++ b/.changeset/calm-carrots-repair.md
@@ -1,0 +1,5 @@
+---
+"litzjs": patch
+---
+
+Guard route and API path matching against malformed percent-encoding so invalid path segments return clean 400 or unmatched results instead of throwing `URIError`.

--- a/src/path-matching.ts
+++ b/src/path-matching.ts
@@ -27,6 +27,34 @@ export function hasPatternSegments(path: string): boolean {
   );
 }
 
+function safeDecodePathSegment(segment: string): string | null {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return null;
+  }
+}
+
+function decodePathSegments(segments: readonly string[]): string[] | null {
+  const decodedSegments: string[] = [];
+
+  for (const segment of segments) {
+    const decodedSegment = safeDecodePathSegment(segment);
+
+    if (decodedSegment === null) {
+      return null;
+    }
+
+    decodedSegments.push(decodedSegment);
+  }
+
+  return decodedSegments;
+}
+
+export function hasMalformedPathnameEncoding(pathname: string): boolean {
+  return trimPathSegments(pathname).some((segment) => safeDecodePathSegment(segment) === null);
+}
+
 function getWildcardParamName(segment: string): string | null {
   if (segment === "*") {
     return null;
@@ -62,7 +90,13 @@ export function matchPathname(routePath: string, pathname: string): Record<strin
       }
 
       if (routeSegment.startsWith(":")) {
-        params[routeSegment.slice(1)] = decodeURIComponent(pathSegment);
+        const decodedPathSegment = safeDecodePathSegment(pathSegment);
+
+        if (decodedPathSegment === null) {
+          return null;
+        }
+
+        params[routeSegment.slice(1)] = decodedPathSegment;
         continue;
       }
 
@@ -71,7 +105,13 @@ export function matchPathname(routePath: string, pathname: string): Record<strin
       }
     }
 
-    const remaining = pathSegments.slice(staticSegments.length).map(decodeURIComponent).join("/");
+    const decodedRemainingSegments = decodePathSegments(pathSegments.slice(staticSegments.length));
+
+    if (decodedRemainingSegments === null) {
+      return null;
+    }
+
+    const remaining = decodedRemainingSegments.join("/");
     const paramName = getWildcardParamName(lastRouteSegment);
 
     if (paramName) {
@@ -96,7 +136,13 @@ export function matchPathname(routePath: string, pathname: string): Record<strin
     }
 
     if (routeSegment.startsWith(":")) {
-      params[routeSegment.slice(1)] = decodeURIComponent(pathSegment);
+      const decodedPathSegment = safeDecodePathSegment(pathSegment);
+
+      if (decodedPathSegment === null) {
+        return null;
+      }
+
+      params[routeSegment.slice(1)] = decodedPathSegment;
       continue;
     }
 
@@ -135,7 +181,13 @@ export function matchPrefixPathname(
     }
 
     if (routeSegment.startsWith(":")) {
-      params[routeSegment.slice(1)] = decodeURIComponent(pathSegment);
+      const decodedPathSegment = safeDecodePathSegment(pathSegment);
+
+      if (decodedPathSegment === null) {
+        return null;
+      }
+
+      params[routeSegment.slice(1)] = decodedPathSegment;
       continue;
     }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -8,6 +8,7 @@ import {
 } from "../input-validation";
 import {
   extractRouteLikeParams,
+  hasMalformedPathnameEncoding,
   interpolatePath,
   matchPathname,
   trimPathSegments,
@@ -122,6 +123,10 @@ export function createServer<TContext = unknown>(
     const url = new URL(request.url);
     let contextLoaded = false;
     let contextValue: TContext | undefined;
+
+    if (hasMalformedPathnameEncoding(url.pathname)) {
+      return createBadRequestResponse();
+    }
 
     async function getContext(): Promise<TContext | undefined> {
       if (contextLoaded) {
@@ -705,6 +710,15 @@ function createUnhandledFaultResponse(): Response {
   return createLitzJsonResponse(500, {
     kind: "fault",
     message: "Internal server error.",
+  });
+}
+
+function createBadRequestResponse(): Response {
+  return new Response("Bad Request", {
+    status: 400,
+    headers: {
+      "content-type": "text/plain; charset=utf-8",
+    },
   });
 }
 

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -29,6 +29,7 @@ import {
 } from "./input-validation";
 import {
   extractRouteLikeParams,
+  hasMalformedPathnameEncoding,
   interpolatePath,
   matchPathname,
   sortByPathSpecificity,
@@ -1514,6 +1515,7 @@ async function handleLitzDocumentRequest(
   next: Connect.NextFunction,
 ): Promise<void> {
   const url = request.url ?? "/";
+  const requestUrl = new URL(url, "http://litzjs.local");
 
   if (request.method !== "GET" && request.method !== "HEAD") {
     next();
@@ -1534,6 +1536,11 @@ async function handleLitzDocumentRequest(
 
   if (!accept.includes("text/html") && !accept.includes("*/*")) {
     next();
+    return;
+  }
+
+  if (hasMalformedPathnameEncoding(requestUrl.pathname)) {
+    sendBadRequest(response);
     return;
   }
 
@@ -1561,6 +1568,11 @@ export async function handleLitzApiRequest(
 
   if (!requestUrl) {
     next();
+    return;
+  }
+
+  if (hasMalformedPathnameEncoding(requestUrl.pathname)) {
+    sendBadRequest(response);
     return;
   }
 
@@ -1902,6 +1914,12 @@ function sendLitzJson(
   response.statusCode = status;
   response.setHeader("content-type", "application/vnd.litzjs.result+json");
   response.end(JSON.stringify(body));
+}
+
+function sendBadRequest(response: ServerResponse): void {
+  response.statusCode = 400;
+  response.setHeader("content-type", "text/plain; charset=utf-8");
+  response.end("Bad Request");
 }
 
 function applyHeaders(response: ServerResponse, headers?: HeadersInit): void {

--- a/tests/path-matching.test.ts
+++ b/tests/path-matching.test.ts
@@ -14,6 +14,10 @@ describe("path matching", () => {
     expect(matchPathname("/users/:id", "/users")).toBeNull();
   });
 
+  test("treats malformed percent-encoding in dynamic segments as an unmatched route", () => {
+    expect(matchPathname("/users/:id", "/users/%E0%A4%A")).toBeNull();
+  });
+
   test("matches prefix params for layouts", () => {
     expect(extractRouteLikeParams("/teams/:teamId", "/teams/core/settings")).toEqual({
       teamId: "core",
@@ -82,10 +86,18 @@ describe("path matching", () => {
       });
     });
 
+    test("treats malformed percent-encoding in wildcard captures as an unmatched route", () => {
+      expect(matchPathname("/files/*path", "/files/%E0%A4%A")).toBeNull();
+    });
+
     test("prefix matching delegates to matchPathname for wildcard routes", () => {
       expect(matchPrefixPathname("/docs/*slug", "/docs/a/b")).toEqual({
         slug: "a/b",
       });
+    });
+
+    test("treats malformed percent-encoding in prefix params as an unmatched route", () => {
+      expect(matchPrefixPathname("/teams/:teamId", "/teams/%E0%A4%A/settings")).toBeNull();
     });
 
     test("sorts wildcard routes below static and dynamic routes", () => {

--- a/tests/server-security.test.ts
+++ b/tests/server-security.test.ts
@@ -239,6 +239,33 @@ describe("server security", () => {
     expect(body).not.toContain("postgres://user:secret@example.com/db");
   });
 
+  test("treats malformed percent-encoding in api route pathnames as bad requests", async () => {
+    const server = createServer({
+      manifest: {
+        apiRoutes: [
+          {
+            path: "/api/projects/:id",
+            api: {
+              methods: {
+                GET() {
+                  return new Response("ok");
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const response = await server.fetch(
+      new Request("https://app.example.com/api/projects/%E0%A4%A"),
+    );
+    const body = await response.text();
+
+    expect(response.status).toBe(400);
+    expect(body).toBe("Bad Request");
+  });
+
   test("does not expose unhandled server error messages from route loaders", async () => {
     const server = createServer({
       manifest: {

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -652,6 +652,36 @@ describe("dev server error masking", () => {
     expect(response.getBody()).not.toContain("s3cret");
     expect(response.getBody()).toContain("API route failed.");
   });
+
+  test("treats malformed percent-encoding in API route pathnames as bad requests", async () => {
+    const server = createMockViteDevServer(async () => ({
+      api: {
+        methods: {
+          GET() {
+            return new Response("ok");
+          },
+        },
+      },
+    }));
+    const request = createMockRequest({
+      url: "/api/projects/%E0%A4%A",
+      method: "GET",
+    });
+    const response = createMockResponse();
+    const next = mock(() => {});
+
+    await handleLitzApiRequest(
+      server,
+      [{ path: "/api/projects/:id", modulePath: "src/api/projects/[id].ts" }],
+      request,
+      response,
+      next,
+    );
+
+    expect(response.statusCode).toBe(400);
+    expect(response.getBody()).toBe("Bad Request");
+    expect(next).not.toHaveBeenCalled();
+  });
 });
 
 describe("manifest discovery", () => {


### PR DESCRIPTION
## Summary
Fix router path matching so malformed percent-encoding in dynamic or wildcard segments no longer throws `URIError` during matching.

## What Changed
- Added safe pathname-segment decoding in `src/path-matching.ts` so malformed dynamic, wildcard, and prefix matches return `null` instead of throwing.
- Added malformed-path guards in the production server and Vite dev middleware so invalid API and document pathnames return `400 Bad Request`.
- Added regression coverage for matcher behavior, production server handling, and Vite dev API handling.
- Added a patch changeset for the fix.

## Why
Badly encoded URLs can come from crawlers, copy-pasted links, proxies, or user-generated hrefs. The router should treat those as invalid input instead of failing through an uncaught exception path.

## Root Cause
Path matching called `decodeURIComponent(...)` directly while extracting route params and wildcard captures. Malformed pathname segments therefore threw `URIError` during route matching rather than producing a clean unmatched or bad-request result.

## Impact
Client route matching now treats malformed dynamic and wildcard segments as unmatched routes, and server-side matching now returns a normalized `400 Bad Request` for malformed API and document pathnames.

## Validation
- `bun run fmt`
- `bun run lint:fix`
- `bun run lint`
- `bun run typecheck`
- `bun run test`

Closes #47
