### PR TITLE
[codex] Fix HMR runtime context singletons

### DIFF
--- a/.changeset/funny-drinks-fix.md
+++ b/.changeset/funny-drinks-fix.md
@@ -1,0 +1,5 @@
+---
+"litzjs": patch
+---
+
+Keep route and resource runtime React contexts on `globalThis` so HMR-updated modules continue sharing the mounted runtime providers.

--- a/src/client/resources.tsx
+++ b/src/client/resources.tsx
@@ -97,10 +97,12 @@ const resourceStore = new Map<string, ResourceStoreEntry>();
 const resourceFormComponentCache = new Map<string, React.ComponentType<RouteFormProps>>();
 const resourceComponentCache = new Map<string, React.ComponentType<any>>();
 
-let resourceLocationContext: React.Context<ResourceLocationState | null> | null = null;
-let resourceStatusContext: React.Context<ResourceStatusState | null> | null = null;
-let resourceDataContext: React.Context<ResourceDataState | null> | null = null;
-let resourceActionsContext: React.Context<ResourceActionsState | null> | null = null;
+declare global {
+  var __litzjsResourceLocationContext: React.Context<ResourceLocationState | null> | undefined;
+  var __litzjsResourceStatusContext: React.Context<ResourceStatusState | null> | undefined;
+  var __litzjsResourceDataContext: React.Context<ResourceDataState | null> | undefined;
+  var __litzjsResourceActionsContext: React.Context<ResourceActionsState | null> | undefined;
+}
 
 function createRuntimeContext<T>(name: string): React.Context<T | null> {
   const createContext = (
@@ -117,23 +119,39 @@ function createRuntimeContext<T>(name: string): React.Context<T | null> {
 }
 
 function getResourceLocationContext(): React.Context<ResourceLocationState | null> {
-  resourceLocationContext ??= createRuntimeContext<ResourceLocationState>("Litz resource location");
-  return resourceLocationContext;
+  if (!globalThis.__litzjsResourceLocationContext) {
+    globalThis.__litzjsResourceLocationContext =
+      createRuntimeContext<ResourceLocationState>("Litz resource location");
+  }
+
+  return globalThis.__litzjsResourceLocationContext;
 }
 
 function getResourceStatusContext(): React.Context<ResourceStatusState | null> {
-  resourceStatusContext ??= createRuntimeContext<ResourceStatusState>("Litz resource status");
-  return resourceStatusContext;
+  if (!globalThis.__litzjsResourceStatusContext) {
+    globalThis.__litzjsResourceStatusContext =
+      createRuntimeContext<ResourceStatusState>("Litz resource status");
+  }
+
+  return globalThis.__litzjsResourceStatusContext;
 }
 
 function getResourceDataContext(): React.Context<ResourceDataState | null> {
-  resourceDataContext ??= createRuntimeContext<ResourceDataState>("Litz resource data");
-  return resourceDataContext;
+  if (!globalThis.__litzjsResourceDataContext) {
+    globalThis.__litzjsResourceDataContext =
+      createRuntimeContext<ResourceDataState>("Litz resource data");
+  }
+
+  return globalThis.__litzjsResourceDataContext;
 }
 
 function getResourceActionsContext(): React.Context<ResourceActionsState | null> {
-  resourceActionsContext ??= createRuntimeContext<ResourceActionsState>("Litz resource actions");
-  return resourceActionsContext;
+  if (!globalThis.__litzjsResourceActionsContext) {
+    globalThis.__litzjsResourceActionsContext =
+      createRuntimeContext<ResourceActionsState>("Litz resource actions");
+  }
+
+  return globalThis.__litzjsResourceActionsContext;
 }
 
 function requireActiveResourceSlice<T extends { id: string }>(

--- a/src/client/route-runtime.tsx
+++ b/src/client/route-runtime.tsx
@@ -48,10 +48,13 @@ export type RouteRuntimeState = RouteLocationState &
   RouteDataState &
   RouteActionsState;
 
-let routeLocationContext: React.Context<RouteLocationState | null> | null = null;
-let routeStatusContext: React.Context<RouteStatusState | null> | null = null;
-let routeDataContext: React.Context<RouteDataState | null> | null = null;
-let routeActionsContext: React.Context<RouteActionsState | null> | null = null;
+declare global {
+  var __litzjsRouteLocationContext: React.Context<RouteLocationState | null> | undefined;
+  var __litzjsRouteStatusContext: React.Context<RouteStatusState | null> | undefined;
+  var __litzjsRouteDataContext: React.Context<RouteDataState | null> | undefined;
+  var __litzjsRouteActionsContext: React.Context<RouteActionsState | null> | undefined;
+}
+
 const routeFormComponentCache = new Map<string, React.ComponentType<RouteFormProps>>();
 
 function createRuntimeContext<T>(name: string): React.Context<T | null> {
@@ -69,23 +72,38 @@ function createRuntimeContext<T>(name: string): React.Context<T | null> {
 }
 
 function getRouteLocationContext(): React.Context<RouteLocationState | null> {
-  routeLocationContext ??= createRuntimeContext<RouteLocationState>("Litz route location");
-  return routeLocationContext;
+  if (!globalThis.__litzjsRouteLocationContext) {
+    globalThis.__litzjsRouteLocationContext =
+      createRuntimeContext<RouteLocationState>("Litz route location");
+  }
+
+  return globalThis.__litzjsRouteLocationContext;
 }
 
 function getRouteStatusContext(): React.Context<RouteStatusState | null> {
-  routeStatusContext ??= createRuntimeContext<RouteStatusState>("Litz route status");
-  return routeStatusContext;
+  if (!globalThis.__litzjsRouteStatusContext) {
+    globalThis.__litzjsRouteStatusContext =
+      createRuntimeContext<RouteStatusState>("Litz route status");
+  }
+
+  return globalThis.__litzjsRouteStatusContext;
 }
 
 function getRouteDataContext(): React.Context<RouteDataState | null> {
-  routeDataContext ??= createRuntimeContext<RouteDataState>("Litz route data");
-  return routeDataContext;
+  if (!globalThis.__litzjsRouteDataContext) {
+    globalThis.__litzjsRouteDataContext = createRuntimeContext<RouteDataState>("Litz route data");
+  }
+
+  return globalThis.__litzjsRouteDataContext;
 }
 
 function getRouteActionsContext(): React.Context<RouteActionsState | null> {
-  routeActionsContext ??= createRuntimeContext<RouteActionsState>("Litz route actions");
-  return routeActionsContext;
+  if (!globalThis.__litzjsRouteActionsContext) {
+    globalThis.__litzjsRouteActionsContext =
+      createRuntimeContext<RouteActionsState>("Litz route actions");
+  }
+
+  return globalThis.__litzjsRouteActionsContext;
 }
 
 function requireActiveRouteSlice<T extends { id: string }>(routeId: string, value: T | null): T {

--- a/tests/runtime-context-singletons.test.tsx
+++ b/tests/runtime-context-singletons.test.tsx
@@ -88,6 +88,8 @@ describe("runtime context singletons", () => {
       );
       const observedRouteId: { current: string | null } = { current: null };
 
+      expect(routeRuntimeA.RouteRuntimeProvider).not.toBe(routeRuntimeB.RouteRuntimeProvider);
+
       function Reader(): React.ReactElement {
         observedRouteId.current = routeRuntimeB.useRequiredRouteLocation("/projects/:id").id;
         return <div data-route-id={observedRouteId.current} />;
@@ -104,6 +106,8 @@ describe("runtime context singletons", () => {
 
       expect(observedRouteId.current).toEqual("/projects/:id");
       expect(globalThis.__litzjsRouteLocationContext).toBeDefined();
+      expect(globalThis.__litzjsRouteStatusContext).toBeDefined();
+      expect(globalThis.__litzjsRouteDataContext).toBeDefined();
       expect(globalThis.__litzjsRouteActionsContext).toBeDefined();
     } finally {
       await act(async () => {
@@ -127,6 +131,10 @@ describe("runtime context singletons", () => {
         await importFresh<typeof import("../src/client/resources")>("../src/client/resources");
       const observedResourceId: { current: string | null } = { current: null };
 
+      expect(resourceRuntimeA.ResourceRuntimeProvider).not.toBe(
+        resourceRuntimeB.ResourceRuntimeProvider,
+      );
+
       function Reader(): React.ReactElement {
         observedResourceId.current =
           resourceRuntimeB.useRequiredResourceLocation("/resources/projects/:id").id;
@@ -144,6 +152,8 @@ describe("runtime context singletons", () => {
 
       expect(observedResourceId.current).toEqual("/resources/projects/:id");
       expect(globalThis.__litzjsResourceLocationContext).toBeDefined();
+      expect(globalThis.__litzjsResourceStatusContext).toBeDefined();
+      expect(globalThis.__litzjsResourceDataContext).toBeDefined();
       expect(globalThis.__litzjsResourceActionsContext).toBeDefined();
     } finally {
       await act(async () => {

--- a/tests/runtime-context-singletons.test.tsx
+++ b/tests/runtime-context-singletons.test.tsx
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as React from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+
+import type { ResourceRuntimeState } from "../src/client/resources";
+import type { RouteRuntimeState } from "../src/client/route-runtime";
+
+import { flushDom, installTestDom } from "./test-dom";
+
+const routeRuntimeGlobalKeys = [
+  "__litzjsRouteLocationContext",
+  "__litzjsRouteStatusContext",
+  "__litzjsRouteDataContext",
+  "__litzjsRouteActionsContext",
+] as const;
+
+const resourceRuntimeGlobalKeys = [
+  "__litzjsResourceLocationContext",
+  "__litzjsResourceStatusContext",
+  "__litzjsResourceDataContext",
+  "__litzjsResourceActionsContext",
+] as const;
+
+async function importFresh<TModule>(path: string): Promise<TModule> {
+  return (await import(`${path}?fresh=${Math.random().toString(36).slice(2)}`)) as TModule;
+}
+
+function createRouteRuntimeState(): RouteRuntimeState {
+  return {
+    id: "/projects/:id",
+    params: {
+      id: "123",
+    },
+    search: new URLSearchParams("tab=overview"),
+    setSearch() {},
+    status: "idle",
+    pending: false,
+    loaderResult: null,
+    actionResult: null,
+    data: null,
+    view: null,
+    error: null,
+    async submit() {},
+    reload() {},
+  };
+}
+
+function createResourceRuntimeState(): ResourceRuntimeState {
+  return {
+    id: "/resources/projects/:id",
+    params: {
+      id: "123",
+    },
+    search: new URLSearchParams("tab=overview"),
+    setSearch() {},
+    status: "idle",
+    pending: false,
+    loaderResult: null,
+    actionResult: null,
+    data: null,
+    view: null,
+    error: null,
+    async submit() {},
+    reload() {},
+  };
+}
+
+describe("runtime context singletons", () => {
+  afterEach(() => {
+    for (const key of [...routeRuntimeGlobalKeys, ...resourceRuntimeGlobalKeys]) {
+      delete globalThis[key];
+    }
+  });
+
+  test("route runtime contexts survive hot re-imports", async () => {
+    const dom = installTestDom();
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    try {
+      const routeRuntimeA = await importFresh<typeof import("../src/client/route-runtime")>(
+        "../src/client/route-runtime",
+      );
+      const routeRuntimeB = await importFresh<typeof import("../src/client/route-runtime")>(
+        "../src/client/route-runtime",
+      );
+      const observedRouteId: { current: string | null } = { current: null };
+
+      function Reader(): React.ReactElement {
+        observedRouteId.current = routeRuntimeB.useRequiredRouteLocation("/projects/:id").id;
+        return <div data-route-id={observedRouteId.current} />;
+      }
+
+      await act(async () => {
+        root.render(
+          <routeRuntimeA.RouteRuntimeProvider value={createRouteRuntimeState()}>
+            <Reader />
+          </routeRuntimeA.RouteRuntimeProvider>,
+        );
+        await flushDom();
+      });
+
+      expect(observedRouteId.current).toEqual("/projects/:id");
+      expect(globalThis.__litzjsRouteLocationContext).toBeDefined();
+      expect(globalThis.__litzjsRouteActionsContext).toBeDefined();
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      dom.cleanup();
+    }
+  });
+
+  test("resource runtime contexts survive hot re-imports", async () => {
+    const dom = installTestDom();
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    try {
+      const resourceRuntimeA =
+        await importFresh<typeof import("../src/client/resources")>("../src/client/resources");
+      const resourceRuntimeB =
+        await importFresh<typeof import("../src/client/resources")>("../src/client/resources");
+      const observedResourceId: { current: string | null } = { current: null };
+
+      function Reader(): React.ReactElement {
+        observedResourceId.current =
+          resourceRuntimeB.useRequiredResourceLocation("/resources/projects/:id").id;
+        return <div data-resource-id={observedResourceId.current} />;
+      }
+
+      await act(async () => {
+        root.render(
+          <resourceRuntimeA.ResourceRuntimeProvider value={createResourceRuntimeState()}>
+            <Reader />
+          </resourceRuntimeA.ResourceRuntimeProvider>,
+        );
+        await flushDom();
+      });
+
+      expect(observedResourceId.current).toEqual("/resources/projects/:id");
+      expect(globalThis.__litzjsResourceLocationContext).toBeDefined();
+      expect(globalThis.__litzjsResourceActionsContext).toBeDefined();
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      dom.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- move route runtime React contexts onto `globalThis` so hot-reloaded route modules reuse the mounted provider identities
- move resource runtime React contexts onto `globalThis` for the same HMR-safe singleton behavior
- add regression coverage that renders providers from one module instance with hooks from a fresh re-import, plus a patch changeset

## Why
Issue #90 reports that route and resource runtime contexts still lived in module-local state after the earlier client-context HMR fix. When Vite replaced a client module, hooks imported from the updated module could observe a different context instance than the provider mounted by the previous module graph, leading to runtime errors and broken route/resource-scoped hooks.

## Root Cause
`src/client/route-runtime.tsx` and `src/client/resources.tsx` cached their context singletons in file-local variables. HMR creates fresh module instances, so those caches were recreated and no longer matched the provider identities from the mounted runtime tree.

## User Impact
Route and resource hooks now keep working across hot updates instead of splitting provider and consumer context identities.

## Validation
- `bun run fmt`
- `bun run lint:fix`
- `bun run test`
- `bun run typecheck`

Closes #90
