### PR TITLE
[codex] fix(vite): honor configured base for internal routing

### DIFF
--- a/.changeset/soft-lamps-share.md
+++ b/.changeset/soft-lamps-share.md
@@ -1,0 +1,5 @@
+---
+"litzjs": patch
+---
+
+Honor Vite's configured `base` for internal client transport URLs, generated browser imports, and Vite/server request routing so apps keep working when mounted under a subpath.

--- a/src/base-path.ts
+++ b/src/base-path.ts
@@ -50,5 +50,8 @@ export function stripBasePath(pathname: string, base: string | undefined): strin
 }
 
 export function resolveBasePathname(pathname: string, base: string | undefined): string {
+  // Preserve the original pathname when it does not include the configured
+  // base so deployments behind a proxy that strips the mount prefix before
+  // forwarding still route internal Litz requests correctly.
   return stripBasePath(pathname, base) ?? pathname;
 }

--- a/src/base-path.ts
+++ b/src/base-path.ts
@@ -1,0 +1,54 @@
+const ABSOLUTE_URL_PATTERN = /^[a-zA-Z][a-zA-Z\d+.-]*:/;
+
+export function normalizeBasePath(base: string | undefined): string {
+  if (!base) {
+    return "/";
+  }
+
+  let pathname = base.trim();
+
+  if (!pathname) {
+    return "/";
+  }
+
+  if (ABSOLUTE_URL_PATTERN.test(pathname) || pathname.startsWith("//")) {
+    pathname = new URL(pathname, "https://litzjs.local").pathname;
+  }
+
+  if (!pathname.startsWith("/")) {
+    pathname = `/${pathname}`;
+  }
+
+  pathname = pathname.replace(/\/+$/, "");
+
+  return pathname || "/";
+}
+
+export function joinBasePath(base: string | undefined, pathname: string): string {
+  const normalizedBase = normalizeBasePath(base);
+  const normalizedPathname = pathname.startsWith("/") ? pathname : `/${pathname}`;
+
+  return normalizedBase === "/" ? normalizedPathname : `${normalizedBase}${normalizedPathname}`;
+}
+
+export function stripBasePath(pathname: string, base: string | undefined): string | null {
+  const normalizedBase = normalizeBasePath(base);
+
+  if (normalizedBase === "/") {
+    return pathname;
+  }
+
+  if (pathname === normalizedBase || pathname === `${normalizedBase}/`) {
+    return "/";
+  }
+
+  if (pathname.startsWith(`${normalizedBase}/`)) {
+    return pathname.slice(normalizedBase.length) || "/";
+  }
+
+  return null;
+}
+
+export function resolveBasePathname(pathname: string, base: string | undefined): string {
+  return stripBasePath(pathname, base) ?? pathname;
+}

--- a/src/client/base-url.ts
+++ b/src/client/base-url.ts
@@ -1,0 +1,13 @@
+import { joinBasePath } from "../base-path";
+
+declare global {
+  var __litzjsBaseUrl: string | undefined;
+}
+
+export function resolveClientTransportPath(pathname: string): string {
+  return joinBasePath(resolveConfiguredBaseUrl(), pathname);
+}
+
+function resolveConfiguredBaseUrl(): string | undefined {
+  return globalThis.__litzjsBaseUrl;
+}

--- a/src/client/resources.tsx
+++ b/src/client/resources.tsx
@@ -19,6 +19,7 @@ import {
   type SearchParamRecord,
 } from "../search-params";
 import { isAbortError } from "./abort-error";
