### PR TITLE
[codex] fix docs package name mismatches

### DIFF
--- a/.changeset/cyan-chefs-smile.md
+++ b/.changeset/cyan-chefs-smile.md
@@ -1,0 +1,5 @@
+---
+"litzjs": patch
+---
+
+Fix docs package name mismatches in installation, Deno, and API reference pages.

--- a/tests/docs-package-names.test.ts
+++ b/tests/docs-package-names.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+function readDoc(relativePath: string) {
+  return readFileSync(path.join(process.cwd(), relativePath), "utf8");
+}
+
+function normalizeWhitespace(value: string) {
+  return value.replaceAll(/\s+/g, " ").trim();
+}
+
+describe("docs package names", () => {
+  test("installation docs use the published package name in every install command", () => {
+    const installationDoc = readDoc("www/src/routes/docs/installation.tsx");
+
+    expect(installationDoc).toContain("bun add litzjs");
+    expect(installationDoc).toContain("npm install litzjs");
+    expect(installationDoc).toContain("yarn add litzjs");
+    expect(installationDoc).toContain("pnpm add litzjs");
+
+    expect(installationDoc).not.toContain("bun add litz`");
+    expect(installationDoc).not.toContain("npm install litz`");
+    expect(installationDoc).not.toContain("yarn add litz`");
+    expect(installationDoc).not.toContain("pnpm add litz`");
+  });
+
+  test("deployment and API reference docs use the published package name", () => {
+    const denoDeployDoc = readDoc("www/src/routes/docs/deno-deploy.tsx");
+    const apiReferenceDoc = normalizeWhitespace(readDoc("www/src/routes/docs/api-reference.tsx"));
+
+    expect(denoDeployDoc).toContain('"litzjs/": "npm:litzjs@latest/"');
+    expect(denoDeployDoc).not.toContain('"litzjs/": "npm:litz@latest/"');
+
+    expect(apiReferenceDoc).toContain(
+      "Complete reference for all exports from litzjs, litzjs/client, litzjs/server, and litzjs/vite.",
+    );
+    expect(apiReferenceDoc).toContain(">litzjs</h2>");
+    expect(apiReferenceDoc).not.toContain("exports from litz, litzjs/client");
+  });
+});

--- a/tests/docs-package-names.test.ts
+++ b/tests/docs-package-names.test.ts
@@ -19,10 +19,10 @@ describe("docs package names", () => {
     expect(installationDoc).toContain("yarn add litzjs");
     expect(installationDoc).toContain("pnpm add litzjs");
 
-    expect(installationDoc).not.toContain("bun add litz`");
-    expect(installationDoc).not.toContain("npm install litz`");
-    expect(installationDoc).not.toContain("yarn add litz`");
-    expect(installationDoc).not.toContain("pnpm add litz`");
+    expect(installationDoc).not.toMatch(/bun add litz(?!js)/);
+    expect(installationDoc).not.toMatch(/npm install litz(?!js)/);
+    expect(installationDoc).not.toMatch(/yarn add litz(?!js)/);
+    expect(installationDoc).not.toMatch(/pnpm add litz(?!js)/);
   });
 
   test("deployment and API reference docs use the published package name", () => {

--- a/www/src/routes/docs/api-reference.tsx
+++ b/www/src/routes/docs/api-reference.tsx
@@ -12,11 +12,12 @@ function ApiReference() {
 
       <h1 className="text-3xl font-bold text-neutral-50 mb-4">API Reference</h1>
       <p className="text-xl text-neutral-300 mb-8">
-        Complete reference for all exports from litz, litzjs/client, litzjs/server, and litzjs/vite.
+        Complete reference for all exports from litzjs, litzjs/client, litzjs/server, and
+        litzjs/vite.
       </p>
 
       <section className="mb-12">
-        <h2 className="text-2xl font-semibold text-neutral-100 mb-4">litz</h2>
+        <h2 className="text-2xl font-semibold text-neutral-100 mb-4">litzjs</h2>
 
         <h3 className="text-xl font-medium text-neutral-100 mb-3">defineRoute</h3>
         <p className="text-neutral-400 mb-4">

--- a/www/src/routes/docs/deno-deploy.tsx
+++ b/www/src/routes/docs/deno-deploy.tsx
@@ -61,7 +61,7 @@ Deno.serve(async (request) => {
     "build": "vite build"
   },
   "imports": {
-    "litzjs/": "npm:litz@latest/"
+    "litzjs/": "npm:litzjs@latest/"
   }
 }`}
         />

--- a/www/src/routes/docs/installation.tsx
+++ b/www/src/routes/docs/installation.tsx
@@ -21,16 +21,16 @@ function DocsInstallationPage() {
         <p className="text-neutral-400 mb-4">Choose your package manager:</p>
 
         <h3 className="text-xl font-medium text-neutral-100 mb-3">Bun</h3>
-        <CodeBlock language="bash" code={`bun add litz`} />
+        <CodeBlock language="bash" code={`bun add litzjs`} />
 
         <h3 className="text-xl font-medium text-neutral-100 mb-3 mt-6">npm</h3>
-        <CodeBlock language="bash" code={`npm install litz`} />
+        <CodeBlock language="bash" code={`npm install litzjs`} />
 
         <h3 className="text-xl font-medium text-neutral-100 mb-3 mt-6">Yarn</h3>
-        <CodeBlock language="bash" code={`yarn add litz`} />
+        <CodeBlock language="bash" code={`yarn add litzjs`} />
 
         <h3 className="text-xl font-medium text-neutral-100 mb-3 mt-6">pnpm</h3>
-        <CodeBlock language="bash" code={`pnpm add litz`} />
+        <CodeBlock language="bash" code={`pnpm add litzjs`} />
       </section>
 
       <section className="mb-12">


### PR DESCRIPTION
## Summary
- fix the docs installation commands to use the published `litzjs` package name for Bun, npm, Yarn, and pnpm
- update the Deno Deploy import map and API reference copy so package names match the published package
- add a regression test that audits the affected docs pages for package-name drift
- include a patch changeset for the docs fix

## Why
Issue #64 reports that the docs site still tells users to install `litz` in copy-paste setup examples even though the published package is `litzjs`. That causes immediate installation and resolution failures for new users.

## Root Cause
The docs content had drifted from the package metadata in `package.json`, and there was no automated check covering the installation page, the Deno import map example, or the API reference copy.

## Impact
Users following the docs now get the correct package name everywhere the issue called out, and the new regression test should catch future package-name mismatches before release.

## Validation
- `bun run fmt`
- `bun run lint:fix`
- `bun test`
- `bun run typecheck`

Closes #64