### PR TITLE
[codex] keep settled resource entries warm across remounts

### DIFF
--- a/.changeset/fifty-shrimps-relax.md
+++ b/.changeset/fifty-shrimps-relax.md
@@ -1,0 +1,5 @@
+---
+"litzjs": patch
+---
+
+Keep settled client resource entries warm across real remounts by retaining them in the cache until idle-entry pruning evicts them.

--- a/src/client/resources.tsx
+++ b/src/client/resources.tsx
@@ -665,19 +665,21 @@ function getInitialSnapshot(): ResourceSnapshot {
 }
 
 function getEntry(key: string): ResourceStoreEntry {
-  let entry = resourceStore.get(key);
+  const cachedEntry = resourceStore.get(key);
 
-  if (!entry) {
-    entry = {
+  if (!cachedEntry) {
+    const entry: ResourceStoreEntry = {
       snapshot: getInitialSnapshot(),
-      listeners: new Set(),
+      listeners: new Set<() => void>(),
       actionSequence: 0,
     };
     resourceStore.set(key, entry);
     pruneResourceStore();
+    return entry;
   }
 
-  return entry;
+  touchResourceEntry(key, cachedEntry);
+  return cachedEntry;
 }
 
 function notify(entry: ResourceStoreEntry): void {
@@ -712,8 +714,25 @@ function syncEntryPendingState(entry: ResourceStoreEntry): void {
   };
 }
 
+function hasSettledResourceEntry(entry: ResourceStoreEntry): boolean {
+  return entry.snapshot.loaderResult !== null || entry.snapshot.actionResult !== null;
+}
+
+function touchResourceEntry(key: string, entry: ResourceStoreEntry): void {
+  if (resourceStore.get(key) !== entry) {
+    return;
+  }
+
+  resourceStore.delete(key);
+  resourceStore.set(key, entry);
+}
+
 function cleanupResourceEntry(key: string, entry: ResourceStoreEntry): void {
   if (entry.listeners.size > 0 || hasActiveEntryRequests(entry) || entry.snapshot.pending) {
+    return;
+  }
+
+  if (hasSettledResourceEntry(entry)) {
     return;
   }
 
@@ -727,6 +746,10 @@ function deferredCleanupResourceEntry(key: string, entry: ResourceStoreEntry): v
 
   queueMicrotask(() => {
     if (entry.listeners.size > 0 || hasActiveEntryRequests(entry) || entry.snapshot.pending) {
+      return;
+    }
+
+    if (hasSettledResourceEntry(entry)) {
       return;
     }
 
@@ -763,7 +786,11 @@ function pruneResourceStore(): void {
       return;
     }
 
-    cleanupResourceEntry(key, entry);
+    if (entry.listeners.size > 0 || hasActiveEntryRequests(entry) || entry.snapshot.pending) {
+      continue;
+    }
+
+    resourceStore.delete(key);
   }
 }
 

--- a/tests/resource-runtime.test.tsx
+++ b/tests/resource-runtime.test.tsx
@@ -434,6 +434,74 @@ describe("resource runtime", () => {
     expect(document.querySelector(".resource-count")?.getAttribute("data-value")).toBe("1");
   });
 
+  test("resource store preserves settled entries across remounts after a later tick", async () => {
+    const resourceId = "user-004";
+    let loaderCalls = 0;
+
+    globalThis.fetch = (async (_input: RequestInfo | URL, _init?: RequestInit) => {
+      loaderCalls += 1;
+      return Response.json({
+        kind: "data",
+        data: { id: resourceId, count: 1 },
+      });
+    }) as typeof fetch;
+
+    await act(async () => {
+      root?.render(<accountResource.Component params={{ id: resourceId }} />);
+      await flushDom();
+    });
+
+    expect(loaderCalls).toBe(1);
+
+    await act(async () => {
+      root?.render(<></>);
+      await flushDom();
+    });
+
+    await act(async () => {
+      root?.render(<accountResource.Component params={{ id: resourceId }} />);
+      await flushDom();
+    });
+
+    expect(loaderCalls).toBe(1);
+    expect(document.querySelector(".resource-count")?.getAttribute("data-value")).toBe("1");
+  });
+
+  test("resource store keeps settled entries warm across navigation away and back", async () => {
+    const resourceId = "user-005";
+    let loaderCalls = 0;
+
+    globalThis.fetch = (async (_input: RequestInfo | URL, _init?: RequestInit) => {
+      loaderCalls += 1;
+      return Response.json({
+        kind: "data",
+        data: { id: resourceId, count: 1 },
+      });
+    }) as typeof fetch;
+
+    await act(async () => {
+      root?.render(<accountResource.Component params={{ id: resourceId }} />);
+      await flushDom();
+    });
+
+    expect(loaderCalls).toBe(1);
+
+    await act(async () => {
+      root?.render(<section className="other-screen" />);
+      await flushDom();
+    });
+
+    expect(document.querySelector(".other-screen")).not.toBeNull();
+
+    await act(async () => {
+      root?.render(<accountResource.Component params={{ id: resourceId }} />);
+      await flushDom();
+    });
+
+    expect(loaderCalls).toBe(1);
+    expect(document.querySelector(".resource-count")?.getAttribute("data-value")).toBe("1");
+  });
+
   test("treats repeated query params as part of the resource cache key", async () => {
     const loaderBodies: string[] = [];
 


### PR DESCRIPTION
## Summary
- retain settled client resource entries after the last subscriber disconnects instead of deleting them on the next microtask
- treat the resource store as an LRU-style warm cache by refreshing entry recency on access and pruning only idle entries when the store exceeds its size limit
- add regression coverage for remount-after-tick and navigation-away/back flows, plus a patch changeset for the behavior change

## Why
Issue #51 calls out that resolved resource data only survives synchronous remounts because the store deletes settled entries as soon as the last listener unsubscribes. That leaves common UI patterns like closing and reopening panels, switching tabs, or navigating away and back unable to reuse warm data.

## Root Cause
`src/client/resources.tsx` eagerly removed idle entries in both the immediate cleanup path and the deferred microtask cleanup path, even when the entry already held a settled loader or action snapshot. As a result, any remount that happened after the unsubscribe tick rebuilt the resource from scratch.

## User Impact
Resources now stay warm across real remounts for the same request key until idle-entry pruning evicts them. Delayed remounts and navigation away/back flows can reuse settled data instead of triggering an unnecessary reload immediately.

## Validation
- `bun fmt`
- `bun lint:fix`
- `bun typecheck`
- `bun test`

Closes #51
