### PR TITLE
[codex] fix(client): normalize invalid transport responses

### DIFF
--- a/.changeset/fair-rats-think.md
+++ b/.changeset/fair-rats-think.md
@@ -1,0 +1,5 @@
+---
+"litzjs": patch
+---
+
+Normalize invalid client loader and action responses into route faults so non-JSON bodies and malformed JSON no longer surface raw parse errors.

--- a/src/client/transport.tsx
+++ b/src/client/transport.tsx
@@ -32,6 +32,8 @@ export type LitzJsonBody =
       digest?: string;
     };
 
+type LitzJsonKind = LitzJsonBody["kind"];
+
 export async function parseLoaderResponse(response: Response): Promise<LoaderHookResult> {
   const contentType = response.headers.get("content-type") ?? "";
   const publicHeaders = createPublicResultHeaders(response.headers);
@@ -40,7 +42,16 @@ export async function parseLoaderResponse(response: Response): Promise<LoaderHoo
     return createViewResult(response, publicHeaders);
   }
 
-  const body = (await response.json()) as LitzJsonBody;
+  const body = await parseLitzJsonResponse(response, [
+    "data",
+    "error",
+    "fault",
+    "redirect",
+  ] as const);
+
+  if (body.kind === "fault") {
+    throw createRouteLikeError(response.status, publicHeaders, body);
+  }
 
   if (body.kind === "data") {
     return {
@@ -67,15 +78,11 @@ export async function parseLoaderResponse(response: Response): Promise<LoaderHoo
     };
   }
 
-  if (body.kind === "fault") {
-    throw createRouteLikeError(response.status, publicHeaders, body);
-  }
-
   if (body.kind === "redirect") {
     throw createRedirectSignal(response.status, publicHeaders, body);
   }
 
-  throw new Error(`Unsupported loader response kind "${body.kind}".`);
+  throw createRouteLikeError(response.status, publicHeaders, body);
 }
 
 export async function parseActionResponse(response: Response): Promise<ActionHookResult> {
@@ -86,7 +93,13 @@ export async function parseActionResponse(response: Response): Promise<ActionHoo
     return createViewResult(response, publicHeaders);
   }
 
-  const body = (await response.json()) as LitzJsonBody;
+  const body = await parseLitzJsonResponse(response, [
+    "data",
+    "invalid",
+    "redirect",
+    "error",
+    "fault",
+  ] as const);
 
   switch (body.kind) {
     case "data":
@@ -130,10 +143,6 @@ export async function parseActionResponse(response: Response): Promise<ActionHoo
         message: body.message,
         digest: body.digest,
       };
-    default:
-      throw new Error(
-        `Unsupported action response kind "${String((body as { kind?: unknown }).kind)}".`,
-      );
   }
 }
 
@@ -207,6 +216,30 @@ export function getRevalidateTargets(headers: Headers): string[] {
     .filter(Boolean);
 }
 
