### PR TITLE
[codex] perf(client): batch route loader fetches

### DIFF
--- a/.changeset/warm-crabs-batch.md
+++ b/.changeset/warm-crabs-batch.md
@@ -1,0 +1,5 @@
+---
+"litzjs": patch
+---
+
+Batch internal route loader requests so layout and route loader chains can reuse one client round-trip while preserving ordered loader results and falling back to individual fetches when batching is unavailable.

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -5,7 +5,6 @@ import type { ActionHookResult, LayoutReference, LoaderHookResult, SubmitOptions
 import type { RouteRuntimeState } from "./runtime";
 
 import { createFormDataPayload } from "../form-data";
-import { LITZ_RESULT_ACCEPT } from "../internal-transport";
 import {
   extractRouteLikeParams,
   hasPatternSegments,
@@ -16,7 +15,7 @@ import { createSearchParamRecord, type SearchParamRecord } from "../search-param
 import { isAbortError } from "./abort-error";
 import { installClientBindings } from "./bindings";
 import { createLinkComponent } from "./link";
-import { processLoaderResults, type LoaderSettledResult } from "./loader-fetch";
+import { fetchRouteLoadersInParallel, processLoaderResults } from "./loader-fetch";
 import { applySearchParams, shouldPrefetchLink } from "./navigation";
 import { resolveSettledPageStatus, withSettledPageState } from "./page-state";
 import {
@@ -38,7 +37,7 @@ import {
   useRequiredRouteStatus,
 } from "./runtime";
 import { sortRecord } from "./sort-record";
-import { getRevalidateTargets, parseLoaderResponse } from "./transport";
+import { getRevalidateTargets } from "./transport";
 
 installClientBindings({
   usePathname,
@@ -458,7 +457,7 @@ function RouteHost(props: {
 
       setPageState((current) => applyCachedLoaderStateToPageState(current, loaderMatches, mode));
 
-      const settled = await fetchLoaderSettledResults(loaderMatches, {
+      const settled = await fetchRouteLoadersInParallel(loaderMatches, {
         routePath: renderedRoute.path,
         baseRequest,
         signal: controller.signal,
@@ -944,7 +943,7 @@ async function reloadCurrentRoute(options: {
 
   const finalLoaderMatch = loaderMatches[loaderMatches.length - 1];
 
-  const settled = await fetchLoaderSettledResults(loaderMatches, {
+  const settled = await fetchRouteLoadersInParallel(loaderMatches, {
     routePath: options.route.path,
     baseRequest,
     signal: options.signal,
@@ -1726,7 +1725,7 @@ async function prefetchRouteLoaderData(
     return;
   }
 
-  const settled = await fetchLoaderSettledResults(loaderMatches, {
+  const settled = await fetchRouteLoadersInParallel(loaderMatches, {
     routePath: route.path,
     baseRequest: {
       params: extractRouteParams(route.path, nextUrl.pathname) ?? {},
@@ -1745,50 +1744,6 @@ async function prefetchRouteLoaderData(
       withLoaderStaleState(result.value.loaderResult, false),
     );
   }
-}
-
-async function fetchLoaderSettledResults(
-  matches: readonly {
-    readonly id: string;
-    readonly cacheKey: string;
-  }[],
-  context: {
-    routePath: string;
-    baseRequest: {
-      params: Record<string, string>;
-      search: URLSearchParams;
-    };
-    signal?: AbortSignal;
-  },
-): Promise<readonly LoaderSettledResult[]> {
-  const search = createSearchParamRecord(context.baseRequest.search);
-
-  return Promise.allSettled(
-    matches.map(async (match) => {
-      const response = await fetch("/_litzjs/route", {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          accept: LITZ_RESULT_ACCEPT,
-        },
-        body: JSON.stringify({
-          path: context.routePath,
-          target: match.id,
-          operation: "loader",
-          request: {
-            params: context.baseRequest.params,
-            search,
-          },
-        }),
-        signal: context.signal,
-      });
-
-      return {
-        match,
-        loaderResult: await parseLoaderResponse(response),
-      };
-    }),
-  );
 }
 
 function withLoaderStaleState(result: LoaderHookResult, stale: boolean): LoaderHookResult {

--- a/src/client/loader-fetch.ts
+++ b/src/client/loader-fetch.ts
@@ -1,6 +1,7 @@
 import type { LoaderHookResult } from "../index";
 
-import { fetchRouteLoader, isRedirectSignal, isRouteLikeError } from "./runtime";
+import { isAbortError } from "./abort-error";
+import { fetchRouteLoader, fetchRouteLoaders, isRedirectSignal, isRouteLikeError } from "./runtime";
 
 interface LoaderMatch {
   readonly id: string;
@@ -24,6 +25,53 @@ interface LoaderSettledEntry {
 export type LoaderSettledResult = PromiseSettledResult<LoaderSettledEntry>;
 
 export async function fetchRouteLoadersInParallel(
+  matches: readonly LoaderMatch[],
+  context: LoaderFetchContext,
+): Promise<readonly LoaderSettledResult[]> {
+  if (matches.length <= 1) {
+    return fetchRouteLoadersIndividually(matches, context);
+  }
+
+  try {
+    const settled = await fetchRouteLoaders(
+      context.routePath,
+      context.baseRequest,
+      matches.map((match) => match.id),
+      context.signal,
+    );
+
+    if (settled.length !== matches.length) {
+      throw new Error("Batched route loader response length did not match the requested targets.");
+    }
+
+    return settled.map((result, index) => {
+      if (result.status === "rejected") {
+        return result;
+      }
+
+      return {
+        status: "fulfilled",
+        value: {
+          match: matches[index]!,
+          loaderResult: result.value,
+        },
+      } satisfies PromiseFulfilledResult<LoaderSettledEntry>;
+    });
+  } catch (error) {
+    if (isAbortError(error)) {
+      return matches.map(() => {
+        return {
+          status: "rejected",
+          reason: error,
+        } satisfies PromiseRejectedResult;
+      });
+    }
+
+    return fetchRouteLoadersIndividually(matches, context);
+  }
+}
+
+async function fetchRouteLoadersIndividually(
   matches: readonly LoaderMatch[],
   context: LoaderFetchContext,
 ): Promise<readonly LoaderSettledResult[]> {

--- a/src/client/runtime.tsx
+++ b/src/client/runtime.tsx
@@ -13,6 +13,7 @@ import {
   isRedirectSignal,
   isRouteLikeError,
   parseActionResponse,
+  parseLoaderBatchResponse,
   parseLoaderResponse,
 } from "./transport";
 
@@ -38,6 +39,30 @@ export async function fetchRouteLoader(
   });
 
   return parseLoaderResponse(response);
+}
+
+export async function fetchRouteLoaders(
+  path: string,
+  request: ResourceRequest,
+  targets: readonly string[],
+  signal?: AbortSignal,
+): Promise<readonly PromiseSettledResult<LoaderHookResult>[]> {
+  const response = await fetch("/_litzjs/route", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: LITZ_RESULT_ACCEPT,
+    },
+    body: JSON.stringify({
+      path,
+      targets,
+      operation: "loader",
+      request: normalizeRequest(request),
+    }),
+    signal,
+  });
+
+  return parseLoaderBatchResponse(response);
 }
 
 export async function fetchRouteAction(

--- a/src/client/transport.tsx
+++ b/src/client/transport.tsx
@@ -33,6 +33,16 @@ export type LitzJsonBody =
     };
 
 type LitzJsonKind = LitzJsonBody["kind"];
+type BatchedLoaderEntry = {
+  status: number;
+  headers?: Array<[string, string]>;
+  body: Extract<LitzJsonBody, { kind: "data" | "redirect" | "error" | "fault" }>;
+};
+
+type BatchedLoaderBody = {
+  kind: "batch";
+  results: BatchedLoaderEntry[];
+};
 
 export async function parseLoaderResponse(response: Response): Promise<LoaderHookResult> {
   const contentType = response.headers.get("content-type") ?? "";
@@ -83,6 +93,99 @@ export async function parseLoaderResponse(response: Response): Promise<LoaderHoo
   }
 
   throw createRouteLikeError(response.status, publicHeaders, body);
+}
+
+export async function parseLoaderBatchResponse(
+  response: Response,
+): Promise<readonly PromiseSettledResult<LoaderHookResult>[]> {
+  const contentType = response.headers.get("content-type") ?? "";
+  const publicHeaders = createPublicResultHeaders(response.headers);
+  const bodyText = await response.text();
+
+  if (!isJsonContentType(contentType)) {
+    throw createRouteLikeError(
+      response.status,
+      publicHeaders,
+      createInvalidTransportFault(response.status, contentType, bodyText, "non-json"),
+    );
+  }
+
+  try {
+    const parsedBody = JSON.parse(bodyText) as unknown;
+
+    if (isBatchedLoaderBody(parsedBody)) {
+      return parsedBody.results.map((entry) => {
+        const headers = createPublicResultHeaders(new Headers(entry.headers));
+
+        switch (entry.body.kind) {
+          case "data":
+            return {
+              status: "fulfilled",
+              value: {
+                kind: "data",
+                status: entry.status,
+                headers,
+                stale: false,
+                data: entry.body.data,
+                render() {
+                  return null;
+                },
+              },
+            } satisfies PromiseFulfilledResult<LoaderHookResult>;
+          case "error":
+            return {
+              status: "fulfilled",
+              value: {
+                kind: "error",
+                status: entry.status,
+                headers,
+                stale: false,
+                message: entry.body.message,
+                code: entry.body.code,
+                data: entry.body.data,
+              },
+            } satisfies PromiseFulfilledResult<LoaderHookResult>;
+          case "redirect":
+            return {
+              status: "rejected",
+              reason: createRedirectSignal(entry.status, headers, entry.body),
+            } satisfies PromiseRejectedResult;
+          case "fault":
+            return {
+              status: "rejected",
+              reason: createRouteLikeError(entry.status, headers, entry.body),
+            } satisfies PromiseRejectedResult;
+        }
+      });
+    }
+
+    if (
+      isLitzJsonBody(parsedBody) &&
+      (parsedBody.kind === "error" || parsedBody.kind === "fault")
+    ) {
+      throw createRouteLikeError(response.status, publicHeaders, parsedBody);
+    }
+
+    if (isLitzJsonBody(parsedBody) && parsedBody.kind === "redirect") {
+      throw createRedirectSignal(response.status, publicHeaders, parsedBody);
+    }
+
+    throw createRouteLikeError(
+      response.status,
+      publicHeaders,
+      createInvalidTransportFault(response.status, contentType, bodyText, "unsupported-kind"),
+    );
+  } catch (error) {
+    if (isRouteLikeError(error) || isRedirectSignal(error)) {
+      throw error;
+    }
+
+    throw createRouteLikeError(
+      response.status,
+      publicHeaders,
+      createInvalidTransportFault(response.status, contentType, bodyText, "malformed-json"),
+    );
+  }
 }
 
 export async function parseActionResponse(response: Response): Promise<ActionHookResult> {
@@ -318,6 +421,45 @@ function isLitzJsonBody(value: unknown): value is LitzJsonBody {
   }
 
   return false;
+}
+
+function isBatchedLoaderBody(value: unknown): value is BatchedLoaderBody {
+  const candidate = value as { kind?: unknown; results?: unknown } | null;
+
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    candidate?.kind === "batch" &&
+    Array.isArray(candidate.results) &&
+    candidate.results.every(isBatchedLoaderEntry)
+  );
+}
+
+function isBatchedLoaderEntry(value: unknown): value is BatchedLoaderEntry {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { status?: unknown }).status === "number" &&
+    isBatchedHeaderEntries((value as { headers?: unknown }).headers) &&
+    isLitzJsonBody((value as { body?: unknown }).body) &&
+    ["data", "redirect", "error", "fault"].includes(
+      ((value as { body: { kind?: unknown } }).body.kind ?? "") as string,
+    )
+  );
+}
+
+function isBatchedHeaderEntries(value: unknown): value is Array<[string, string]> | undefined {
+  return (
+    value === undefined ||
+    (Array.isArray(value) &&
+      value.every(
+        (entry) =>
+          Array.isArray(entry) &&
+          entry.length === 2 &&
+          typeof entry[0] === "string" &&
+          typeof entry[1] === "string",
+      ))
+  );
 }
 
 function createResponsePreview(bodyText: string): string {

--- a/src/internal-transport.ts
+++ b/src/internal-transport.ts
@@ -17,6 +17,7 @@ export type InternalPayload = {
 export type InternalRequestMetadata = {
   path?: string;
   target?: string;
+  targets?: string[];
   operation?: "loader" | "action";
   request?: {
     params?: Record<string, string>;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -59,6 +59,29 @@ type RouteModule = {
   };
 };
 
+type RouteMatchEntry = {
+  id: string;
+  path: string;
+  loader?: (context: unknown) => Awaitable<unknown>;
+  input?: RuntimeInputValidation;
+  middleware: MiddlewareHandler<unknown, unknown>[];
+};
+
+type BatchedLoaderResponseEntry = {
+  status: number;
+  headers?: Array<[string, string]>;
+  body: {
+    kind: "data" | "redirect" | "error" | "fault";
+    data?: unknown;
+    revalidate?: string[];
+    location?: string;
+    replace?: boolean;
+    message?: string;
+    code?: string;
+    digest?: string;
+  };
+};
+
 type ResourceModule = {
   path: string;
   resource?: {
@@ -326,6 +349,7 @@ async function handleRouteRequest<TContext>(
     const body = await parseInternalRequestBody(request);
     const routePath = body.path;
     const targetId = body.target;
+    const targetIds = body.targets?.filter((value): value is string => typeof value === "string");
     const operation =
       body.operation ?? (new URL(request.url).pathname === "/_litzjs/action" ? "action" : "loader");
     const entry = routes.find((route) => route.path === routePath);
@@ -335,6 +359,52 @@ async function handleRouteRequest<TContext>(
     }
 
     const chain = getRouteMatchChain(entry);
+    const normalizedRequest = normalizeInternalRequest(
+      request,
+      routePath,
+      body.request,
+      body.payload,
+    );
+    const signal = request.signal;
+    const context = await getContext();
+
+    if (operation === "loader" && targetIds && targetIds.length > 0) {
+      const results: BatchedLoaderResponseEntry[] = [];
+
+      for (const batchTargetId of targetIds) {
+        const batchTarget = findTargetRouteMatch(chain, batchTargetId);
+
+        if (!batchTarget) {
+          return createLitzJsonResponse(404, { kind: "fault", message: "Route target not found." });
+        }
+
+        const batchResult = await executeRouteTarget({
+          route: entry.route,
+          operation,
+          chain,
+          target: batchTarget,
+          normalizedRequest,
+          signal,
+          context,
+        });
+        const serializedResult = createBatchedLoaderResponseEntry(batchResult);
+
+        if (!serializedResult) {
+          return createLitzJsonResponse(409, {
+            kind: "fault",
+            message: "Batched route loaders do not support view results.",
+          });
+        }
+
+        results.push(serializedResult);
+      }
+
+      return createLitzJsonResponse(200, {
+        kind: "batch",
+        results,
+      });
+    }
+
     const target =
       operation === "action"
         ? chain[chain.length - 1]
@@ -344,61 +414,15 @@ async function handleRouteRequest<TContext>(
       return createLitzJsonResponse(404, { kind: "fault", message: "Route target not found." });
     }
 
-    const targetIndex = chain.findIndex((candidate) => candidate.id === target.id);
-    const handler =
-      operation === "action" ? (entry.route.action ?? entry.route.options?.action) : target.loader;
-    const validation = operation === "action" ? entry.route.options?.input : target.input;
-    const middleware = chain.slice(0, targetIndex + 1).flatMap((candidate) => candidate.middleware);
     viewId = `${target.id}#${operation}`;
-
-    if (!handler) {
-      return createLitzJsonResponse(405, {
-        kind: "fault",
-        message: `Route does not define a ${operation}.`,
-      });
-    }
-
-    const normalizedRequest = normalizeInternalRequest(
-      request,
-      routePath,
-      body.request,
-      body.payload,
-    );
-    const signal = request.signal;
-    const context = await getContext();
-    const result = await runMiddlewareChain({
-      middleware,
-      request: normalizedRequest.request,
-      params:
-        operation === "action"
-          ? normalizedRequest.params
-          : (extractRouteLikeParams(target.path, new URL(normalizedRequest.request.url).pathname) ??
-            normalizedRequest.params),
+    const result = await executeRouteTarget({
+      route: entry.route,
+      operation,
+      chain,
+      target,
+      normalizedRequest,
       signal,
       context,
-      async execute(nextContext) {
-        const params =
-          operation === "action"
-            ? normalizedRequest.params
-            : (extractRouteLikeParams(
-                target.path,
-                new URL(normalizedRequest.request.url).pathname,
-              ) ?? normalizedRequest.params);
-        const input = await resolveValidatedInput({
-          validation,
-          request: normalizedRequest.request,
-          params,
-          signal,
-          context: nextContext,
-        });
-        return handler({
-          request: normalizedRequest.request,
-          params,
-          signal,
-          context: nextContext,
-          input,
-        });
-      },
     });
 
     return createServerResultResponse(result, viewId);
@@ -526,13 +550,7 @@ async function runMiddlewareChain<TContext, TResult>(options: {
   return dispatch(0, options.context);
 }
 
-function getRouteMatchChain(entry: RouteModule): Array<{
-  id: string;
-  path: string;
-  loader?: (context: unknown) => Awaitable<unknown>;
-  input?: RuntimeInputValidation;
-  middleware: MiddlewareHandler<unknown, unknown>[];
-}> {
+function getRouteMatchChain(entry: RouteModule): RouteMatchEntry[] {
   const layouts = collectLayouts(entry.route?.options?.layout);
 
   return [
@@ -562,24 +580,159 @@ function collectLayouts(layout: LayoutModule | undefined): LayoutModule[] {
 }
 
 function findTargetRouteMatch(
-  chain: Array<{
-    id: string;
-    path: string;
-    loader?: (context: unknown) => Awaitable<unknown>;
-    input?: RuntimeInputValidation;
-    middleware: MiddlewareHandler<unknown, unknown>[];
-  }>,
+  chain: RouteMatchEntry[],
   targetId: string,
-):
-  | {
-      id: string;
-      path: string;
-      loader?: (context: unknown) => Awaitable<unknown>;
-      input?: RuntimeInputValidation;
-      middleware: MiddlewareHandler<unknown, unknown>[];
-    }
-  | undefined {
+): RouteMatchEntry | undefined {
   return chain.find((entry) => entry.id === targetId);
+}
+
+async function executeRouteTarget<TContext>(options: {
+  route: NonNullable<RouteModule["route"]>;
+  operation: "loader" | "action";
+  chain: RouteMatchEntry[];
+  target: RouteMatchEntry;
+  normalizedRequest: {
+    request: Request;
+    params: Record<string, string>;
+  };
+  signal: AbortSignal;
+  context: TContext | undefined;
+}): Promise<unknown> {
+  const targetIndex = options.chain.findIndex((candidate) => candidate.id === options.target.id);
+  const handler =
+    options.operation === "action"
+      ? (options.route.action ?? options.route.options?.action)
+      : options.target.loader;
+  const validation =
+    options.operation === "action" ? options.route.options?.input : options.target.input;
+
+  if (!handler) {
+    return {
+      kind: "fault",
+      status: 405,
+      message: `Route does not define a ${options.operation}.`,
+    };
+  }
+
+  const params =
+    options.operation === "action"
+      ? options.normalizedRequest.params
+      : (extractRouteLikeParams(
+          options.target.path,
+          new URL(options.normalizedRequest.request.url).pathname,
+        ) ?? options.normalizedRequest.params);
+
+  return runMiddlewareChain({
+    middleware: options.chain
+      .slice(0, targetIndex + 1)
+      .flatMap((candidate) => candidate.middleware),
+    request: options.normalizedRequest.request,
+    params,
+    signal: options.signal,
+    context: options.context,
+    async execute(nextContext) {
+      const input = await resolveValidatedInput({
+        validation,
+        request: options.normalizedRequest.request,
+        params,
+        signal: options.signal,
+        context: nextContext,
+      });
+
+      return handler({
+        request: options.normalizedRequest.request,
+        params,
+        signal: options.signal,
+        context: nextContext,
+        input,
+      });
+    },
+  });
+}
+
+function createBatchedLoaderResponseEntry(result: unknown): BatchedLoaderResponseEntry | null {
+  if (!result || typeof result !== "object" || !("kind" in result)) {
+    return {
+      status: 500,
+      body: {
+        kind: "fault",
+        message: "Handler returned an unknown result.",
+      },
+    };
+  }
+
+  const serverResult = result as {
+    kind: string;
+    status?: number;
+    headers?: HeadersInit;
+    data?: unknown;
+    location?: string;
+    replace?: boolean;
+    revalidate?: string[];
+    message?: string;
+    code?: string;
+    digest?: string;
+  };
+  const headers = new Headers(serverResult.headers);
+  applyRevalidateHeader(headers, serverResult.revalidate);
+  const serializedHeaderEntries = Array.from(headers.entries());
+  const serializedHeaders =
+    serializedHeaderEntries.length > 0 ? serializedHeaderEntries : undefined;
+
+  switch (serverResult.kind) {
+    case "data":
+      return {
+        status: serverResult.status ?? 200,
+        headers: serializedHeaders,
+        body: {
+          kind: "data",
+          data: serverResult.data,
+          revalidate: serverResult.revalidate ?? [],
+        },
+      };
+    case "redirect":
+      return {
+        status: serverResult.status ?? 303,
+        headers: serializedHeaders,
+        body: {
+          kind: "redirect",
+          location: serverResult.location,
+          replace: serverResult.replace ?? false,
+          revalidate: serverResult.revalidate ?? [],
+        },
+      };
+    case "error":
+      return {
+        status: serverResult.status ?? 500,
+        headers: serializedHeaders,
+        body: {
+          kind: "error",
+          message: serverResult.message ?? "Error",
+          code: serverResult.code,
+          data: serverResult.data,
+        },
+      };
+    case "fault":
+      return {
+        status: serverResult.status ?? 500,
+        headers: serializedHeaders,
+        body: {
+          kind: "fault",
+          message: serverResult.message ?? "Fault",
+          digest: serverResult.digest,
+        },
+      };
+    case "view":
+      return null;
+    default:
+      return {
+        status: 500,
+        body: {
+          kind: "fault",
+          message: `Unsupported result kind "${serverResult.kind}".`,
+        },
+      };
+  }
 }
 
 async function createServerResultResponse(

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -1203,6 +1203,29 @@ type DevMiddlewareHandler<TContext = unknown, TResult = unknown> = (
   next: DevMiddlewareNext<TContext, TResult>,
 ) => Promise<TResult> | TResult;
 
+type DevRouteMatchEntry = {
+  id: string;
+  path: string;
+  loader?: (context: unknown) => Promise<unknown>;
+  input?: RuntimeInputValidation;
+  middleware: DevMiddlewareHandler<unknown, unknown>[];
+};
+
+type BatchedLoaderResponseEntry = {
+  status: number;
+  headers?: Array<[string, string]>;
+  body: {
+    kind: "data" | "redirect" | "error" | "fault";
+    data?: unknown;
+    revalidate?: string[];
+    location?: string;
+    replace?: boolean;
+    message?: string;
+    code?: string;
+    digest?: string;
+  };
+};
+
 export async function handleLitzResourceRequest(
   server: ViteDevServer,
   manifest: DiscoveredResource[],
@@ -1348,6 +1371,7 @@ export async function handleLitzRouteRequest(
 
     const routePath = body.path;
     const targetId = body.target;
+    const targetIds = body.targets?.filter((value): value is string => typeof value === "string");
     const operation =
       body.operation ?? (request.url.startsWith("/_litzjs/action") ? "action" : "loader");
     const entry = manifest.find((route) => route.path === routePath);
@@ -1424,6 +1448,55 @@ export async function handleLitzRouteRequest(
       path: entry.path,
       route,
     });
+    const normalizedRequest = normalizeInternalResourceRequest(
+      internalRequest,
+      routePath,
+      body.request,
+      body.payload,
+    );
+    const controller = new AbortController();
+    request.once("close", () => controller.abort());
+    const signal = controller.signal;
+
+    if (operation === "loader" && targetIds && targetIds.length > 0) {
+      const results: BatchedLoaderResponseEntry[] = [];
+
+      for (const batchTargetId of targetIds) {
+        const batchTarget = findDevTargetRouteMatch(chain, batchTargetId);
+
+        if (!batchTarget) {
+          sendLitzJson(response, 404, { kind: "fault", message: "Route target not found." });
+          return;
+        }
+
+        const batchResult = await executeDevRouteTarget({
+          route,
+          operation,
+          chain,
+          target: batchTarget,
+          normalizedRequest,
+          signal,
+        });
+        const serializedResult = createDevBatchedLoaderResponseEntry(batchResult);
+
+        if (!serializedResult) {
+          sendLitzJson(response, 409, {
+            kind: "fault",
+            message: "Batched route loaders do not support view results.",
+          });
+          return;
+        }
+
+        results.push(serializedResult);
+      }
+
+      sendLitzJson(response, 200, {
+        kind: "batch",
+        results,
+      });
+      return;
+    }
+
     const target =
       operation === "action"
         ? chain[chain.length - 1]
@@ -1434,62 +1507,14 @@ export async function handleLitzRouteRequest(
       return;
     }
 
-    const targetIndex = chain.findIndex((candidate) => candidate.id === target.id);
-    const handler =
-      operation === "action" ? (route.action ?? route.options?.action) : target.loader;
-    const validation = operation === "action" ? route.options?.input : target.input;
     viewId = `${target.id}#${operation}`;
-
-    if (!handler) {
-      sendLitzJson(response, 405, {
-        kind: "fault",
-        message: `Route does not define a ${operation}.`,
-      });
-      return;
-    }
-
-    const normalizedRequest = normalizeInternalResourceRequest(
-      internalRequest,
-      routePath,
-      body.request,
-      body.payload,
-    );
-    const controller = new AbortController();
-    request.once("close", () => controller.abort());
-    const signal = controller.signal;
-    const result = await runDevMiddlewareChain({
-      middleware: chain.slice(0, targetIndex + 1).flatMap((candidate) => candidate.middleware),
-      request: normalizedRequest.request,
-      params:
-        operation === "action"
-          ? normalizedRequest.params
-          : (extractRouteLikeParams(target.path, new URL(normalizedRequest.request.url).pathname) ??
-            normalizedRequest.params),
+    const result = await executeDevRouteTarget({
+      route,
+      operation,
+      chain,
+      target,
+      normalizedRequest,
       signal,
-      context: undefined,
-      async execute(nextContext) {
-        const params =
-          operation === "action"
-            ? normalizedRequest.params
-            : (extractRouteLikeParams(
-                target.path,
-                new URL(normalizedRequest.request.url).pathname,
-              ) ?? normalizedRequest.params);
-        const input = await resolveValidatedInput({
-          validation,
-          request: normalizedRequest.request,
-          params,
-          signal,
-          context: nextContext,
-        });
-        return handler({
-          request: normalizedRequest.request,
-          params,
-          signal,
-          context: nextContext,
-          input,
-        });
-      },
     });
 
     await sendServerResult(server, response, result, viewId);
@@ -2002,13 +2027,7 @@ function getDevRouteMatchChain(entry: {
       middleware?: DevMiddlewareHandler<unknown, unknown>[];
     };
   };
-}): Array<{
-  id: string;
-  path: string;
-  loader?: (context: unknown) => Promise<unknown>;
-  input?: RuntimeInputValidation;
-  middleware: DevMiddlewareHandler<unknown, unknown>[];
-}> {
+}): DevRouteMatchEntry[] {
   const layouts = collectDevLayouts(entry.route.options?.layout);
 
   return [
@@ -2088,6 +2107,175 @@ function findDevTargetRouteMatch<TEntry extends { id: string }>(
   targetId: string,
 ): TEntry | undefined {
   return chain.find((entry) => entry.id === targetId);
+}
+
+async function executeDevRouteTarget(options: {
+  route: {
+    loader?: (context: unknown) => Promise<unknown>;
+    action?: (context: unknown) => Promise<unknown>;
+    options?: {
+      layout?: {
+        id: string;
+        path: string;
+        options?: {
+          layout?: unknown;
+          loader?: (context: unknown) => Promise<unknown>;
+          input?: RuntimeInputValidation;
+          middleware?: DevMiddlewareHandler<unknown, unknown>[];
+        };
+      };
+      loader?: (context: unknown) => Promise<unknown>;
+      action?: (context: unknown) => Promise<unknown>;
+      input?: RuntimeInputValidation;
+      middleware?: DevMiddlewareHandler<unknown, unknown>[];
+    };
+  };
+  operation: "loader" | "action";
+  chain: DevRouteMatchEntry[];
+  target: DevRouteMatchEntry;
+  normalizedRequest: {
+    request: Request;
+    params: Record<string, string>;
+  };
+  signal: AbortSignal;
+}): Promise<unknown> {
+  const targetIndex = options.chain.findIndex((candidate) => candidate.id === options.target.id);
+  const handler =
+    options.operation === "action"
+      ? (options.route.action ?? options.route.options?.action)
+      : options.target.loader;
+  const validation =
+    options.operation === "action" ? options.route.options?.input : options.target.input;
+
+  if (!handler) {
+    return {
+      kind: "fault",
+      status: 405,
+      message: `Route does not define a ${options.operation}.`,
+    };
+  }
+
+  const params =
+    options.operation === "action"
+      ? options.normalizedRequest.params
+      : (extractRouteLikeParams(
+          options.target.path,
+          new URL(options.normalizedRequest.request.url).pathname,
+        ) ?? options.normalizedRequest.params);
+
+  return runDevMiddlewareChain({
+    middleware: options.chain
+      .slice(0, targetIndex + 1)
+      .flatMap((candidate) => candidate.middleware),
+    request: options.normalizedRequest.request,
+    params,
+    signal: options.signal,
+    context: undefined,
+    async execute(nextContext) {
+      const input = await resolveValidatedInput({
+        validation,
+        request: options.normalizedRequest.request,
+        params,
+        signal: options.signal,
+        context: nextContext,
+      });
+
+      return handler({
+        request: options.normalizedRequest.request,
+        params,
+        signal: options.signal,
+        context: nextContext,
+        input,
+      });
+    },
+  });
+}
+
+function createDevBatchedLoaderResponseEntry(result: unknown): BatchedLoaderResponseEntry | null {
+  if (!result || typeof result !== "object" || !("kind" in result)) {
+    return {
+      status: 500,
+      body: {
+        kind: "fault",
+        message: "Handler returned an unknown result.",
+      },
+    };
+  }
+
+  const serverResult = result as {
+    kind: string;
+    status?: number;
+    headers?: HeadersInit;
+    data?: unknown;
+    location?: string;
+    replace?: boolean;
+    revalidate?: string[];
+    message?: string;
+    code?: string;
+    digest?: string;
+  };
+  const headers = new Headers(serverResult.headers);
+  if (serverResult.revalidate?.length) {
+    headers.set("x-litzjs-revalidate", serverResult.revalidate.join(","));
+  }
+  const serializedHeaderEntries = Array.from(headers.entries());
+  const serializedHeaders =
+    serializedHeaderEntries.length > 0 ? serializedHeaderEntries : undefined;
+
+  switch (serverResult.kind) {
+    case "data":
+      return {
+        status: serverResult.status ?? 200,
+        headers: serializedHeaders,
+        body: {
+          kind: "data",
+          data: serverResult.data,
+          revalidate: serverResult.revalidate ?? [],
+        },
+      };
+    case "redirect":
+      return {
+        status: serverResult.status ?? 303,
+        headers: serializedHeaders,
+        body: {
+          kind: "redirect",
+          location: serverResult.location,
+          replace: serverResult.replace ?? false,
+          revalidate: serverResult.revalidate ?? [],
+        },
+      };
+    case "error":
+      return {
+        status: serverResult.status ?? 500,
+        headers: serializedHeaders,
+        body: {
+          kind: "error",
+          message: serverResult.message ?? "Error",
+          code: serverResult.code,
+          data: serverResult.data,
+        },
+      };
+    case "fault":
+      return {
+        status: serverResult.status ?? 500,
+        headers: serializedHeaders,
+        body: {
+          kind: "fault",
+          message: serverResult.message ?? "Fault",
+          digest: serverResult.digest,
+        },
+      };
+    case "view":
+      return null;
+    default:
+      return {
+        status: 500,
+        body: {
+          kind: "fault",
+          message: `Unsupported result kind "${serverResult.kind}".`,
+        },
+      };
+  }
 }
 
 /**

--- a/tests/loader-fetch.test.ts
+++ b/tests/loader-fetch.test.ts
@@ -1,29 +1,10 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { LoaderSettledResult } from "../src/client/loader-fetch";
 import type { LoaderHookResult } from "../src/index";
 
-const mockFetchRouteLoader = mock();
-
-void mock.module("../src/client/runtime", () => ({
-  fetchRouteLoader: mockFetchRouteLoader,
-  isRedirectSignal(value: unknown): boolean {
-    return (
-      typeof value === "object" &&
-      value !== null &&
-      "kind" in value &&
-      (value as { kind: string }).kind === "redirect"
-    );
-  },
-  isRouteLikeError(value: unknown): boolean {
-    return (
-      typeof value === "object" &&
-      value !== null &&
-      "kind" in value &&
-      ((value as { kind: string }).kind === "error" || (value as { kind: string }).kind === "fault")
-    );
-  },
-}));
+const mockFetch = mock<typeof fetch>();
+const originalFetch = globalThis.fetch;
 
 import { processLoaderResults } from "../src/client/loader-fetch";
 
@@ -41,162 +22,128 @@ function createDataResult(data: unknown): LoaderHookResult {
   } as LoaderHookResult;
 }
 
+function createTransportResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "content-type": "application/vnd.litzjs.result+json",
+    },
+  });
+}
+
 beforeEach(() => {
-  mockFetchRouteLoader.mockReset();
+  mockFetch.mockReset();
+  globalThis.fetch = mockFetch as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
 });
 
 describe("fetchRouteLoadersInParallel", () => {
-  test("fetches all loaders concurrently rather than sequentially", async () => {
-    let activeCalls = 0;
-    let maxConcurrentCalls = 0;
+  test("fetches all loaders in a single batched request", async () => {
+    const baseRequest = {
+      params: { id: "7" },
+      search: new URLSearchParams("tab=settings"),
+    };
+    const controller = new AbortController();
 
-    mockFetchRouteLoader.mockImplementation(
-      () =>
-        new Promise<LoaderHookResult>((resolve) => {
-          activeCalls++;
-          maxConcurrentCalls = Math.max(maxConcurrentCalls, activeCalls);
-          setTimeout(() => {
-            activeCalls--;
-            resolve(createDataResult({ value: "ok" }));
-          }, 10);
-        }),
+    mockFetch.mockResolvedValue(
+      createTransportResponse({
+        kind: "batch",
+        results: [
+          {
+            status: 200,
+            body: {
+              kind: "data",
+              data: "layout-data",
+              revalidate: [],
+            },
+          },
+          {
+            status: 200,
+            body: {
+              kind: "data",
+              data: "route-data",
+              revalidate: [],
+            },
+          },
+        ],
+      }),
     );
 
     const { fetchRouteLoadersInParallel } = await import("../src/client/loader-fetch");
 
-    const matches = [createMatch("layout-a"), createMatch("layout-b"), createMatch("route")];
+    const matches = [createMatch("layout-a"), createMatch("route")];
 
-    await fetchRouteLoadersInParallel(matches, {
+    const results = await fetchRouteLoadersInParallel(matches, {
       routePath: "/test",
-      baseRequest: { params: {}, search: new URLSearchParams() },
+      baseRequest,
+      signal: controller.signal,
     });
 
-    expect(maxConcurrentCalls).toBe(3);
-    expect(mockFetchRouteLoader).toHaveBeenCalledTimes(3);
-  });
-
-  test("returns results in the same order as input matches", async () => {
-    const resolvers: Array<(result: LoaderHookResult) => void> = [];
-
-    mockFetchRouteLoader.mockImplementation(
-      () =>
-        new Promise<LoaderHookResult>((resolve) => {
-          resolvers.push(resolve);
-        }),
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch.mock.calls[0]?.[0]).toBe("/_litzjs/route");
+    expect((mockFetch.mock.calls[0]?.[1] as RequestInit | undefined)?.signal).toBe(
+      controller.signal,
     );
+    const requestBody = (mockFetch.mock.calls[0]?.[1] as RequestInit | undefined)?.body;
 
-    const { fetchRouteLoadersInParallel } = await import("../src/client/loader-fetch");
-
-    const matches = [createMatch("first"), createMatch("second"), createMatch("third")];
-
-    const promise = fetchRouteLoadersInParallel(matches, {
-      routePath: "/test",
-      baseRequest: { params: {}, search: new URLSearchParams() },
+    expect(typeof requestBody).toBe("string");
+    expect(JSON.parse(requestBody as string)).toEqual({
+      path: "/test",
+      targets: ["layout-a", "route"],
+      operation: "loader",
+      request: {
+        params: { id: "7" },
+        search: {
+          tab: "settings",
+        },
+      },
     });
-
-    // Resolve in reverse order
-    resolvers[2]!(createDataResult("third-data"));
-    resolvers[0]!(createDataResult("first-data"));
-    resolvers[1]!(createDataResult("second-data"));
-
-    const results = await promise;
-
-    expect(results).toHaveLength(3);
+    expect(results).toHaveLength(2);
     expect(results[0]!.status).toBe("fulfilled");
     expect(results[1]!.status).toBe("fulfilled");
-    expect(results[2]!.status).toBe("fulfilled");
-
-    const values = results.map((r) => (r as PromiseFulfilledResult<unknown>).value) as Array<{
-      match: { id: string };
-      loaderResult: LoaderHookResult;
-    }>;
-
-    expect(values[0]!.match.id).toBe("first");
-    expect(values[1]!.match.id).toBe("second");
-    expect(values[2]!.match.id).toBe("third");
-  });
-
-  test("passes abort signal to fetchRouteLoader", async () => {
-    const receivedSignals: Array<AbortSignal | undefined> = [];
-
-    mockFetchRouteLoader.mockImplementation(
-      (_path: string, _req: unknown, _target: string, signal?: AbortSignal) => {
-        receivedSignals.push(signal);
-        return Promise.resolve(createDataResult("ok"));
-      },
+    expect((results[0] as PromiseFulfilledResult<{ match: { id: string } }>).value.match.id).toBe(
+      "layout-a",
     );
-
-    const { fetchRouteLoadersInParallel } = await import("../src/client/loader-fetch");
-
-    const controller = new AbortController();
-    const matches = [createMatch("a"), createMatch("b")];
-
-    await fetchRouteLoadersInParallel(matches, {
-      routePath: "/test",
-      baseRequest: { params: {}, search: new URLSearchParams() },
-      signal: controller.signal,
-    });
-
-    expect(receivedSignals).toHaveLength(2);
-    expect(receivedSignals[0]).toBe(controller.signal);
-    expect(receivedSignals[1]).toBe(controller.signal);
+    expect((results[1] as PromiseFulfilledResult<{ match: { id: string } }>).value.match.id).toBe(
+      "route",
+    );
   });
 
-  test("rejects in-flight fetches when signal is aborted", async () => {
-    const controller = new AbortController();
-
-    mockFetchRouteLoader.mockImplementation(
-      (_path: string, _req: unknown, _target: string, signal?: AbortSignal) =>
-        new Promise<LoaderHookResult>((resolve, reject) => {
-          const onAbort = () =>
-            reject(new DOMException("The operation was aborted.", "AbortError"));
-          if (signal?.aborted) {
-            onAbort();
-            return;
-          }
-          signal?.addEventListener("abort", onAbort);
-          // Never resolves naturally — only via abort
+  test("falls back to individual loader requests when the batched request fails", async () => {
+    mockFetch
+      .mockRejectedValueOnce(new Error("batch unsupported"))
+      .mockResolvedValueOnce(
+        createTransportResponse({
+          kind: "data",
+          data: "ok-loader-ok",
+          revalidate: [],
         }),
-    );
+      )
+      .mockResolvedValueOnce(
+        createTransportResponse(
+          {
+            kind: "fault",
+            message: "fail",
+          },
+          500,
+        ),
+      );
 
     const { fetchRouteLoadersInParallel } = await import("../src/client/loader-fetch");
 
-    const matches = [createMatch("a")];
-
-    const promise = fetchRouteLoadersInParallel(matches, {
-      routePath: "/test",
-      baseRequest: { params: {}, search: new URLSearchParams() },
-      signal: controller.signal,
-    });
-
-    controller.abort();
-
-    const results = await promise;
-
-    expect(results[0]!.status).toBe("rejected");
-    expect((results[0] as PromiseRejectedResult).reason).toBeInstanceOf(DOMException);
-  });
-
-  test("captures rejected loaders without blocking other results", async () => {
-    mockFetchRouteLoader.mockImplementation((_path: string, _req: unknown, target: string) => {
-      if (target === "failing") {
-        return Promise.reject({ kind: "error", status: 500, message: "fail" });
-      }
-      return Promise.resolve(createDataResult("ok"));
-    });
-
-    const { fetchRouteLoadersInParallel } = await import("../src/client/loader-fetch");
-
-    const matches = [createMatch("ok-loader"), createMatch("failing"), createMatch("another-ok")];
+    const matches = [createMatch("ok-loader"), createMatch("failing")];
 
     const results = await fetchRouteLoadersInParallel(matches, {
       routePath: "/test",
       baseRequest: { params: {}, search: new URLSearchParams() },
     });
 
+    expect(mockFetch).toHaveBeenCalledTimes(3);
     expect(results[0]!.status).toBe("fulfilled");
     expect(results[1]!.status).toBe("rejected");
-    expect(results[2]!.status).toBe("fulfilled");
   });
 });
 

--- a/tests/offline-route.test.ts
+++ b/tests/offline-route.test.ts
@@ -1,29 +1,7 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 
 import type { LoaderSettledResult } from "../src/client/loader-fetch";
 import type { LoaderHookResult } from "../src/index";
-
-const mockFetchRouteLoader = mock();
-
-void mock.module("../src/client/runtime", () => ({
-  fetchRouteLoader: mockFetchRouteLoader,
-  isRedirectSignal(value: unknown): boolean {
-    return (
-      typeof value === "object" &&
-      value !== null &&
-      "kind" in value &&
-      (value as { kind: string }).kind === "redirect"
-    );
-  },
-  isRouteLikeError(value: unknown): boolean {
-    return (
-      typeof value === "object" &&
-      value !== null &&
-      "kind" in value &&
-      ((value as { kind: string }).kind === "error" || (value as { kind: string }).kind === "fault")
-    );
-  },
-}));
 
 import { processLoaderResults } from "../src/client/loader-fetch";
 
@@ -40,10 +18,6 @@ function createDataResult(data: unknown): LoaderHookResult {
     stale: false,
   } as LoaderHookResult;
 }
-
-beforeEach(() => {
-  mockFetchRouteLoader.mockReset();
-});
 
 describe("processLoaderResults offline handling", () => {
   describe("resolveOfflineEligible + onOfflineStale", () => {

--- a/tests/server-security.test.ts
+++ b/tests/server-security.test.ts
@@ -213,6 +213,128 @@ describe("server security", () => {
     expect(body.data.term).toBe("litz");
   });
 
+  test("supports batched internal route loader requests and preserves requested order", async () => {
+    let layoutCalls = 0;
+    let routeCalls = 0;
+
+    const server = createServer({
+      manifest: {
+        routes: [
+          {
+            id: "projects.show",
+            path: "/projects/:id",
+            route: {
+              loader(context: unknown) {
+                routeCalls += 1;
+
+                const { request, params } = context as {
+                  request: Request;
+                  params: Record<string, string>;
+                };
+
+                return {
+                  kind: "data",
+                  data: {
+                    source: "route",
+                    href: request.url,
+                    id: params.id,
+                  },
+                };
+              },
+              options: {
+                layout: {
+                  id: "projects.layout",
+                  path: "/projects",
+                  options: {
+                    loader(context: unknown) {
+                      layoutCalls += 1;
+
+                      const { request } = context as {
+                        request: Request;
+                      };
+
+                      return {
+                        kind: "data",
+                        data: {
+                          source: "layout",
+                          href: request.url,
+                        },
+                      };
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const response = await server.fetch(
+      new Request("https://app.example.com/_litzjs/route", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          path: "/projects/:id",
+          targets: ["projects.show", "projects.layout"],
+          operation: "loader",
+          request: {
+            params: { id: "42" },
+            search: {
+              tab: "settings",
+            },
+          },
+        }),
+      }),
+    );
+    const body = (await response.json()) as {
+      kind: "batch";
+      results: Array<{
+        status: number;
+        body: {
+          kind: "data";
+          data: {
+            source: string;
+            href: string;
+            id?: string;
+          };
+          revalidate: string[];
+        };
+      }>;
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.kind).toBe("batch");
+    expect(layoutCalls).toBe(1);
+    expect(routeCalls).toBe(1);
+    expect(body.results).toHaveLength(2);
+    expect(body.results[0]).toEqual({
+      status: 200,
+      body: {
+        kind: "data",
+        data: {
+          source: "route",
+          href: "https://app.example.com/projects/42?tab=settings",
+          id: "42",
+        },
+        revalidate: [],
+      },
+    });
+    expect(body.results[1]).toEqual({
+      status: 200,
+      body: {
+        kind: "data",
+        data: {
+          source: "layout",
+          href: "https://app.example.com/projects/42?tab=settings",
+        },
+        revalidate: [],
+      },
+    });
+  });
+
   test("does not expose unhandled server error messages from api routes", async () => {
     const server = createServer({
       manifest: {

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -477,6 +477,108 @@ describe("dev server abort signal lifecycle", () => {
 });
 
 describe("dev server error masking", () => {
+  test("supports batched internal route loader requests and preserves requested order", async () => {
+    let layoutCalls = 0;
+    let routeCalls = 0;
+
+    const server = createMockViteDevServer(async () => ({
+      route: {
+        async loader({ request, params }: { request: Request; params: Record<string, string> }) {
+          routeCalls += 1;
+
+          return {
+            kind: "data",
+            data: {
+              source: "route",
+              href: request.url,
+              id: params.id,
+            },
+          };
+        },
+        options: {
+          layout: {
+            id: "projects.layout",
+            path: "/projects",
+            options: {
+              async loader({ request }: { request: Request }) {
+                layoutCalls += 1;
+
+                return {
+                  kind: "data",
+                  data: {
+                    source: "layout",
+                    href: request.url,
+                  },
+                };
+              },
+            },
+          },
+        },
+      },
+    }));
+    const internalMetadata = JSON.stringify({
+      path: "/projects/:id",
+      targets: ["projects.show", "projects.layout"],
+      operation: "loader",
+      request: {
+        params: { id: "42" },
+        search: {
+          tab: "settings",
+        },
+      },
+    });
+    const request = createMockRequest({
+      url: "/_litzjs/route",
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: internalMetadata,
+    });
+    const response = createMockResponse();
+    const next = mock(() => {});
+
+    await handleLitzRouteRequest(
+      server,
+      [{ id: "projects.show", path: "/projects/:id", modulePath: "src/routes/projects.ts" }],
+      request,
+      response,
+      next,
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(layoutCalls).toBe(1);
+    expect(routeCalls).toBe(1);
+    expect(JSON.parse(response.getBody())).toEqual({
+      kind: "batch",
+      results: [
+        {
+          status: 200,
+          body: {
+            kind: "data",
+            data: {
+              source: "route",
+              href: "http://localhost:5173/projects/42?tab=settings",
+              id: "42",
+            },
+            revalidate: [],
+          },
+        },
+        {
+          status: 200,
+          body: {
+            kind: "data",
+            data: {
+              source: "layout",
+              href: "http://localhost:5173/projects/42?tab=settings",
+            },
+            revalidate: [],
+          },
+        },
+      ],
+    });
+  });
+
   test("treats missing internal route targets as faults", async () => {
     const server = createMockViteDevServer(async () => ({}));
     const internalMetadata = JSON.stringify({


### PR DESCRIPTION
## Summary
- batch layout and route loader fetches into a single internal `/_litzjs/route` request during navigation and prefetch flows
- add client-side batched loader parsing with ordered settled results plus individual-request fallback when batching is unavailable
- extend the production server and Vite dev server route handlers to accept ordered loader target arrays and return ordered batched loader payloads
- add regression coverage for client batching, production server batching, and Vite dev-server batching
- add a changeset for the patch release

## Why
Issue #50 identified that nested layout chains were still issuing one internal POST per loader target. That duplicated request serialization and transport work for every active layout/route loader in a chain.

## Root Cause
The client navigation and prefetch paths were constructing one internal route-loader request per match, even though the request metadata was identical except for the loader target id. The server-side route handlers also only accepted a single loader target at a time.

## What Changed
- `src/client/index.ts` now routes loader fetches through the shared loader batching helper instead of its own per-target fetch loop
- `src/client/loader-fetch.ts`, `src/client/runtime.tsx`, and `src/client/transport.tsx` now support batched loader requests and ordered settled result parsing
- `src/internal-transport.ts` now carries ordered loader target arrays
- `src/server/index.ts` and `src/vite.ts` now accept batched route-loader targets and return ordered batched loader result payloads
- batching falls back to individual requests when the batch path is unavailable, including unsupported view-loader cases
- tests were updated to cover the new transport contract without leaking runtime module mocks across the suite

## Impact
Routes with multiple loader-backed layouts can now collapse repeated internal loader fetches into a single client round-trip while preserving ordered loader handling and existing client-facing behavior.

## Validation
- `bun run fmt`
- `bun run lint:fix`
- `bun run typecheck`
- `bun test`

Closes #50