+import { resolveClientTransportPath } from "./base-url";
 import { applySearchParams } from "./navigation";
 import { sortRecord } from "./sort-record";
 import {
@@ -465,7 +466,7 @@ async function performPreparedResourceRequest(
     try {
       const response =
         operation === "action"
-          ? await fetch("/_litzjs/resource", {
+          ? await fetch(resolveClientTransportPath("/_litzjs/resource"), {
               method: "POST",
               ...createInternalActionRequestInit(
                 {
@@ -480,7 +481,7 @@ async function performPreparedResourceRequest(
               ),
               signal: actionController?.signal,
             })
-          : await fetch("/_litzjs/resource", {
+          : await fetch(resolveClientTransportPath("/_litzjs/resource"), {
               method: "POST",
               headers: {
                 "content-type": "application/json",

--- a/src/client/runtime.tsx
+++ b/src/client/runtime.tsx
@@ -9,6 +9,7 @@ import {
   createSearchParams,
   type SearchParamRecord,
 } from "../search-params";
+import { resolveClientTransportPath } from "./base-url";
 import {
   isRedirectSignal,
   isRouteLikeError,
@@ -23,7 +24,7 @@ export async function fetchRouteLoader(
   target?: string,
   signal?: AbortSignal,
 ): Promise<LoaderHookResult> {
-  const response = await fetch("/_litzjs/route", {
+  const response = await fetch(resolveClientTransportPath("/_litzjs/route"), {
     method: "POST",
     headers: {
       "content-type": "application/json",
@@ -47,7 +48,7 @@ export async function fetchRouteLoaders(
   targets: readonly string[],
   signal?: AbortSignal,
 ): Promise<readonly PromiseSettledResult<LoaderHookResult>[]> {
-  const response = await fetch("/_litzjs/route", {
+  const response = await fetch(resolveClientTransportPath("/_litzjs/route"), {
     method: "POST",
     headers: {
       "content-type": "application/json",
@@ -80,7 +81,7 @@ export async function fetchRouteAction(
     payload,
   );
 
-  const response = await fetch("/_litzjs/action", {
+  const response = await fetch(resolveClientTransportPath("/_litzjs/action"), {
     method: "POST",
     headers: actionRequest.headers,
     body: actionRequest.body,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,5 +1,6 @@
 import type { ApiRouteMethod } from "../index";
 
+import { normalizeBasePath, resolveBasePathname } from "../base-path";
 import {
   createApiResponseFromResult,
   isServerResultLike,
@@ -136,6 +137,7 @@ export type CreateServerOptions<TContext = unknown> = {
   createContext?(request: Request): Promise<TContext> | TContext;
   onError?(error: unknown, context: TContext | undefined): void;
   manifest?: ServerManifest;
+  base?: string;
   document?: DocumentResponseOption;
   notFound?: DocumentResponseOption;
   assets?: (request: Request) => Promise<Response | null | undefined> | Response | null | undefined;
@@ -145,9 +147,11 @@ export function createServer<TContext = unknown>(
   options: CreateServerOptions<TContext> = {},
 ): { fetch(request: Request): Promise<Response> } {
   const manifest = options.manifest ?? {};
+  const basePath = normalizeBasePath(options.base);
 
   async function handle(request: Request): Promise<Response> {
     const url = new URL(request.url);
+    const pathname = resolveBasePathname(url.pathname, basePath);
     let contextLoaded = false;
     let contextValue: TContext | undefined;
 
@@ -166,7 +170,7 @@ export function createServer<TContext = unknown>(
     }
 
     try {
-      if (url.pathname === "/_litzjs/resource") {
+      if (pathname === "/_litzjs/resource") {
         return await handleResourceRequest(
           request,
           manifest.resources ?? [],
@@ -176,17 +180,23 @@ export function createServer<TContext = unknown>(
         );
       }
 
-      if (url.pathname === "/_litzjs/route" || url.pathname === "/_litzjs/action") {
+      if (pathname === "/_litzjs/route" || pathname === "/_litzjs/action") {
         return await handleRouteRequest(
           request,
           manifest.routes ?? [],
           getContext,
           (error, context) => options.onError?.(error, context),
           () => (contextLoaded ? contextValue : undefined),
+          basePath,
         );
       }
 
-      const apiResponse = await handleApiRequest(request, manifest.apiRoutes ?? [], getContext);
+      const apiResponse = await handleApiRequest(
+        request,
+        manifest.apiRoutes ?? [],
+        getContext,
+        basePath,
+      );
 
       if (apiResponse) {
         return apiResponse;
@@ -199,8 +209,8 @@ export function createServer<TContext = unknown>(
           return toHeadResponseIfNeeded(request, assetResponse);
         }
 
-        if (shouldServeDocument(request, url.pathname)) {
-          const matchedRoute = hasMatchingDocumentRoute(manifest.routes ?? [], url.pathname);
+        if (shouldServeDocument(request, pathname)) {
+          const matchedRoute = hasMatchingDocumentRoute(manifest.routes ?? [], pathname);
           const primaryResponse = matchedRoute
             ? await createDocumentResponse(options.document, request, 200)
             : await createDocumentResponse(options.notFound, request, 404);
@@ -373,6 +383,7 @@ async function handleRouteRequest<TContext>(
   getContext: () => Promise<TContext | undefined>,
   reportError?: (error: unknown, context: TContext | undefined) => void,
   getLoadedContext?: () => TContext | undefined,
+  base?: string,
 ): Promise<Response> {
   let viewId = "litzjs#view";
 
@@ -385,8 +396,9 @@ async function handleRouteRequest<TContext>(
     const routePath = body.path;
     const targetId = body.target;
     const targetIds = body.targets?.filter((value): value is string => typeof value === "string");
+    const requestPathname = resolveBasePathname(new URL(request.url).pathname, base);
     const operation =
-      body.operation ?? (new URL(request.url).pathname === "/_litzjs/action" ? "action" : "loader");
+      body.operation ?? (requestPathname === "/_litzjs/action" ? "action" : "loader");
     const entry = routes.find((route) => route.path === routePath);
 
     if (!routePath || !entry?.route) {
@@ -475,13 +487,15 @@ async function handleApiRequest<TContext>(
   request: Request,
   apiRoutes: ApiModule[],
   getContext: () => Promise<TContext | undefined>,
+  base?: string,
 ): Promise<Response | null> {
   try {
     const url = new URL(request.url);
+    const pathname = resolveBasePathname(url.pathname, base);
     const matched = apiRoutes
       .map((candidate) => ({
         entry: candidate,
-        params: matchPathname(candidate.path, url.pathname),
+        params: matchPathname(candidate.path, pathname),
       }))
       .find((candidate) => candidate.params !== null);
 

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -307,6 +307,9 @@ if (import.meta.hot) {
   globalThis.__litzjsViteHot = import.meta.hot;
 }
 
+// The imported app graph executes before this assignment, but the transport
+// helpers only read the value lazily during fetch calls, matching the existing
+// HMR global pattern above.
 globalThis.__litzjsBaseUrl = ${JSON.stringify(configuredBase)};
 
 import ${JSON.stringify(toBrowserImportSpecifier(root, browserEntryPath, configuredBase))};
@@ -1943,21 +1946,20 @@ export async function handleLitzApiRequest(
   }
 
   const requestUrl = request.url ? new URL(request.url, "http://litzjs.local") : null;
-  const pathname = requestUrl ? resolveBasePathname(requestUrl.pathname, base) : null;
 
   if (!requestUrl) {
     next();
     return;
   }
 
+  const pathname = resolveBasePathname(requestUrl.pathname, base);
+
   if (hasMalformedPathnameEncoding(requestUrl.pathname)) {
     sendBadRequest(response);
     return;
   }
 
-  const matched = manifest.find((entry) =>
-    matchPathPattern(entry.path, pathname ?? requestUrl.pathname),
-  );
+  const matched = manifest.find((entry) => matchPathPattern(entry.path, pathname));
 
   if (!matched) {
     next();

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -20,6 +20,7 @@ import ts from "typescript";
 
 import type { ApiRouteMethod } from "./index";
 
+import { joinBasePath, normalizeBasePath, resolveBasePathname } from "./base-path";
 import { createClientModuleProjection } from "./client-projection";
 import {
   createApiResponseFromResult,
@@ -95,6 +96,7 @@ const RESOLVED_LITZ_RSC_RENDERER_ID = "\0virtual:litzjs:rsc-renderer";
  */
 export function litz(options: LitzPluginOptions = {}): Plugin[] {
   let root = process.cwd();
+  let configuredBase = "/";
   let browserEntryPath = "src/main.tsx";
   let serverEntryPath: string | null = null;
   let serverEntryFilePath: string | null = null;
@@ -180,6 +182,7 @@ export function litz(options: LitzPluginOptions = {}): Plugin[] {
 
     async configResolved(config) {
       root = config.root;
+      configuredBase = normalizeBasePath(config.base);
       outputRootDir = path.resolve(root, config.build.outDir || "dist");
       clientOutDir = path.resolve(
         root,
@@ -263,7 +266,12 @@ export function litz(options: LitzPluginOptions = {}): Plugin[] {
     // browser entries wire up the framework's server and client entry points.
     load(id) {
       if (id === RESOLVED_ROUTE_MANIFEST_ID) {
-        return createRouteManifestModule(routeManifest, root, this.environment.name === "client");
+        return createRouteManifestModule(
+          routeManifest,
+          root,
+          this.environment.name === "client",
+          configuredBase,
+        );
       }
 
       if (id === RESOLVED_RESOURCE_MANIFEST_ID) {
@@ -284,6 +292,7 @@ import { createServer } from "litzjs/server";
 import { serverManifest } from ${JSON.stringify(SERVER_MANIFEST_ID)};
 
 export default createServer({
+  base: ${JSON.stringify(configuredBase)},
   manifest: serverManifest,
   createContext() {
     return undefined;
@@ -298,7 +307,9 @@ if (import.meta.hot) {
   globalThis.__litzjsViteHot = import.meta.hot;
 }
 
-import ${JSON.stringify(toImportSpecifier(root, browserEntryPath))};
+globalThis.__litzjsBaseUrl = ${JSON.stringify(configuredBase)};
+
+import ${JSON.stringify(toBrowserImportSpecifier(root, browserEntryPath, configuredBase))};
 `;
       }
 
@@ -558,16 +569,23 @@ export async function renderView(node, metadata = {}) {
       server.watcher.on("unlink", onFileAddOrUnlink);
 
       server.middlewares.use((request, response, next) => {
-        void handleLitzResourceRequest(server, resourceManifest, request, response, next);
+        void handleLitzResourceRequest(
+          server,
+          resourceManifest,
+          request,
+          response,
+          next,
+          configuredBase,
+        );
       });
       server.middlewares.use((request, response, next) => {
-        void handleLitzRouteRequest(server, routeManifest, request, response, next);
+        void handleLitzRouteRequest(server, routeManifest, request, response, next, configuredBase);
       });
       server.middlewares.use((request, response, next) => {
-        void handleLitzApiRequest(server, apiManifest, request, response, next);
+        void handleLitzApiRequest(server, apiManifest, request, response, next, configuredBase);
       });
       server.middlewares.use((request, response, next) => {
-        void handleLitzDocumentRequest(server, request, response, next);
+        void handleLitzDocumentRequest(server, request, response, next, configuredBase);
       });
     },
 
@@ -597,7 +615,7 @@ export async function renderView(node, metadata = {}) {
         serverEntryFilePath &&
         cleanId === serverEntryFilePath
       ) {
-        const transformed = injectServerManifestIntoServerEntry(cleanId, code);
+        const transformed = injectServerManifestIntoServerEntry(cleanId, code, configuredBase);
 
         if (!transformed) {
           return null;
@@ -662,6 +680,7 @@ export async function renderView(node, metadata = {}) {
             serverOutDir,
             clientOutDir,
             options.embedAssets ?? false,
+            configuredBase,
           );
 
           if (!hasFinalizedServerArtifacts) {
@@ -689,6 +708,7 @@ export async function renderView(node, metadata = {}) {
         serverOutDir,
         clientOutDir,
         inlineClientAssets,
+        configuredBase,
       );
     },
   };
@@ -1162,6 +1182,7 @@ function createRouteManifestModule(
   manifest: DiscoveredRoute[],
   root: string,
   lazy: boolean,
+  base: string,
 ): string {
   if (!lazy) {
     const imports: string[] = [];
@@ -1184,7 +1205,7 @@ function createRouteManifestModule(
   }
 
   const lines = manifest.map((route, index) => {
-    const importPath = toImportSpecifier(root, route.modulePath);
+    const importPath = toBrowserImportSpecifier(root, route.modulePath, base);
     const resolvedModuleFile = path.resolve(root, route.modulePath);
 
     return [
@@ -1221,7 +1242,11 @@ function createClientProjectedFileSet(
  * helper that merges in the route/resource/API manifest. Returns `null` if no
  * `createServer` import is found.
  */
-function injectServerManifestIntoServerEntry(filePath: string, source: string): string | null {
+function injectServerManifestIntoServerEntry(
+  filePath: string,
+  source: string,
+  base: string,
+): string | null {
   const scriptKind = filePath.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS;
   const sourceFile = ts.createSourceFile(
     filePath,
@@ -1333,6 +1358,10 @@ function injectServerManifestIntoServerEntry(filePath: string, source: string): 
                       ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
                       ts.factory.createObjectLiteralExpression(),
                     ),
+                  ),
+                  ts.factory.createPropertyAssignment(
+                    ts.factory.createIdentifier("base"),
+                    ts.factory.createStringLiteral(base),
                   ),
                 ],
                 true,
@@ -1459,6 +1488,10 @@ function toImportSpecifier(root: string, relativeModulePath: string): string {
   return `/@fs/${absolutePath.split(path.sep).join("/")}`;
 }
 
+function toBrowserImportSpecifier(root: string, relativeModulePath: string, base: string): string {
+  return joinBasePath(base, toImportSpecifier(root, relativeModulePath));
+}
+
 function toProjectImportSpecifier(relativeModulePath: string): string {
   return `/${relativeModulePath}`;
 }
@@ -1520,15 +1553,18 @@ export async function handleLitzResourceRequest(
   request: IncomingMessage,
   response: ServerResponse,
   next: Connect.NextFunction,
+  base = "/",
 ): Promise<void> {
   let viewId = "litzjs#view";
+  const requestUrl = request.url ? new URL(request.url, "http://litzjs.local") : null;
+  const pathname = requestUrl ? resolveBasePathname(requestUrl.pathname, base) : "/";
 
   if (!hasRunnableRscEnvironment(server)) {
     next();
     return;
   }
 
-  if (!request.url?.startsWith("/_litzjs/resource")) {
+  if (pathname !== "/_litzjs/resource") {
     next();
     return;
   }
@@ -1644,15 +1680,18 @@ export async function handleLitzRouteRequest(
   request: IncomingMessage,
   response: ServerResponse,
   next: Connect.NextFunction,
+  base = "/",
 ): Promise<void> {
   let viewId = "litzjs#view";
+  const requestUrl = request.url ? new URL(request.url, "http://litzjs.local") : null;
+  const pathname = requestUrl ? resolveBasePathname(requestUrl.pathname, base) : "/";
 
   if (!hasRunnableRscEnvironment(server)) {
     next();
     return;
   }
 
-  if (!request.url?.startsWith("/_litzjs/route") && !request.url?.startsWith("/_litzjs/action")) {
+  if (pathname !== "/_litzjs/route" && pathname !== "/_litzjs/action") {
     next();
     return;
   }
@@ -1670,8 +1709,7 @@ export async function handleLitzRouteRequest(
     const routePath = body.path;
     const targetId = body.target;
     const targetIds = body.targets?.filter((value): value is string => typeof value === "string");
-    const operation =
-      body.operation ?? (request.url.startsWith("/_litzjs/action") ? "action" : "loader");
+    const operation = body.operation ?? (pathname === "/_litzjs/action" ? "action" : "loader");
     const entry = manifest.find((route) => route.path === routePath);
 
     if (!routePath || !entry) {
@@ -1836,6 +1874,7 @@ async function handleLitzDocumentRequest(
   request: IncomingMessage,
   response: ServerResponse,
   next: Connect.NextFunction,
+  base = "/",
 ): Promise<void> {
   if (!hasRunnableRscEnvironment(server)) {
     next();
@@ -1844,18 +1883,23 @@ async function handleLitzDocumentRequest(
 
   const url = request.url ?? "/";
   const requestUrl = new URL(url, "http://litzjs.local");
+  const pathname = resolveBasePathname(requestUrl.pathname, base);
 
   if (request.method !== "GET" && request.method !== "HEAD") {
     next();
     return;
   }
 
-  if (url.startsWith("/_litzjs/") || url.startsWith("/@") || url.startsWith("/node_modules/")) {
+  if (
+    pathname.startsWith("/_litzjs/") ||
+    pathname.startsWith("/@") ||
+    pathname.startsWith("/node_modules/")
+  ) {
     next();
     return;
   }
 
-  if (path.extname(url)) {
+  if (path.extname(pathname)) {
     next();
     return;
   }
@@ -1891,6 +1935,7 @@ export async function handleLitzApiRequest(
   request: IncomingMessage,
   response: ServerResponse,
   next: Connect.NextFunction,
+  base = "/",
 ): Promise<void> {
   if (!hasRunnableRscEnvironment(server)) {
     next();
@@ -1898,6 +1943,7 @@ export async function handleLitzApiRequest(
   }
 
   const requestUrl = request.url ? new URL(request.url, "http://litzjs.local") : null;
+  const pathname = requestUrl ? resolveBasePathname(requestUrl.pathname, base) : null;
 
   if (!requestUrl) {
     next();
@@ -1909,7 +1955,9 @@ export async function handleLitzApiRequest(
     return;
   }
 
-  const matched = manifest.find((entry) => matchPathPattern(entry.path, requestUrl.pathname));
+  const matched = manifest.find((entry) =>
+    matchPathPattern(entry.path, pathname ?? requestUrl.pathname),
+  );
 
   if (!matched) {
     next();
@@ -2712,6 +2760,7 @@ function finalizeServerArtifacts(
   serverOutDir: string,
   clientOutDir: string,
   inlineClientAssets: boolean,
+  base: string,
 ): boolean {
   let rscEntrySource: string;
   let rscAssetsManifestSource: string;
@@ -2782,7 +2831,7 @@ function finalizeServerArtifacts(
 
   try {
     wrapperSource = inlineClientAssets
-      ? createInlineAssetServerWrapper(inlinedServerSource, documentHtml, clientAssets)
+      ? createInlineAssetServerWrapper(inlinedServerSource, documentHtml, clientAssets, base)
       : createServerModuleWrapper(inlinedServerSource);
   } catch {
     return false;
@@ -3048,12 +3097,14 @@ function createInlineAssetServerWrapper(
   serverModuleSource: string,
   documentHtml: string,
   clientAssets: EmbeddedClientAsset[],
+  base: string,
 ): string {
   const serializedClientAssets = JSON.stringify(clientAssets);
   const serializedDocumentHtml = JSON.stringify(documentHtml);
   const { source, handlerName } = transformServerModuleSource(serverModuleSource);
 
   return [
+    `const LITZ_BASE_PATH = ${JSON.stringify(base)};`,
     `const LITZ_DOCUMENT_HTML = ${serializedDocumentHtml};`,
     `const LITZ_CLIENT_ASSETS = new Map(${serializedClientAssets}.map((asset) => [asset.path, asset]));`,
     "",
@@ -3087,6 +3138,22 @@ function createInlineAssetServerWrapper(
     "  });",
     "}",
     "",
+    "function __litzjsStripBasePath(pathname) {",
+    "  if (LITZ_BASE_PATH === '/') {",
+    "    return pathname;",
+    "  }",
+    "",
+    "  if (pathname === LITZ_BASE_PATH || pathname === `${LITZ_BASE_PATH}/`) {",
+    "    return '/';",
+    "  }",
+    "",
+    "  if (pathname.startsWith(`${LITZ_BASE_PATH}/`)) {",
+    "    return pathname.slice(LITZ_BASE_PATH.length) || '/';",
+    "  }",
+    "",
+    "  return pathname;",
+    "}",
+    "",
     "function __litzjsShouldServeDocument(request, pathname) {",
     "  if (pathname.startsWith('/_litzjs/') || pathname.startsWith('/api/')) {",
     "    return false;",
@@ -3104,13 +3171,14 @@ function createInlineAssetServerWrapper(
     "",
     "async function handle(request) {",
     "  const url = new URL(request.url);",
-    "  const asset = LITZ_CLIENT_ASSETS.get(url.pathname);",
+    "  const pathname = __litzjsStripBasePath(url.pathname);",
+    "  const asset = LITZ_CLIENT_ASSETS.get(pathname);",
     "",
     "  if ((request.method === 'GET' || request.method === 'HEAD') && asset) {",
     "    return __litzjsCreateStaticAssetResponse(asset, request);",
     "  }",
     "",
-    "  if ((request.method === 'GET' || request.method === 'HEAD') && __litzjsShouldServeDocument(request, url.pathname)) {",
+    "  if ((request.method === 'GET' || request.method === 'HEAD') && __litzjsShouldServeDocument(request, pathname)) {",
     "    return new Response(request.method === 'HEAD' ? null : LITZ_DOCUMENT_HTML, {",
     "      status: 200,",
     "      headers: {",

--- a/tests/loader-fetch.test.ts
+++ b/tests/loader-fetch.test.ts
@@ -5,6 +5,8 @@ import type { LoaderHookResult } from "../src/index";
 
 const mockFetch = mock<typeof fetch>();
 const originalFetch = globalThis.fetch;
+const baseUrlTarget = globalThis as typeof globalThis & { __litzjsBaseUrl?: string };
+const originalBaseUrl = baseUrlTarget.__litzjsBaseUrl;
 
 import { processLoaderResults } from "../src/client/loader-fetch";
 
@@ -38,9 +40,58 @@ beforeEach(() => {
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  baseUrlTarget.__litzjsBaseUrl = originalBaseUrl;
 });
 
 describe("fetchRouteLoadersInParallel", () => {
+  test("uses the configured client base for internal route loader requests", async () => {
+    baseUrlTarget.__litzjsBaseUrl = "/app/";
+    mockFetch.mockResolvedValue(
+      createTransportResponse({
+        kind: "data",
+        data: "ok",
+        revalidate: [],
+      }),
+    );
+
+    const { fetchRouteLoader } = await import("../src/client/runtime");
+
+    await fetchRouteLoader("/test", {
+      params: {},
+      search: new URLSearchParams(),
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch.mock.calls[0]?.[0]).toBe("/app/_litzjs/route");
+  });
+
+  test("uses the configured client base for internal route action requests", async () => {
+    baseUrlTarget.__litzjsBaseUrl = "/app/";
+    mockFetch.mockResolvedValue(
+      createTransportResponse({
+        kind: "data",
+        data: "ok",
+        revalidate: [],
+      }),
+    );
+
+    const { fetchRouteAction } = await import("../src/client/runtime");
+    const payload = new FormData();
+    payload.append("name", "Litz");
+
+    await fetchRouteAction(
+      "/test",
+      {
+        params: {},
+        search: new URLSearchParams(),
+      },
+      payload,
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch.mock.calls[0]?.[0]).toBe("/app/_litzjs/action");
+  });
+
   test("fetches all loaders in a single batched request", async () => {
     const baseRequest = {
       params: { id: "7" },

--- a/tests/resource-runtime.test.tsx
+++ b/tests/resource-runtime.test.tsx
@@ -28,6 +28,9 @@ type Deferred<T> = {
   resolve(value: T): void;
 };
 
+const baseUrlTarget = globalThis as typeof globalThis & { __litzjsBaseUrl?: string };
+const originalBaseUrl = baseUrlTarget.__litzjsBaseUrl;
+
 type IsExact<T, U> =
   (<Value>() => Value extends T ? 1 : 2) extends <Value>() => Value extends U ? 1 : 2
     ? (<Value>() => Value extends U ? 1 : 2) extends <Value>() => Value extends T ? 1 : 2
@@ -300,6 +303,7 @@ describe("resource runtime", () => {
     }
 
     globalThis.fetch = originalFetch;
+    baseUrlTarget.__litzjsBaseUrl = originalBaseUrl;
     resetClientBindings();
     container?.remove();
     cleanupDom?.();
@@ -394,6 +398,28 @@ describe("resource runtime", () => {
       "idle",
       "idle",
     ]);
+  });
+
+  test("uses the configured client base for internal resource requests", async () => {
+    const requestUrls: string[] = [];
+    baseUrlTarget.__litzjsBaseUrl = "/app/";
+
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      requestUrls.push(
+        input instanceof URL ? input.toString() : typeof input === "string" ? input : input.url,
+      );
+      return Response.json({
+        kind: "data",
+        data: { id: "user-base", count: 1 },
+      });
+    }) as typeof fetch;
+
+    await act(async () => {
+      root?.render(<accountResource.Component params={{ id: "user-base" }} />);
+      await flushDom();
+    });
+
+    expect(requestUrls).toEqual(["/app/_litzjs/resource"]);
   });
 
   test("resource store preserves entries across unmount/remount cycles", async () => {

--- a/tests/server-not-found.test.ts
+++ b/tests/server-not-found.test.ts
@@ -188,4 +188,42 @@ describe("server not-found handling", () => {
     expect(response.headers.get("content-type")).toBe("image/svg+xml");
     expect(await response.text()).toBe("<svg />");
   });
+
+  test("matches document routes beneath the configured base path", async () => {
+    const server = createServer({
+      base: "/app/",
+      manifest: {
+        routes: [
+          {
+            id: "projects.show",
+            path: "/projects/:id",
+            route: {},
+          },
+        ],
+      },
+      document: '<!doctype html><html><body><div id="app">app</div></body></html>',
+      notFound: "<!doctype html><html><body><h1>Missing</h1></body></html>",
+    });
+
+    const matchedResponse = await server.fetch(
+      new Request("https://app.example.com/app/projects/42", {
+        headers: {
+          accept: "text/html",
+        },
+      }),
+    );
+
+    const missingResponse = await server.fetch(
+      new Request("https://app.example.com/app/missing", {
+        headers: {
+          accept: "text/html",
+        },
+      }),
+    );
+
+    expect(matchedResponse.status).toBe(200);
+    expect(await matchedResponse.text()).toContain('id="app"');
+    expect(missingResponse.status).toBe(404);
+    expect(await missingResponse.text()).toContain("<h1>Missing</h1>");
+  });
 });

--- a/tests/server-security.test.ts
+++ b/tests/server-security.test.ts
@@ -87,6 +87,67 @@ describe("server security", () => {
     expect(body.data.pathname).toBe("/projects/42");
   });
 
+  test("matches base-prefixed internal route actions", async () => {
+    const server = createServer({
+      base: "/app/",
+      manifest: {
+        routes: [
+          {
+            id: "projects.show",
+            path: "/projects/:id",
+            route: {
+              action(context: unknown) {
+                const { request } = context as { request: Request };
+
+                return {
+                  kind: "data",
+                  data: {
+                    href: request.url,
+                    pathname: new URL(request.url).pathname,
+                  },
+                };
+              },
+            },
+          },
+        ],
+      },
+    });
+    const actionRequest = createInternalActionRequestInit(
+      {
+        path: "/projects/:id",
+        operation: "action",
+        request: {
+          params: {
+            id: "42",
+          },
+        },
+      },
+      {
+        name: "Litz",
+      },
+    );
+
+    const response = await server.fetch(
+      new Request("https://app.example.com/app/_litzjs/action", {
+        method: "POST",
+        headers: actionRequest.headers,
+        body: actionRequest.body,
+      }),
+    );
+    const body = (await response.json()) as {
+      kind: "data";
+      data: {
+        href: string;
+        pathname: string;
+      };
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.kind).toBe("data");
+    expect(body.data.href).toBe("https://app.example.com/projects/42");
+    expect(body.data.pathname).toBe("/projects/42");
+  });
+
   test("reuses the original request signal for route handlers", async () => {
     const server = createServer({
       manifest: {

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -491,6 +491,227 @@ describe("dev server hot updates", () => {
       rmSync(root, { force: true, recursive: true });
     }
   });
+
+  test("prefixes client route manifest imports with the configured base", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "litz-route-manifest-base-"));
+
+    try {
+      mkdirSync(path.join(root, "src"), { recursive: true });
+      writeFileSync(path.join(root, "src", "main.tsx"), "export {};\n", "utf8");
+      mkdirSync(path.join(root, "src", "routes"), { recursive: true });
+      writeFileSync(
+        path.join(root, "src", "routes", "index.tsx"),
+        'import { defineRoute } from "litzjs";\n\nexport const route = defineRoute("/", {\n  component() {\n    return null;\n  },\n});\n',
+        "utf8",
+      );
+
+      const plugin = litz().find((candidate) => candidate.name === "litzjs/vite");
+
+      if (!plugin?.configResolved || !plugin.resolveId || !plugin.load) {
+        throw new Error("Expected litzjs/vite route-manifest hooks to be available.");
+      }
+
+      const configResolved =
+        typeof plugin.configResolved === "function"
+          ? plugin.configResolved
+          : plugin.configResolved.handler;
+      const resolveId =
+        typeof plugin.resolveId === "function" ? plugin.resolveId : plugin.resolveId.handler;
+      const load = typeof plugin.load === "function" ? plugin.load : plugin.load.handler;
+      const pluginContext = {} as never;
+
+      await configResolved.call(pluginContext, {
+        root,
+        base: "/app/",
+        command: "serve",
+        build: {
+          outDir: "dist",
+        },
+        environments: {
+          client: {
+            build: {
+              outDir: path.join("dist", "client"),
+            },
+          },
+          rsc: {
+            build: {
+              outDir: path.join("dist", "server"),
+              rollupOptions: {
+                output: {
+                  codeSplitting: false,
+                },
+              },
+            },
+          },
+        },
+      } as never);
+
+      const resolvedId = resolveId.call(
+        pluginContext,
+        "virtual:litzjs:route-manifest",
+        undefined,
+        {} as never,
+      );
+      const manifestSource = load.call(
+        {
+          environment: {
+            name: "client",
+          },
+        } as never,
+        resolvedId as string,
+        {} as never,
+      ) as string;
+
+      expect(manifestSource).toContain('import("/app/@fs/');
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("prefixes the generated browser entry import with the configured base", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "litz-browser-entry-base-"));
+
+    try {
+      mkdirSync(path.join(root, "src"), { recursive: true });
+      writeFileSync(path.join(root, "src", "main.tsx"), "export {};\n", "utf8");
+
+      const plugin = litz().find((candidate) => candidate.name === "litzjs/vite");
+
+      if (!plugin?.configResolved || !plugin.resolveId || !plugin.load) {
+        throw new Error("Expected litzjs/vite browser-entry hooks to be available.");
+      }
+
+      const configResolved =
+        typeof plugin.configResolved === "function"
+          ? plugin.configResolved
+          : plugin.configResolved.handler;
+      const resolveId =
+        typeof plugin.resolveId === "function" ? plugin.resolveId : plugin.resolveId.handler;
+      const load = typeof plugin.load === "function" ? plugin.load : plugin.load.handler;
+      const pluginContext = {} as never;
+
+      await configResolved.call(pluginContext, {
+        root,
+        base: "/app/",
+        command: "serve",
+        build: {
+          outDir: "dist",
+        },
+        environments: {
+          client: {
+            build: {
+              outDir: path.join("dist", "client"),
+            },
+          },
+          rsc: {
+            build: {
+              outDir: path.join("dist", "server"),
+              rollupOptions: {
+                output: {
+                  codeSplitting: false,
+                },
+              },
+            },
+          },
+        },
+      } as never);
+
+      const resolvedId = resolveId.call(
+        pluginContext,
+        "virtual:litzjs:browser-entry",
+        undefined,
+        {} as never,
+      );
+      const browserEntrySource = load.call(
+        {
+          environment: {
+            name: "client",
+          },
+        } as never,
+        resolvedId as string,
+        {} as never,
+      ) as string;
+
+      expect(browserEntrySource).toContain('import "/app/@fs/');
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("injects the configured base into transformed server entries", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "litz-server-entry-base-"));
+
+    try {
+      mkdirSync(path.join(root, "src"), { recursive: true });
+      writeFileSync(path.join(root, "src", "main.tsx"), "export {};\n", "utf8");
+      writeFileSync(
+        path.join(root, "src", "server.ts"),
+        'import { createServer } from "litzjs/server";\n\nexport default createServer();\n',
+        "utf8",
+      );
+
+      const plugin = litz().find((candidate) => candidate.name === "litzjs/vite");
+
+      if (!plugin?.configResolved || !plugin.transform) {
+        throw new Error("Expected litzjs/vite transform hooks to be available.");
+      }
+
+      const configResolved =
+        typeof plugin.configResolved === "function"
+          ? plugin.configResolved
+          : plugin.configResolved.handler;
+      const transform =
+        typeof plugin.transform === "function" ? plugin.transform : plugin.transform.handler;
+      const pluginContext = {
+        environment: {
+          name: "rsc",
+        },
+      } as never;
+
+      await configResolved.call(
+        {} as never,
+        {
+          root,
+          base: "/app/",
+          command: "serve",
+          build: {
+            outDir: "dist",
+          },
+          environments: {
+            client: {
+              build: {
+                outDir: path.join("dist", "client"),
+              },
+            },
+            rsc: {
+              build: {
+                outDir: path.join("dist", "server"),
+                rollupOptions: {
+                  output: {
+                    codeSplitting: false,
+                  },
+                },
+              },
+            },
+          },
+        } as never,
+      );
+
+      const result = await transform.call(
+        pluginContext,
+        'import { createServer } from "litzjs/server";\n\nexport default createServer();\n',
+        path.join(root, "src", "server.ts"),
+      );
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          code: expect.stringContaining('base: "/app"'),
+        }),
+      );
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
 });
 
 function createMockViteDevServer(
@@ -573,6 +794,128 @@ function createMockResponse(): ServerResponse & { getBody(): string } {
 }
 
 describe("dev server abort signal lifecycle", () => {
+  test("matches base-prefixed internal resource requests", async () => {
+    let capturedHref = "";
+    const server = createMockViteDevServer(async () => ({
+      resource: {
+        async loader({ request }: { request: Request }) {
+          capturedHref = request.url;
+          return {
+            kind: "data",
+            data: { ok: true },
+          };
+        },
+      },
+    }));
+    const request = createMockRequest({
+      url: "/app/_litzjs/resource",
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        path: "/resources/config",
+        operation: "loader",
+        request: {},
+      }),
+    });
+    const response = createMockResponse();
+    const next = mock(() => {});
+
+    await handleLitzResourceRequest(
+      server,
+      [
+        {
+          path: "/resources/config",
+          modulePath: "src/resources/config.ts",
+          hasLoader: true,
+          hasAction: false,
+          hasComponent: false,
+        },
+      ],
+      request,
+      response,
+      next,
+      "/app/",
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(capturedHref).toBe("http://localhost:5173/resources/config");
+  });
+
+  test("matches base-prefixed internal route requests", async () => {
+    let capturedHref = "";
+    const server = createMockViteDevServer(async () => ({
+      route: {
+        async loader({ request }: { request: Request }) {
+          capturedHref = request.url;
+          return {
+            kind: "data",
+            data: { ok: true },
+          };
+        },
+      },
+    }));
+    const request = createMockRequest({
+      url: "/app/_litzjs/route",
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        path: "/projects/:id",
+        target: "projects.show",
+        operation: "loader",
+        request: {
+          params: { id: "42" },
+        },
+      }),
+    });
+    const response = createMockResponse();
+    const next = mock(() => {});
+
+    await handleLitzRouteRequest(
+      server,
+      [{ id: "projects.show", path: "/projects/:id", modulePath: "src/routes/projects.ts" }],
+      request,
+      response,
+      next,
+      "/app/",
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(capturedHref).toBe("http://localhost:5173/projects/42");
+  });
+
+  test("matches base-prefixed API requests", async () => {
+    let capturedHref = "";
+    const server = createMockViteDevServer(async () => ({
+      api: {
+        methods: {
+          GET({ request }: { request: Request }) {
+            capturedHref = request.url;
+            return new Response("ok");
+          },
+        },
+      },
+    }));
+    const request = createMockRequest({
+      url: "/app/api/test",
+      method: "GET",
+    });
+    const response = createMockResponse();
+    const next = mock(() => {});
+
+    await handleLitzApiRequest(
+      server,
+      [{ path: "/api/test", modulePath: "src/api/test.ts" }],
+      request,
+      response,
+      next,
+      "/app/",
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(response.getBody()).toBe("ok");
+    expect(capturedHref).toBe("http://litzjs.local/app/api/test");
+  });
+
   test("rebuilds repeated query params for internal resource requests", async () => {
     let capturedTags: string[] = [];
     let capturedHref = "";

--- a/www/src/routes/docs/api-reference.tsx
+++ b/www/src/routes/docs/api-reference.tsx
@@ -968,6 +968,7 @@ const serverGroups: readonly ReferenceGroupSpec[] = [
   createContext?(request: Request): Promise<TContext> | TContext;
   onError?(error: unknown, context: TContext | undefined): void;
   manifest?: ServerManifest;
+  base?: string;
   document?: Response | string | ((request: Request) => Promise<Response | string | null | undefined> | Response | string | null | undefined);
   notFound?: Response | string | ((request: Request) => Promise<Response | string | null | undefined> | Response | string | null | undefined);
   assets?: (request: Request) => Promise<Response | null | undefined> | Response | null | undefined;


### PR DESCRIPTION
## Summary
This PR fixes issue #89 by honoring Vite's configured `base` for internal Litz client transport URLs, generated browser import specifiers, and base-aware request matching in both the Vite dev middleware and the server runtime.

## What Changed
- Added shared base-path normalization helpers used across the client runtime, Vite plugin, and server runtime.
- Updated client route/resource transport requests to resolve against the configured base instead of hardcoding root-relative `/_litzjs/...` URLs.
- Updated generated browser import specifiers in the Vite plugin so lazy route imports and the browser entry stay under the configured base.
- Threaded the configured base through Vite dev middleware and `createServer(...)` so internal transport endpoints, API matching, and document routing work when the app is mounted beneath a subpath.
- Updated the inline asset server wrapper to strip the configured base before asset/document checks.
- Added regression tests covering client transport URLs, Vite-generated browser imports, dev middleware routing, and server runtime routing under a non-root base.
- Added a patch changeset.

## Why
The current Vite integration assumed the app lived at `/`:
- client transport always posted to root-relative `/_litzjs/route`, `/_litzjs/action`, and `/_litzjs/resource`
- generated browser imports were emitted as absolute `/...` paths
- dev and server request handling matched internal/API/document routes against unprefixed pathnames

With `base` set to a subpath, those assumptions break normal Vite behavior and can cause loader/action/resource requests, lazy route imports, and document routing to fail.

## User Impact
Apps mounted under a Vite `base` subpath now behave the same way as standard Vite apps:
- internal Litz transport requests stay under the configured base
- generated browser imports resolve beneath the configured base
- dev and server routing continue to recognize Litz internal endpoints, API routes, and document requests correctly

## Validation
- `bun fmt`
- `bun lint:fix`
- `bun typecheck`
- `bun test`

Closes #89