+async function parseLitzJsonResponse<const TAllowedKinds extends readonly LitzJsonKind[]>(
+  response: Response,
+  allowedKinds: TAllowedKinds,
+): Promise<Extract<LitzJsonBody, { kind: TAllowedKinds[number] | "fault" }>> {
+  const contentType = response.headers.get("content-type") ?? "";
+  const bodyText = await response.text();
+
+  if (!isJsonContentType(contentType)) {
+    return createInvalidTransportFault(response.status, contentType, bodyText, "non-json");
+  }
+
+  try {
+    const parsedBody = JSON.parse(bodyText) as unknown;
+
+    if (isLitzJsonBody(parsedBody) && allowedKinds.includes(parsedBody.kind)) {
+      return parsedBody as Extract<LitzJsonBody, { kind: TAllowedKinds[number] | "fault" }>;
+    }
+
+    return createInvalidTransportFault(response.status, contentType, bodyText, "unsupported-kind");
+  } catch {
+    return createInvalidTransportFault(response.status, contentType, bodyText, "malformed-json");
+  }
+}
+
 function createRouteLikeError(
   status: number,
   headers: Headers,
@@ -221,6 +254,84 @@ function createRouteLikeError(
     digest: "digest" in body ? body.digest : undefined,
     data: "data" in body ? body.data : undefined,
   };
+}
+
+function createInvalidTransportFault(
+  status: number,
+  contentType: string,
+  bodyText: string,
+  reason: "malformed-json" | "non-json" | "unsupported-kind",
+): Extract<LitzJsonBody, { kind: "fault" }> {
+  const detail = describeInvalidTransportResponse(status, contentType, bodyText, reason);
+
+  return {
+    kind: "fault",
+    message: detail,
+  };
+}
+
+function describeInvalidTransportResponse(
+  status: number,
+  contentType: string,
+  bodyText: string,
+  reason: "malformed-json" | "non-json" | "unsupported-kind",
+): string {
+  if (!isDevelopmentEnvironment()) {
+    return "[litzjs] The server returned an invalid response.";
+  }
+
+  const responseType =
+    reason === "malformed-json"
+      ? "malformed JSON"
+      : reason === "unsupported-kind"
+        ? "an unsupported result payload"
+        : "a non-JSON payload";
+  const normalizedContentType = contentType || "unknown content-type";
+  const preview = createResponsePreview(bodyText);
+
+  return `[litzjs] The server returned ${responseType} with status ${status} and content-type "${normalizedContentType}". Preview: ${preview}`;
+}
+
+function isJsonContentType(contentType: string): boolean {
+  const mimeType = contentType.split(";", 1)[0]?.trim().toLowerCase() ?? "";
+
+  return mimeType === "application/json" || mimeType.endsWith("+json");
+}
+
+function isLitzJsonBody(value: unknown): value is LitzJsonBody {
+  if (typeof value !== "object" || value === null || !("kind" in value)) {
+    return false;
+  }
+
+  const kind = (value as { kind?: unknown }).kind;
+
+  if (kind === "data" || kind === "invalid") {
+    return true;
+  }
+
+  if (kind === "redirect") {
+    return typeof (value as { location?: unknown }).location === "string";
+  }
+
+  if (kind === "error" || kind === "fault") {
+    return typeof (value as { message?: unknown }).message === "string";
+  }
+
+  return false;
+}
+
+function createResponsePreview(bodyText: string): string {
+  const normalized = bodyText.replace(/\s+/g, " ").trim();
+
+  if (!normalized) {
+    return "<empty>";
+  }
+
+  return normalized.length > 120 ? `${normalized.slice(0, 117)}...` : normalized;
+}
+
+function isDevelopmentEnvironment(): boolean {
+  return process.env.NODE_ENV !== "production";
 }
 
 function createRedirectSignal(

--- a/tests/transport-headers.test.ts
+++ b/tests/transport-headers.test.ts
@@ -3,12 +3,24 @@ import { describe, expect, test, mock } from "bun:test";
 import {
   createViewResult,
   getRevalidateTargets,
+  parseActionResponse,
   parseLoaderResponse,
 } from "../src/client/transport";
 
 void mock.module("@vitejs/plugin-rsc/browser", () => ({
   createFromReadableStream: () => Promise.resolve(null),
 }));
+
+const originalNodeEnv = process.env.NODE_ENV;
+
+function setNodeEnv(value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env.NODE_ENV;
+    return;
+  }
+
+  process.env.NODE_ENV = value;
+}
 
 describe("transport header reading", () => {
   test("createViewResult reads status from x-litzjs-status header", async () => {
@@ -68,11 +80,62 @@ describe("transport header reading", () => {
       },
       { status: 404 },
     );
+    const error = await parseLoaderResponse(response).catch((reason) => reason);
 
-    await expect(parseLoaderResponse(response)).rejects.toMatchObject({
+    expect(error).toMatchObject({
       kind: "fault",
       status: 404,
       message: "Route not found.",
     });
+  });
+
+  test("parseLoaderResponse normalizes non-JSON error responses into development faults", async () => {
+    setNodeEnv("development");
+
+    try {
+      const response = new Response("<html><body>Bad gateway</body></html>", {
+        status: 502,
+        headers: {
+          "content-type": "text/html; charset=utf-8",
+        },
+      });
+      const error = await parseLoaderResponse(response).catch((reason) => reason);
+
+      expect(error).toMatchObject({
+        kind: "fault",
+        status: 502,
+      });
+      expect((error as { message: string }).message).toContain("502");
+      expect((error as { message: string }).message).toContain("Bad gateway");
+    } finally {
+      setNodeEnv(originalNodeEnv);
+    }
+  });
+
+  test("parseActionResponse normalizes malformed JSON into production faults", async () => {
+    setNodeEnv("production");
+
+    try {
+      const response = new Response('{"kind":"data"', {
+        status: 503,
+        headers: {
+          "content-type": "application/json; charset=utf-8",
+        },
+      });
+      const result = await parseActionResponse(response);
+
+      expect(result).not.toBeNull();
+
+      if (!result || result.kind !== "fault") {
+        throw new Error("Expected a normalized fault result.");
+      }
+
+      expect(result.status).toBe(503);
+      expect(result.message).toBe("[litzjs] The server returned an invalid response.");
+      expect(result.digest).toBeUndefined();
+      expect(result.headers.get("content-type")).toBe("application/json; charset=utf-8");
+    } finally {
+      setNodeEnv(originalNodeEnv);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- validate client loader and action responses before attempting to parse them as Litz JSON
- normalize non-JSON, malformed JSON, and unsupported result payloads into structured route faults instead of surfacing raw parse errors
- add regression coverage for HTML/non-JSON loader failures and malformed JSON action failures
- include a patch changeset for the transport fix

## Root Cause
The client transport treated every non-view response as valid JSON and called `response.json()` immediately. When a proxy, CDN, dev server, or upstream host returned HTML, plain text, malformed JSON, or an unexpected payload shape, the runtime surfaced a generic parse/runtime error instead of a stable route fault.

## Impact
Applications now receive structured route faults for invalid transport responses, preserving the original HTTP status and enabling route error boundaries and retry UI to handle upstream failures consistently. In development mode, the fault message also includes the HTTP status, content type, and a short body preview to aid diagnosis.

## Validation
- `bun run fmt`
- `bun run lint:fix`
- `bun test`
- `bun run typecheck`

Closes #48
