### PR TITLE
[codex] fix(client): handle lazy route module load failures

### DIFF
--- a/.changeset/neat-bears-worry.md
+++ b/.changeset/neat-bears-worry.md
@@ -1,0 +1,5 @@
+---
+"litzjs": patch
+---
+
+Handle lazy client route module load failures as managed route faults so rejected imports and missing `route` exports render the framework error state instead of surfacing unhandled errors.

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -386,6 +386,24 @@ function RouteHost(props: {
     (route: LoadedRoute) => createBootstrapPageState(route, url.pathname, search),
     [search, url.pathname],
   );
+  const resolveRouteLoadFailureState = React.useCallback(
+    (error: unknown) => {
+      const failedRoute = createRouteLoadFailureRoute(
+        matched?.entry ?? {
+          id: url.pathname,
+          path: url.pathname,
+          load: async () => ({}),
+        },
+      );
+
+      return {
+        displayLocation: props.location,
+        renderedRoute: failedRoute,
+        pageState: createRouteLoadFailurePageState(failedRoute, url.pathname, search, error),
+      };
+    },
+    [matched, props.location, search, url.pathname],
+  );
   const { displayLocation, renderedRoute, pageState, setPageState } = useResolvedRouteState<
     LoadedRoute,
     PageState
@@ -396,6 +414,7 @@ function RouteHost(props: {
     createBootstrapPageState: createBootstrapPageStateForLocation,
     getCachedRoute: getCachedRouteModule,
     setCachedRoute: setCachedRouteModule,
+    resolveRouteLoadFailureState,
   });
 
   const displayedUrl = React.useMemo(() => new URL(displayLocation), [displayLocation]);
@@ -421,7 +440,7 @@ function RouteHost(props: {
   }, [displayedSearch, displayedUrl.pathname, renderedRoute]);
 
   React.useEffect(() => {
-    if (!renderedRoute || !activeRouteState) {
+    if (!renderedRoute || !activeRouteState || pageState.errorInfo) {
       return;
     }
 
@@ -516,7 +535,7 @@ function RouteHost(props: {
     return () => {
       controller.abort();
     };
-  }, [activeRouteState, navigate, renderedRoute]);
+  }, [activeRouteState, navigate, pageState.errorInfo, renderedRoute]);
   const activeMatches: ActiveMatch[] = activeRouteState?.activeMatches ?? [];
   const matchesValue = activeMatches;
   const reloadImpl = React.useCallback(
@@ -643,6 +662,25 @@ type PageState = {
   offlineStaleMatchIds?: ReadonlySet<string>;
 };
 
+function normalizeRouteModuleLoadError(error: unknown): MatchErrorInfo {
+  return {
+    kind: "fault",
+    status: 500,
+    headers: new Headers(),
+    message: error instanceof Error ? error.message : "Failed to load route module.",
+  };
+}
+
+function createRouteLoadFailureRoute(entry: ManifestEntry): LoadedRoute {
+  return {
+    id: entry.id,
+    path: entry.path,
+    component() {
+      return React.createElement(React.Fragment);
+    },
+  };
+}
+
 function createEmptyPageState(): PageState {
   return {
     matchStates: {},
@@ -733,6 +771,23 @@ function createBootstrapPageState(
     error,
     status: hasCachedLoader ? "revalidating" : "loading",
     pending: missingLoader || hasCachedLoader,
+  };
+}
+
+function createRouteLoadFailurePageState(
+  route: LoadedRoute,
+  pathname: string,
+  search: URLSearchParams,
+  error: unknown,
+): PageState {
+  return {
+    ...createBootstrapPageState(route, pathname, search),
+    status: "error",
+    pending: false,
+    error: null,
+    errorInfo: normalizeRouteModuleLoadError(error),
+    errorTargetId: route.id,
+    offlineStaleMatchIds: undefined,
   };
 }
 

--- a/src/client/route-host-state.tsx
+++ b/src/client/route-host-state.tsx
@@ -15,6 +15,12 @@ export type MatchedManifestEntry<TRoute> = {
   entry: RouteManifestEntry<TRoute>;
 } | null;
 
+export type RouteLoadFailureState<TRoute, TPageState> = {
+  displayLocation: string;
+  renderedRoute: TRoute | null;
+  pageState: TPageState;
+};
+
 export function useResolvedRouteState<TRoute, TPageState>(options: {
   matched: MatchedManifestEntry<TRoute>;
   location: string;
@@ -22,6 +28,11 @@ export function useResolvedRouteState<TRoute, TPageState>(options: {
   createBootstrapPageState(this: void, route: TRoute): TPageState;
   getCachedRoute(this: void, id: string): TRoute | null;
   setCachedRoute(this: void, id: string, route: TRoute): void;
+  resolveRouteLoadFailureState?(
+    this: void,
+    error: unknown,
+    previousRoute: TRoute | null,
+  ): RouteLoadFailureState<TRoute, TPageState>;
 }): {
   displayLocation: string;
   renderedRoute: TRoute | null;
@@ -32,6 +43,7 @@ export function useResolvedRouteState<TRoute, TPageState>(options: {
   const createBootstrapPageState = options.createBootstrapPageState;
   const getCachedRoute = options.getCachedRoute;
   const setCachedRoute = options.setCachedRoute;
+  const resolveRouteLoadFailureState = options.resolveRouteLoadFailureState;
   const [displayLocation, setDisplayLocation] = React.useState(() => options.location);
   const [renderedRoute, setRenderedRoute] = React.useState<TRoute | null>(null);
   const [pageState, setPageState] = React.useState<TPageState>(() => createEmptyPageState());
@@ -80,25 +92,36 @@ export function useResolvedRouteState<TRoute, TPageState>(options: {
         return;
       }
 
-      const loaded = await matchedEntry.load();
+      try {
+        const loaded = await matchedEntry.load();
 
-      if (cancelled) {
-        return;
+        if (cancelled) {
+          return;
+        }
+
+        if (!loaded.route) {
+          throw new Error(`Route module "${matchedEntry.id}" does not export "route".`);
+        }
+
+        setCachedRoute(matchedEntry.id, loaded.route);
+        const loadedRouteState = resolveLoadedRouteState({
+          loadedRoute: loaded.route,
+          nextLocation: options.location,
+          createBootstrapPageState: (route) => createBootstrapPageState(route),
+        });
+        setPageState(loadedRouteState.pageState);
+        setRenderedRoute(loadedRouteState.loadedRoute);
+        setDisplayLocation(loadedRouteState.displayLocation);
+      } catch (error) {
+        if (cancelled || !resolveRouteLoadFailureState) {
+          throw error;
+        }
+
+        const failedRouteState = resolveRouteLoadFailureState(error, renderedRouteRef.current);
+        setRenderedRoute(failedRouteState.renderedRoute);
+        setDisplayLocation(failedRouteState.displayLocation);
+        setPageState(failedRouteState.pageState);
       }
-
-      if (!loaded.route) {
-        throw new Error(`Route module "${matchedEntry.id}" does not export "route".`);
-      }
-
-      setCachedRoute(matchedEntry.id, loaded.route);
-      const loadedRouteState = resolveLoadedRouteState({
-        loadedRoute: loaded.route,
-        nextLocation: options.location,
-        createBootstrapPageState: (route) => createBootstrapPageState(route),
-      });
-      setPageState(loadedRouteState.pageState);
-      setRenderedRoute(loadedRouteState.loadedRoute);
-      setDisplayLocation(loadedRouteState.displayLocation);
     }
 
     void loadRouteModule();
@@ -112,6 +135,7 @@ export function useResolvedRouteState<TRoute, TPageState>(options: {
     getCachedRoute,
     options.location,
     options.matched,
+    resolveRouteLoadFailureState,
     setCachedRoute,
   ]);
 

--- a/tests/client-wildcard-route-runtime.test.tsx
+++ b/tests/client-wildcard-route-runtime.test.tsx
@@ -32,6 +32,13 @@ const loadDocsRoute = mock(async () => ({
     component: DocsRoute,
   },
 }));
+const loadBrokenRoute = mock(async () => ({
+  route: {
+    id: "broken-route",
+    path: "/broken",
+    component: BrokenRoute,
+  },
+}));
 const loadProjectRoute = mock(async () => ({
   route: projectRoute,
 }));
@@ -57,12 +64,17 @@ function HomeRoute(): React.ReactElement {
       <Link href="/projects/42?tab=activity" prefetchData>
         Open project route
       </Link>
+      <Link href="/broken">Open broken route</Link>
     </main>
   );
 }
 
 function DocsRoute(): React.ReactElement {
   return <div id="route-state" data-value="wildcard-route" />;
+}
+
+function BrokenRoute(): React.ReactElement {
+  return <div id="route-state" data-value="broken-route" />;
 }
 
 function ProjectRoute(): React.ReactElement {
@@ -133,6 +145,11 @@ void mock.module("virtual:litzjs:route-manifest", () => ({
       load: loadProjectRoute,
     },
     {
+      id: "broken-route",
+      path: "/broken",
+      load: loadBrokenRoute,
+    },
+    {
       id: submitRoute.id,
       path: submitRoute.path,
       load: loadSubmitRoute,
@@ -159,6 +176,7 @@ describe("client wildcard route runtime", () => {
     clientModule = null;
     loadHomeRoute.mockClear();
     loadDocsRoute.mockClear();
+    loadBrokenRoute.mockClear();
     loadProjectRoute.mockClear();
     loadSubmitRoute.mockClear();
     routeSubmitEvents.length = 0;
@@ -206,6 +224,56 @@ describe("client wildcard route runtime", () => {
       "wildcard-route",
     );
     expect(loadDocsRoute).toHaveBeenCalledTimes(1);
+  });
+
+  test("renders a managed route fault when a lazy route module rejects during navigation", async () => {
+    loadBrokenRoute.mockImplementationOnce(async () => Promise.reject(new Error("Chunk 404")));
+    clientModule = await import("../src/client/index");
+
+    await act(async () => {
+      clientModule?.mountApp(container!);
+      await flushApp();
+    });
+
+    const link = container?.querySelector('a[href="/broken"]');
+
+    expect(link).not.toBeNull();
+
+    await act(async () => {
+      link?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, button: 0 }));
+      await flushApp();
+    });
+
+    expect(window.location.pathname).toBe("/broken");
+    expect(document.querySelector("h1")?.textContent).toBe("Route Error");
+    expect(document.querySelector("p")?.textContent).toBe("fault 500: Chunk 404");
+  });
+
+  test("renders a managed route fault when a lazy route module omits the route export", async () => {
+    loadBrokenRoute.mockImplementationOnce(
+      async () => ({}) as Awaited<ReturnType<typeof loadBrokenRoute>>,
+    );
+    clientModule = await import("../src/client/index");
+
+    await act(async () => {
+      clientModule?.mountApp(container!);
+      await flushApp();
+    });
+
+    const link = container?.querySelector('a[href="/broken"]');
+
+    expect(link).not.toBeNull();
+
+    await act(async () => {
+      link?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, button: 0 }));
+      await flushApp();
+    });
+
+    expect(window.location.pathname).toBe("/broken");
+    expect(document.querySelector("h1")?.textContent).toBe("Route Error");
+    expect(document.querySelector("p")?.textContent).toBe(
+      'fault 500: Route module "broken-route" does not export "route".',
+    );
   });
 
   test("uses prefetched loader data immediately on navigation while revalidating in the background", async () => {

--- a/tests/route-host-state.test.tsx
+++ b/tests/route-host-state.test.tsx
@@ -37,6 +37,12 @@ type TestRoute = {
   };
 };
 
+type TestPageState = {
+  routeId: string | null;
+  status: "loading" | "idle" | "error";
+  errorMessage: string | null;
+};
+
 function renderTestRoute(route: TestRoute): React.ReactElement {
   const routeNode = React.createElement(route.component);
 
@@ -144,12 +150,16 @@ describe("route host state", () => {
       const createEmptyPageState = React.useCallback(
         () => ({
           routeId: null,
+          status: "loading" as const,
+          errorMessage: null,
         }),
         [],
       );
       const createBootstrapPageState = React.useCallback(
         (route: TestRoute) => ({
           routeId: route.id,
+          status: "idle" as const,
+          errorMessage: null,
         }),
         [],
       );
@@ -157,7 +167,7 @@ describe("route host state", () => {
       const setCachedRoute = React.useCallback((id: string, route: TestRoute) => {
         cache.set(id, route);
       }, []);
-      const state = useResolvedRouteState<TestRoute, { routeId: string | null }>({
+      const state = useResolvedRouteState<TestRoute, TestPageState>({
         matched,
         location: props.location,
         createEmptyPageState,
@@ -214,5 +224,182 @@ describe("route host state", () => {
     );
     expect(document.getElementById("page-state")?.getAttribute("data-value")).toBe("next-route");
     expect(mountEvents).toEqual(["mount"]);
+  });
+
+  test("routes rejected route module loads through the failure state callback", async () => {
+    const loadError = new Error("Chunk 404");
+    const fallbackRoute: TestRoute = {
+      id: "route-load-fault",
+      component() {
+        return <div id="route-state" data-value="route-load-fault" />;
+      },
+    };
+
+    function TestHarness(props: { location: string }) {
+      const matched = React.useMemo(
+        () =>
+          ({
+            entry: {
+              id: "broken-route",
+              load: async () => Promise.reject(loadError),
+            },
+          }) satisfies MatchedManifestEntry<TestRoute>,
+        [],
+      );
+      const createEmptyPageState = React.useCallback(
+        () => ({
+          routeId: null,
+          status: "loading" as const,
+          errorMessage: null,
+        }),
+        [],
+      );
+      const createBootstrapPageState = React.useCallback(
+        (route: TestRoute) => ({
+          routeId: route.id,
+          status: "idle" as const,
+          errorMessage: null,
+        }),
+        [],
+      );
+      const setCachedRoute = React.useCallback(() => {}, []);
+      const resolveRouteLoadFailureState = React.useCallback(
+        (error: unknown) => ({
+          displayLocation: props.location,
+          renderedRoute: fallbackRoute,
+          pageState: {
+            routeId: fallbackRoute.id,
+            status: "error" as const,
+            errorMessage: error instanceof Error ? error.message : String(error),
+          },
+        }),
+        [props.location],
+      );
+      const state = useResolvedRouteState<TestRoute, TestPageState>({
+        matched,
+        location: props.location,
+        createEmptyPageState,
+        createBootstrapPageState,
+        getCachedRoute: React.useCallback(() => null, []),
+        setCachedRoute,
+        resolveRouteLoadFailureState,
+      });
+
+      return (
+        <div>
+          <div id="display-location" data-value={state.displayLocation} />
+          <div id="page-state" data-value={state.pageState.routeId ?? "none"} />
+          <div id="status-state" data-value={state.pageState.status} />
+          <div id="error-state" data-value={state.pageState.errorMessage ?? "none"} />
+          {state.renderedRoute ? renderTestRoute(state.renderedRoute) : null}
+        </div>
+      );
+    }
+
+    await act(async () => {
+      root?.render(<TestHarness location="https://example.com/broken" />);
+      await flushDom();
+    });
+
+    expect(document.getElementById("route-state")?.getAttribute("data-value")).toBe(
+      "route-load-fault",
+    );
+    expect(document.getElementById("display-location")?.getAttribute("data-value")).toBe(
+      "https://example.com/broken",
+    );
+    expect(document.getElementById("page-state")?.getAttribute("data-value")).toBe(
+      "route-load-fault",
+    );
+    expect(document.getElementById("status-state")?.getAttribute("data-value")).toBe("error");
+    expect(document.getElementById("error-state")?.getAttribute("data-value")).toBe("Chunk 404");
+  });
+
+  test("routes missing route exports through the failure state callback", async () => {
+    const fallbackRoute: TestRoute = {
+      id: "route-load-fault",
+      component() {
+        return <div id="route-state" data-value="route-load-fault" />;
+      },
+    };
+
+    function TestHarness(props: { location: string }) {
+      const matched = React.useMemo(
+        () =>
+          ({
+            entry: {
+              id: "missing-route-export",
+              load: async () => ({}),
+            },
+          }) satisfies MatchedManifestEntry<TestRoute>,
+        [],
+      );
+      const createEmptyPageState = React.useCallback(
+        () => ({
+          routeId: null,
+          status: "loading" as const,
+          errorMessage: null,
+        }),
+        [],
+      );
+      const createBootstrapPageState = React.useCallback(
+        (route: TestRoute) => ({
+          routeId: route.id,
+          status: "idle" as const,
+          errorMessage: null,
+        }),
+        [],
+      );
+      const setCachedRoute = React.useCallback(() => {}, []);
+      const resolveRouteLoadFailureState = React.useCallback(
+        (error: unknown) => ({
+          displayLocation: props.location,
+          renderedRoute: fallbackRoute,
+          pageState: {
+            routeId: fallbackRoute.id,
+            status: "error" as const,
+            errorMessage: error instanceof Error ? error.message : String(error),
+          },
+        }),
+        [props.location],
+      );
+      const state = useResolvedRouteState<TestRoute, TestPageState>({
+        matched,
+        location: props.location,
+        createEmptyPageState,
+        createBootstrapPageState,
+        getCachedRoute: React.useCallback(() => null, []),
+        setCachedRoute,
+        resolveRouteLoadFailureState,
+      });
+
+      return (
+        <div>
+          <div id="display-location" data-value={state.displayLocation} />
+          <div id="page-state" data-value={state.pageState.routeId ?? "none"} />
+          <div id="status-state" data-value={state.pageState.status} />
+          <div id="error-state" data-value={state.pageState.errorMessage ?? "none"} />
+          {state.renderedRoute ? renderTestRoute(state.renderedRoute) : null}
+        </div>
+      );
+    }
+
+    await act(async () => {
+      root?.render(<TestHarness location="https://example.com/missing-export" />);
+      await flushDom();
+    });
+
+    expect(document.getElementById("route-state")?.getAttribute("data-value")).toBe(
+      "route-load-fault",
+    );
+    expect(document.getElementById("display-location")?.getAttribute("data-value")).toBe(
+      "https://example.com/missing-export",
+    );
+    expect(document.getElementById("page-state")?.getAttribute("data-value")).toBe(
+      "route-load-fault",
+    );
+    expect(document.getElementById("status-state")?.getAttribute("data-value")).toBe("error");
+    expect(document.getElementById("error-state")?.getAttribute("data-value")).toBe(
+      'Route module "missing-route-export" does not export "route".',
+    );
   });
 });


### PR DESCRIPTION
## Summary
- normalize lazy client route module load failures into managed route faults instead of letting `useResolvedRouteState(...)` surface unhandled effect errors
- install a synthetic fallback route for failed client navigations so the framework route error UI can render for rejected imports and missing `export const route`
- add route-host and client runtime regressions for both failure modes and include a patch changeset

## Why
Issue #49 identified that active navigation could reject while loading a lazy route module or resolve a module without `route`, leaving the client runtime with an unhandled error and no framework-managed recovery path.

## Root Cause
`useResolvedRouteState(...)` awaited `matchedEntry.load()` directly inside a layout effect and threw when the promise rejected or the module omitted `route`. The client host had no way to translate that failure into page fault state, and the subsequent no-loader settle path could also clear any synthetic error state immediately.

## What Changed
- added a route-load failure resolver hook in `src/client/route-host-state.tsx`
- translated route module load failures into managed client page fault state in `src/client/index.ts`
- kept synthetic route faults from being cleared by the no-loader reload effect
- added direct route-host regression coverage for rejected imports and missing route exports
- added client runtime coverage proving navigation now renders `Route Error` for both failure modes
- added a patch changeset for `litzjs`

## Impact
Client-side navigation now fails closed into the framework error UI when a lazy route chunk rejects or a route module is malformed, instead of surfacing an unhandled runtime error or rendering a blank route host.

## Validation
- `bun fmt`
- `bun lint:fix`
- `bun lint`
- `bun typecheck`
- `bun test`

Fixes #49
