### PR TITLE
feat(vite): support standard Vite HTML entry patterns (MPA, inline scripts)

### DIFF
--- a/.changeset/fuzzy-lemons-warn.md
+++ b/.changeset/fuzzy-lemons-warn.md
@@ -1,0 +1,7 @@
+---
+"litzjs": patch
+---
+
+Tighten Vite HTML entry discovery so unsupported configurations fail fast instead of producing partial client builds.
+
+The Vite integration now allows multiple HTML entry files only when they all share the same external module script, which matches the current single-client-entry runtime model. Projects that use inline module scripts or different external entry modules per HTML file now receive a clear configuration error during startup instead of silently building an incomplete client bundle.

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -137,6 +137,17 @@ type DiscoveredApiRoute = {
   modulePath: string;
 };
 
+type HtmlEntryInfo = {
+  /** The path to the HTML file relative to root */
+  htmlPath: string;
+  /** The module entry type */
+  type: "external" | "inline";
+  /** For external: the module path; for inline: the temp file path */
+  modulePath: string;
+  /** The original inline script content (if inline) */
+  inlineContent?: string;
+};
+
 // Virtual module IDs. Each pair has a bare ID (used in import statements) and a
 // resolved ID prefixed with `\0` — the Vite convention that marks a module as
 // virtual so it is never resolved from disk.
@@ -163,6 +174,7 @@ export function litz(options: LitzPluginOptions = {}): PluginOption {
   let root = process.cwd();
   let configuredBase = "/";
   let browserEntryPath = "src/main.tsx";
+  let htmlEntries: HtmlEntryInfo[] = [];
   let serverEntryPath: string | null = null;
   let serverEntryFilePath: string | null = null;
   let intermediateBuildOutDir = path.resolve(root, "dist");
@@ -218,9 +230,16 @@ export function litz(options: LitzPluginOptions = {}): PluginOption {
       intermediateBuildOutDir = path.resolve(root, config.build.outDir || "dist");
       finalNitroOutDir = path.resolve(root, ".output");
 
-      browserEntryPath = await discoverBrowserEntry(root);
+      htmlEntries = await discoverHtmlEntries(root);
+      browserEntryPath = htmlEntries[0]?.modulePath ?? "src/main.tsx";
       serverEntryPath = await discoverServerEntry(root, options.server);
       serverEntryFilePath = serverEntryPath ? path.resolve(root, serverEntryPath) : null;
+
+      // Validate HTML entries and warn about unsupported patterns
+      const htmlErrors = validateHtmlEntries(htmlEntries);
+      for (const error of htmlErrors) {
+        console.warn(`[litzjs] ${error}`);
+      }
 
       // Re-write with the actual server entry path now that it has been
       // discovered.
@@ -608,7 +627,7 @@ export async function renderView(node, metadata = {}) {
         void handleLitzApiRequest(server, apiManifest, request, response, next, configuredBase);
       });
       server.middlewares.use((request, response, next) => {
-        void handleLitzDocumentRequest(server, request, response, next, configuredBase);
+        void handleLitzDocumentRequest(server, htmlEntries, request, response, next, configuredBase);
       });
     },
 
@@ -760,24 +779,86 @@ export async function discoverAllManifests(
   };
 }
 
-async function discoverBrowserEntry(root: string): Promise<string> {
-  const indexHtmlPath = path.join(root, "index.html");
+/**
+ * Discovers all HTML entry files in the project root.
+ * Supports Vite's standard HTML entry patterns including:
+ * - Root index.html with external module script
+ * - Multiple HTML files for MPA setups
+ * - Inline module scripts
+ */
+export async function discoverHtmlEntries(root: string): Promise<HtmlEntryInfo[]> {
+  const entries: HtmlEntryInfo[] = [];
+  const htmlFiles = await glob(["*.html", "**/*.html"], {
+    cwd: root,
+    absolute: true,
+    ignore: ["node_modules/**", "dist/**", ".output/**"],
+  });
 
-  try {
-    const html = await readFile(indexHtmlPath, "utf8");
-    const scriptMatch = html.match(
-      /<script[^>]+type=["']module["'][^>]+src=["']([^"']+)["'][^>]*><\/script>/i,
-    );
-    const scriptSrc = scriptMatch?.[1];
+  for (const htmlFile of htmlFiles) {
+    try {
+      const html = await readFile(htmlFile, "utf8");
+      const relativePath = normalizeRelativePath(root, htmlFile);
 
-    if (!scriptSrc) {
-      return "src/main.tsx";
+      const externalMatch = html.match(
+        /<script[^>]+type=["']module["'][^>]+src=["']([^"']+)["'][^>]*><\/script>/i,
+      );
+
+      if (externalMatch?.[1]) {
+        const scriptSrc = externalMatch[1];
+        const modulePath = scriptSrc.startsWith("/") ? scriptSrc.slice(1) : scriptSrc;
+        entries.push({
+          htmlPath: relativePath,
+          type: "external",
+          modulePath,
+        });
+        continue;
+      }
+
+      const inlineMatch = html.match(
+        /<script[^>]+type=["']module["'][^>]*>([\s\S]*?)<\/script>/i,
+      );
+
+      if (inlineMatch?.[1]?.trim()) {
+        entries.push({
+          htmlPath: relativePath,
+          type: "inline",
+          modulePath: `virtual:litzjs:inline-entry:${relativePath}`,
+          inlineContent: inlineMatch[1].trim(),
+        });
+      }
+    } catch {
+      // Skip files that can't be read
     }
-
-    return scriptSrc.startsWith("/") ? scriptSrc.slice(1) : scriptSrc;
-  } catch {
-    return "src/main.tsx";
   }
+
+  if (entries.length === 0) {
+    entries.push({
+      htmlPath: "index.html",
+      type: "external",
+      modulePath: "src/main.tsx",
+    });
+  }
+
+  return entries;
+}
+
+/**
+ * Validates that the discovered HTML entries are supported.
+ * Returns an array of validation errors (empty if valid).
+ */
+export function validateHtmlEntries(entries: HtmlEntryInfo[]): string[] {
+  const errors: string[] = [];
+
+  for (const entry of entries) {
+    if (entry.type === "inline") {
+      errors.push(
+        `Inline module scripts in ${entry.htmlPath} are not fully supported. ` +
+          `Consider using an external script: <script type="module" src="your-entry.tsx"></script>`,
+      );
+    }
+  }
+
+  return errors;
 }
 
 export async function discoverServerEntry(
@@ -1935,6 +2016,7 @@ export async function handleLitzRouteRequest(
 
 async function handleLitzDocumentRequest(
   server: ViteDevServer,
+  htmlEntries: HtmlEntryInfo[],
   request: IncomingMessage,
   response: ServerResponse,
   next: Connect.NextFunction,
@@ -1976,8 +2058,23 @@ async function handleLitzDocumentRequest(
   }
 
   try {
-    const templatePath = path.join(server.config.root, "index.html");
-    const template = await readFile(templatePath, "utf8");
+    const htmlEntry = findHtmlEntryForPath(pathname, htmlEntries);
+
+    if (!htmlEntry) {
+      next();
+      return;
+    }
+
+    const templatePath = path.join(server.config.root, htmlEntry.htmlPath);
+    let template = await readFile(templatePath, "utf8");
+
+    if (htmlEntry.type === "inline" && htmlEntry.inlineContent) {
+      template = template.replace(
+        /<script[^>]+type=["']module["'][^>]*>[\s\S]*?<\/script>/i,
+        `<script type="module">${htmlEntry.inlineContent}</script>`,
+      );
+    }
+
     const html = await server.transformIndexHtml(url, template);
     response.statusCode = 200;
     response.setHeader("content-type", "text/html; charset=utf-8");
@@ -1986,6 +2083,43 @@ async function handleLitzDocumentRequest(
     server.ssrFixStacktrace(error as Error);
     next(error as Error);
   }
+}
+
+/**
+ * Finds the appropriate HTML entry for a given request path.
+ * Supports Vite's standard MPA patterns:
+ * - / -> index.html
+ * - /about -> about.html
+ * - /nested/path -> nested/path.html or nested/path/index.html
+ */
+function findHtmlEntryForPath(
+  pathname: string,
+  entries: HtmlEntryInfo[],
+): HtmlEntryInfo | null {
+  if (entries.length === 0) {
+    return null;
+  }
+
+  if (entries.length === 1) {
+    return entries[0] ?? null;
+  }
+
+  for (const entry of entries) {
+    const htmlPath = entry.htmlPath;
+    const normalizedPath = htmlPath.replace(/\.html$/, "").replace(/\/index$/, "");
+
+    if (normalizedPath === "index" && pathname === "/") {
+      return entry;
+    }
+
+    const entryPath = normalizedPath === "index" ? "/" : `/${normalizedPath}`;
+    if (pathname === entryPath || pathname.startsWith(`${entryPath}/`)) {
+      return entry;
+    }
+  }
+
+  const indexEntry = entries.find((e) => e.htmlPath === "index.html");
+  return indexEntry ?? entries[0] ?? null;
 }
 
 export async function handleLitzApiRequest(

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -231,7 +231,10 @@ export function litz(options: LitzPluginOptions = {}): PluginOption {
       finalNitroOutDir = path.resolve(root, ".output");
 
       htmlEntries = await discoverHtmlEntries(root);
-      browserEntryPath = htmlEntries[0]?.modulePath ?? "src/main.tsx";
+      // Use the first external entry for browserEntryPath (virtual IDs for inline
+      // scripts are not resolvable by the module system)
+      const externalEntry = htmlEntries.find((e) => e.type === "external");
+      browserEntryPath = externalEntry?.modulePath ?? "src/main.tsx";
       serverEntryPath = await discoverServerEntry(root, options.server);
       serverEntryFilePath = serverEntryPath ? path.resolve(root, serverEntryPath) : null;
 
@@ -788,7 +791,7 @@ export async function discoverAllManifests(
  */
 export async function discoverHtmlEntries(root: string): Promise<HtmlEntryInfo[]> {
   const entries: HtmlEntryInfo[] = [];
-  const htmlFiles = await glob(["*.html", "**/*.html"], {
+  const htmlFiles = await glob("**/*.html", {
     cwd: root,
     absolute: true,
     ignore: ["node_modules/**", "dist/**", ".output/**"],
@@ -844,21 +847,21 @@ export async function discoverHtmlEntries(root: string): Promise<HtmlEntryInfo[]
 
 /**
  * Validates that the discovered HTML entries are supported.
- * Returns an array of validation errors (empty if valid).
+ * Returns an array of validation warnings (empty if all entries are valid).
  */
 export function validateHtmlEntries(entries: HtmlEntryInfo[]): string[] {
-  const errors: string[] = [];
+  const warnings: string[] = [];
 
   for (const entry of entries) {
     if (entry.type === "inline") {
-      errors.push(
+      warnings.push(
         `Inline module scripts in ${entry.htmlPath} are not fully supported. ` +
           `Consider using an external script: <script type="module" src="your-entry.tsx"></script>`,
       );
     }
   }
 
-  return errors;
+  return warnings;
 }
 
 export async function discoverServerEntry(
@@ -2091,6 +2094,9 @@ async function handleLitzDocumentRequest(
  * - / -> index.html
  * - /about -> about.html
  * - /nested/path -> nested/path.html or nested/path/index.html
+ *
+ * Entries are sorted by specificity (more specific paths first) to ensure
+ * that /about/team matches /about/team.html before /about.html.
  */
 function findHtmlEntryForPath(
   pathname: string,
@@ -2104,7 +2110,14 @@ function findHtmlEntryForPath(
     return entries[0] ?? null;
   }
 
-  for (const entry of entries) {
+  // Sort by specificity: more path segments = more specific
+  const sortedEntries = [...entries].sort((a, b) => {
+    const aSegments = a.htmlPath.replace(/\.html$/, "").split("/").length;
+    const bSegments = b.htmlPath.replace(/\.html$/, "").split("/").length;
+    return bSegments - aSegments;
+  });
+
+  for (const entry of sortedEntries) {
     const htmlPath = entry.htmlPath;
     const normalizedPath = htmlPath.replace(/\.html$/, "").replace(/\/index$/, "");
 

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -802,9 +802,10 @@ export async function discoverHtmlEntries(
       const html = await readFile(htmlFile, "utf8");
       const relativePath = normalizeRelativePath(root, htmlFile);
 
-      const externalMatch = html.match(
-        /<script[^>]+type=["']module["'][^>]+src=["']([^"']+)["'][^>]*><\/script>/i,
+      const moduleScriptTag = html.match(
+        /<script\b(?=[^>]*\btype=["']module["'])[^>]*><\/script>/i,
       );
+      const externalMatch = moduleScriptTag?.[0].match(/\bsrc=["']([^"']+)["']/i);
 
       if (externalMatch?.[1]) {
         const scriptSrc = externalMatch[1];

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -142,10 +142,8 @@ type HtmlEntryInfo = {
   htmlPath: string;
   /** The module entry type */
   type: "external" | "inline";
-  /** For external: the module path; for inline: the temp file path */
+  /** For external: the module path; for inline: a placeholder virtual id */
   modulePath: string;
-  /** The original inline script content (if inline) */
-  inlineContent?: string;
 };
 
 // Virtual module IDs. Each pair has a bare ID (used in import statements) and a
@@ -230,19 +228,10 @@ export function litz(options: LitzPluginOptions = {}): PluginOption {
       intermediateBuildOutDir = path.resolve(root, config.build.outDir || "dist");
       finalNitroOutDir = path.resolve(root, ".output");
 
-      htmlEntries = await discoverHtmlEntries(root);
-      // Use the first external entry for browserEntryPath (virtual IDs for inline
-      // scripts are not resolvable by the module system)
-      const externalEntry = htmlEntries.find((e) => e.type === "external");
-      browserEntryPath = externalEntry?.modulePath ?? "src/main.tsx";
+      htmlEntries = await discoverHtmlEntries(root, config.build.outDir || "dist");
+      browserEntryPath = resolveBrowserEntryPath(htmlEntries);
       serverEntryPath = await discoverServerEntry(root, options.server);
       serverEntryFilePath = serverEntryPath ? path.resolve(root, serverEntryPath) : null;
-
-      // Validate HTML entries and warn about unsupported patterns
-      const htmlErrors = validateHtmlEntries(htmlEntries);
-      for (const error of htmlErrors) {
-        console.warn(`[litzjs] ${error}`);
-      }
 
       // Re-write with the actual server entry path now that it has been
       // discovered.
@@ -791,17 +780,21 @@ export async function discoverAllManifests(
 
 /**
  * Discovers all HTML entry files in the project root.
- * Supports Vite's standard HTML entry patterns including:
+ * Supports HTML entry discovery for Litz's shared-client runtime.
+ * Compatible entries may include:
  * - Root index.html with external module script
- * - Multiple HTML files for MPA setups
- * - Inline module scripts
+ * - Multiple HTML files that all share the same external module script
+ * - Inline module scripts, which are discovered for validation purposes
  */
-export async function discoverHtmlEntries(root: string): Promise<HtmlEntryInfo[]> {
+export async function discoverHtmlEntries(
+  root: string,
+  buildOutDir = "dist",
+): Promise<HtmlEntryInfo[]> {
   const entries: HtmlEntryInfo[] = [];
   const htmlFiles = await glob("**/*.html", {
     cwd: root,
     absolute: true,
-    ignore: ["node_modules/**", "dist/**", ".output/**"],
+    ignore: createHtmlEntryIgnorePatterns(root, buildOutDir),
   });
 
   for (const htmlFile of htmlFiles) {
@@ -831,7 +824,6 @@ export async function discoverHtmlEntries(root: string): Promise<HtmlEntryInfo[]
           htmlPath: relativePath,
           type: "inline",
           modulePath: `virtual:litzjs:inline-entry:${relativePath}`,
-          inlineContent: inlineMatch[1].trim(),
         });
       }
     } catch {
@@ -850,23 +842,59 @@ export async function discoverHtmlEntries(root: string): Promise<HtmlEntryInfo[]
   return entries;
 }
 
-/**
- * Validates that the discovered HTML entries are supported.
- * Returns an array of validation warnings (empty if all entries are valid).
- */
-export function validateHtmlEntries(entries: HtmlEntryInfo[]): string[] {
-  const warnings: string[] = [];
+function createHtmlEntryIgnorePatterns(root: string, buildOutDir: string): string[] {
+  const ignorePatterns = [
+    "node_modules/**",
+    ".output/**",
+    "public/**",
+    "test/**",
+    "tests/**",
+    "e2e/**",
+    "cypress/**",
+    "coverage/**",
+    ".storybook/**",
+    "storybook-static/**",
+    "fixtures/**",
+  ];
+  const absoluteBuildOutDir = path.resolve(root, buildOutDir);
+  const relativeBuildOutDir = normalizeRelativePath(root, absoluteBuildOutDir);
 
-  for (const entry of entries) {
-    if (entry.type === "inline") {
-      warnings.push(
-        `Inline module scripts in ${entry.htmlPath} are not fully supported. ` +
-          `Consider using an external script: <script type="module" src="your-entry.tsx"></script>`,
-      );
-    }
+  if (
+    relativeBuildOutDir &&
+    relativeBuildOutDir !== "." &&
+    !relativeBuildOutDir.startsWith("../") &&
+    !path.isAbsolute(relativeBuildOutDir)
+  ) {
+    ignorePatterns.push(`${relativeBuildOutDir}/**`);
   }
 
-  return warnings;
+  return ignorePatterns;
+}
+
+export function resolveBrowserEntryPath(entries: HtmlEntryInfo[]): string {
+  const inlineEntries = entries.filter((entry) => entry.type === "inline");
+
+  if (inlineEntries.length > 0) {
+    const files = inlineEntries.map((entry) => entry.htmlPath).join(", ");
+    throw new Error(
+      `[litzjs] Inline module scripts are not supported in HTML entries: ${files}. ` +
+        `Use an external script such as <script type="module" src="src/main.tsx"></script>.`,
+    );
+  }
+
+  const externalModulePaths = [...new Set(entries.map((entry) => entry.modulePath))];
+
+  if (externalModulePaths.length > 1) {
+    const entrySummary = entries
+      .map((entry) => `${entry.htmlPath} -> ${entry.modulePath}`)
+      .join(", ");
+    throw new Error(
+      `[litzjs] Multiple HTML entry module scripts are not supported by the current Vite integration. ` +
+        `All HTML entries must share the same external module script. Found: ${entrySummary}.`,
+    );
+  }
+
+  return externalModulePaths[0] ?? "src/main.tsx";
 }
 
 export async function discoverServerEntry(
@@ -2022,7 +2050,7 @@ export async function handleLitzRouteRequest(
   }
 }
 
-async function handleLitzDocumentRequest(
+export async function handleLitzDocumentRequest(
   server: ViteDevServer,
   htmlEntries: HtmlEntryInfo[],
   request: IncomingMessage,
@@ -2074,14 +2102,7 @@ async function handleLitzDocumentRequest(
     }
 
     const templatePath = path.join(server.config.root, htmlEntry.htmlPath);
-    let template = await readFile(templatePath, "utf8");
-
-    if (htmlEntry.type === "inline" && htmlEntry.inlineContent) {
-      template = template.replace(
-        /<script[^>]+type=["']module["'][^>]*>[\s\S]*?<\/script>/i,
-        `<script type="module">${htmlEntry.inlineContent}</script>`,
-      );
-    }
+    const template = await readFile(templatePath, "utf8");
 
     const html = await server.transformIndexHtml(url, template);
     response.statusCode = 200;
@@ -2108,15 +2129,16 @@ function findHtmlEntryForPath(pathname: string, entries: HtmlEntryInfo[]): HtmlE
     return null;
   }
 
-  if (entries.length === 1) {
-    return entries[0] ?? null;
-  }
+  const countNormalizedUrlSegments = (htmlPath: string) =>
+    htmlPath
+      .replace(/\.html$/, "")
+      .replace(/\/index$/, "")
+      .split("/")
+      .filter(Boolean).length;
 
-  // Sort by specificity: more path segments = more specific
+  // Sort by specificity: more URL path segments = more specific.
   const sortedEntries = [...entries].sort((a, b) => {
-    const aSegments = a.htmlPath.replace(/\.html$/, "").split("/").length;
-    const bSegments = b.htmlPath.replace(/\.html$/, "").split("/").length;
-    return bSegments - aSegments;
+    return countNormalizedUrlSegments(b.htmlPath) - countNormalizedUrlSegments(a.htmlPath);
   });
 
   for (const entry of sortedEntries) {
@@ -2134,7 +2156,7 @@ function findHtmlEntryForPath(pathname: string, entries: HtmlEntryInfo[]): HtmlE
   }
 
   const indexEntry = entries.find((e) => e.htmlPath === "index.html");
-  return indexEntry ?? entries[0] ?? null;
+  return indexEntry ?? null;
 }
 
 export async function handleLitzApiRequest(

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -630,7 +630,14 @@ export async function renderView(node, metadata = {}) {
         void handleLitzApiRequest(server, apiManifest, request, response, next, configuredBase);
       });
       server.middlewares.use((request, response, next) => {
-        void handleLitzDocumentRequest(server, htmlEntries, request, response, next, configuredBase);
+        void handleLitzDocumentRequest(
+          server,
+          htmlEntries,
+          request,
+          response,
+          next,
+          configuredBase,
+        );
       });
     },
 
@@ -817,9 +824,7 @@ export async function discoverHtmlEntries(root: string): Promise<HtmlEntryInfo[]
         continue;
       }
 
-      const inlineMatch = html.match(
-        /<script[^>]+type=["']module["'][^>]*>([\s\S]*?)<\/script>/i,
-      );
+      const inlineMatch = html.match(/<script[^>]+type=["']module["'][^>]*>([\s\S]*?)<\/script>/i);
 
       if (inlineMatch?.[1]?.trim()) {
         entries.push({
@@ -2098,10 +2103,7 @@ async function handleLitzDocumentRequest(
  * Entries are sorted by specificity (more specific paths first) to ensure
  * that /about/team matches /about/team.html before /about.html.
  */
-function findHtmlEntryForPath(
-  pathname: string,
-  entries: HtmlEntryInfo[],
-): HtmlEntryInfo | null {
+function findHtmlEntryForPath(pathname: string, entries: HtmlEntryInfo[]): HtmlEntryInfo | null {
   if (entries.length === 0) {
     return null;
   }

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -737,6 +737,32 @@ describe("dev server hot updates", () => {
     }
   });
 
+  test("discovers external module scripts when src appears before type", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "litz-browser-entry-attr-order-"));
+
+    try {
+      mkdirSync(path.join(root, "src"), { recursive: true });
+      writeFileSync(
+        path.join(root, "index.html"),
+        '<!doctype html><html><body><script src="./src/main.tsx" type="module"></script></body></html>\n',
+        "utf8",
+      );
+      writeFileSync(path.join(root, "src", "main.tsx"), "export {};\n", "utf8");
+
+      const entries = await discoverHtmlEntries(root);
+
+      expect(entries).toEqual([
+        {
+          htmlPath: "index.html",
+          type: "external",
+          modulePath: "./src/main.tsx",
+        },
+      ]);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   test("ignores HTML files inside a custom build output directory", async () => {
     const root = mkdtempSync(path.join(tmpdir(), "litz-browser-entry-custom-outdir-"));
 

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -21,11 +21,13 @@ import {
   buildLitzApp,
   discoverAllManifests,
   discoverApiRouteFromFile,
+  discoverHtmlEntries,
   discoverLayoutFromFile,
   discoverResourceFromFile,
   discoverRouteFromFile,
   discoverServerEntry,
   handleLitzApiRequest,
+  handleLitzDocumentRequest,
   handleLitzResourceRequest,
   handleLitzRouteRequest,
   litz,
@@ -653,6 +655,294 @@ describe("dev server hot updates", () => {
     }
   });
 
+  test("uses a shared external HTML module script for the generated browser entry", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "litz-browser-entry-html-shared-"));
+
+    try {
+      mkdirSync(path.join(root, "src"), { recursive: true });
+      writeFileSync(
+        path.join(root, "index.html"),
+        '<!doctype html><html><body><script type="module" src="/src/entry.tsx"></script></body></html>\n',
+        "utf8",
+      );
+      writeFileSync(
+        path.join(root, "about.html"),
+        '<!doctype html><html><body><script type="module" src="/src/entry.tsx"></script></body></html>\n',
+        "utf8",
+      );
+      writeFileSync(path.join(root, "src", "entry.tsx"), "export {};\n", "utf8");
+
+      const plugin = (litz() as Plugin[]).find((candidate) => candidate.name === "litzjs/vite");
+
+      if (!plugin?.configResolved || !plugin.resolveId || !plugin.load) {
+        throw new Error("Expected litzjs/vite browser-entry hooks to be available.");
+      }
+
+      const configResolved =
+        typeof plugin.configResolved === "function"
+          ? plugin.configResolved
+          : plugin.configResolved.handler;
+      const resolveId =
+        typeof plugin.resolveId === "function" ? plugin.resolveId : plugin.resolveId.handler;
+      const load = typeof plugin.load === "function" ? plugin.load : plugin.load.handler;
+      const pluginContext = {} as never;
+
+      await configResolved.call(pluginContext, {
+        root,
+        base: "/",
+        command: "serve",
+        build: {
+          outDir: "dist",
+        },
+        environments: {
+          client: {
+            build: {
+              outDir: path.join("dist", "client"),
+            },
+          },
+          rsc: {
+            build: {
+              outDir: path.join("dist", "server"),
+              rollupOptions: {
+                output: {
+                  codeSplitting: false,
+                },
+              },
+            },
+          },
+        },
+      } as never);
+
+      const resolvedId = resolveId.call(
+        pluginContext,
+        "virtual:litzjs:browser-entry",
+        undefined,
+        {} as never,
+      );
+      const browserEntrySource = load.call(
+        {
+          environment: {
+            name: "client",
+          },
+        } as never,
+        resolvedId as string,
+        {} as never,
+      ) as string;
+
+      expect(browserEntrySource).toContain(
+        `/@fs/${path.join(root, "src", "entry.tsx").replaceAll("\\", "/")}`,
+      );
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("ignores HTML files inside a custom build output directory", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "litz-browser-entry-custom-outdir-"));
+
+    try {
+      mkdirSync(path.join(root, "src"), { recursive: true });
+      mkdirSync(path.join(root, "build"), { recursive: true });
+      writeFileSync(
+        path.join(root, "index.html"),
+        '<!doctype html><html><body><script type="module" src="/src/main.tsx"></script></body></html>\n',
+        "utf8",
+      );
+      writeFileSync(path.join(root, "src", "main.tsx"), "export {};\n", "utf8");
+      writeFileSync(
+        path.join(root, "build", "index.html"),
+        '<!doctype html><html><body><script type="module" src="/build/assets/app.js"></script></body></html>\n',
+        "utf8",
+      );
+
+      const entries = await discoverHtmlEntries(root, "build");
+
+      expect(entries).toEqual([
+        {
+          htmlPath: "index.html",
+          type: "external",
+          modulePath: "src/main.tsx",
+        },
+      ]);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("ignores HTML files inside tool and fixture directories", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "litz-browser-entry-tooling-html-"));
+
+    try {
+      mkdirSync(path.join(root, "src"), { recursive: true });
+      mkdirSync(path.join(root, "cypress"), { recursive: true });
+      mkdirSync(path.join(root, ".storybook"), { recursive: true });
+      writeFileSync(
+        path.join(root, "index.html"),
+        '<!doctype html><html><body><script type="module" src="/src/main.tsx"></script></body></html>\n',
+        "utf8",
+      );
+      writeFileSync(path.join(root, "src", "main.tsx"), "export {};\n", "utf8");
+      writeFileSync(
+        path.join(root, "cypress", "fixture.html"),
+        '<!doctype html><html><body><script type="module" src="/cypress/fixture.js"></script></body></html>\n',
+        "utf8",
+      );
+      writeFileSync(
+        path.join(root, ".storybook", "preview-head.html"),
+        '<!doctype html><html><body><script type="module" src="/storybook/preview.js"></script></body></html>\n',
+        "utf8",
+      );
+
+      const entries = await discoverHtmlEntries(root);
+
+      expect(entries).toEqual([
+        {
+          htmlPath: "index.html",
+          type: "external",
+          modulePath: "src/main.tsx",
+        },
+      ]);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("rejects HTML entries that use different external module scripts", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "litz-browser-entry-html-mismatch-"));
+
+    try {
+      mkdirSync(path.join(root, "src"), { recursive: true });
+      writeFileSync(
+        path.join(root, "index.html"),
+        '<!doctype html><html><body><script type="module" src="/src/main.tsx"></script></body></html>\n',
+        "utf8",
+      );
+      writeFileSync(
+        path.join(root, "admin.html"),
+        '<!doctype html><html><body><script type="module" src="/src/admin.tsx"></script></body></html>\n',
+        "utf8",
+      );
+      writeFileSync(path.join(root, "src", "main.tsx"), "export {};\n", "utf8");
+      writeFileSync(path.join(root, "src", "admin.tsx"), "export {};\n", "utf8");
+
+      const plugin = (litz() as Plugin[]).find((candidate) => candidate.name === "litzjs/vite");
+
+      if (!plugin?.configResolved) {
+        throw new Error("Expected litzjs/vite configResolved hook to be available.");
+      }
+
+      const configResolved =
+        typeof plugin.configResolved === "function"
+          ? plugin.configResolved
+          : plugin.configResolved.handler;
+
+      let error: unknown;
+
+      try {
+        await configResolved.call(
+          {} as never,
+          {
+            root,
+            base: "/",
+            command: "serve",
+            build: {
+              outDir: "dist",
+            },
+            environments: {
+              client: {
+                build: {
+                  outDir: path.join("dist", "client"),
+                },
+              },
+              rsc: {
+                build: {
+                  outDir: path.join("dist", "server"),
+                  rollupOptions: {
+                    output: {
+                      codeSplitting: false,
+                    },
+                  },
+                },
+              },
+            },
+          } as never,
+        );
+      } catch (caughtError) {
+        error = caughtError;
+      }
+
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain(
+        "All HTML entries must share the same external module script",
+      );
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("rejects HTML entries that use inline module scripts", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "litz-browser-entry-html-inline-"));
+
+    try {
+      writeFileSync(
+        path.join(root, "index.html"),
+        '<!doctype html><html><body><script type="module">console.log("inline");</script></body></html>\n',
+        "utf8",
+      );
+
+      const plugin = (litz() as Plugin[]).find((candidate) => candidate.name === "litzjs/vite");
+
+      if (!plugin?.configResolved) {
+        throw new Error("Expected litzjs/vite configResolved hook to be available.");
+      }
+
+      const configResolved =
+        typeof plugin.configResolved === "function"
+          ? plugin.configResolved
+          : plugin.configResolved.handler;
+
+      let error: unknown;
+
+      try {
+        await configResolved.call(
+          {} as never,
+          {
+            root,
+            base: "/",
+            command: "serve",
+            build: {
+              outDir: "dist",
+            },
+            environments: {
+              client: {
+                build: {
+                  outDir: path.join("dist", "client"),
+                },
+              },
+              rsc: {
+                build: {
+                  outDir: path.join("dist", "server"),
+                  rollupOptions: {
+                    output: {
+                      codeSplitting: false,
+                    },
+                  },
+                },
+              },
+            },
+          } as never,
+        );
+      } catch (caughtError) {
+        error = caughtError;
+      }
+
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain("Inline module scripts are not supported");
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   test("injects the configured base into transformed server entries", async () => {
     const root = mkdtempSync(path.join(tmpdir(), "litz-server-entry-base-"));
 
@@ -736,6 +1026,7 @@ function createMockViteDevServer(
     config: { root: "/fake-root" },
     ssrFixStacktrace: mock(() => {}),
     ssrLoadModule: ssrLoadModuleImpl,
+    transformIndexHtml: mock(async (_url: string, template: string) => template),
     environments: {
       rsc: {
         pluginContainer: {
@@ -807,6 +1098,138 @@ function createMockResponse(): ServerResponse & { getBody(): string } {
     },
   } as unknown as ServerResponse & { getBody(): string };
 }
+
+describe("document entry resolution", () => {
+  test("prefers the more specific non-index entry over a sibling index entry", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "litz-document-specificity-"));
+
+    try {
+      mkdirSync(path.join(root, "about", "team"), { recursive: true });
+      writeFileSync(
+        path.join(root, "about", "team", "index.html"),
+        "<html><body>team index</body></html>\n",
+        "utf8",
+      );
+      writeFileSync(
+        path.join(root, "about", "team", "foo.html"),
+        "<html><body>team foo</body></html>\n",
+        "utf8",
+      );
+
+      const server = {
+        ...createMockViteDevServer(async () => ({})),
+        config: { root },
+      } as ViteDevServer;
+      const request = createMockRequest({
+        url: "/about/team/foo",
+        method: "GET",
+        headers: { accept: "text/html" },
+      });
+      const response = createMockResponse();
+      const next = mock(() => {});
+
+      await handleLitzDocumentRequest(
+        server,
+        [
+          {
+            htmlPath: "about/team/index.html",
+            type: "external",
+            modulePath: "src/main.tsx",
+          },
+          {
+            htmlPath: "about/team/foo.html",
+            type: "external",
+            modulePath: "src/main.tsx",
+          },
+        ],
+        request,
+        response,
+        next,
+      );
+
+      expect(response.statusCode).toBe(200);
+      expect(response.getBody()).toContain("team foo");
+      expect(next).not.toHaveBeenCalled();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("serves index.html for unmatched HTML routes when an index entry exists", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "litz-document-index-fallback-"));
+
+    try {
+      writeFileSync(path.join(root, "index.html"), "<html><body>index</body></html>\n", "utf8");
+      writeFileSync(path.join(root, "about.html"), "<html><body>about</body></html>\n", "utf8");
+
+      const server = {
+        ...createMockViteDevServer(async () => ({})),
+        config: { root },
+      } as ViteDevServer;
+      const request = createMockRequest({
+        url: "/missing",
+        method: "GET",
+        headers: { accept: "text/html" },
+      });
+      const response = createMockResponse();
+      const next = mock(() => {});
+
+      await handleLitzDocumentRequest(
+        server,
+        [
+          { htmlPath: "index.html", type: "external", modulePath: "src/main.tsx" },
+          { htmlPath: "about.html", type: "external", modulePath: "src/main.tsx" },
+        ],
+        request,
+        response,
+        next,
+      );
+
+      expect(response.statusCode).toBe(200);
+      expect(response.getBody()).toContain("index");
+      expect(next).not.toHaveBeenCalled();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("calls next for unmatched HTML routes when no index entry exists", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "litz-document-no-index-fallback-"));
+
+    try {
+      writeFileSync(path.join(root, "about.html"), "<html><body>about</body></html>\n", "utf8");
+      writeFileSync(path.join(root, "contact.html"), "<html><body>contact</body></html>\n", "utf8");
+
+      const server = {
+        ...createMockViteDevServer(async () => ({})),
+        config: { root },
+      } as ViteDevServer;
+      const request = createMockRequest({
+        url: "/missing",
+        method: "GET",
+        headers: { accept: "text/html" },
+      });
+      const response = createMockResponse();
+      const next = mock(() => {});
+
+      await handleLitzDocumentRequest(
+        server,
+        [
+          { htmlPath: "about.html", type: "external", modulePath: "src/main.tsx" },
+          { htmlPath: "contact.html", type: "external", modulePath: "src/main.tsx" },
+        ],
+        request,
+        response,
+        next,
+      );
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(response.getBody()).toBe("");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
 
 describe("dev server abort signal lifecycle", () => {
   test("matches base-prefixed internal resource requests", async () => {


### PR DESCRIPTION
## Summary
- discover and route multiple HTML files during development without pretending full multi-entry MPA build support exists
- fail fast for unsupported HTML entry configurations that do not fit the current single browser-entry runtime model
- tighten HTML route matching and discovery with regression coverage for the review-reported edge cases

## Related Issue
Fixes #91

## What Changed
- Added `discoverHtmlEntries()` to find HTML entry files used for document routing in dev.
- Added `resolveBrowserEntryPath()` to enforce the supported contract for the generated browser entry:
  - all discovered HTML entries must share the same external module script
  - inline module scripts are rejected
- Updated document routing to:
  - choose the most specific matching HTML entry
  - rank entries by normalized URL segment count so sibling `index.html` and leaf pages resolve correctly
  - fall back only to `index.html` for unmatched requests
  - call `next()` when no matching entry exists and there is no `index.html`
- Tightened HTML discovery to ignore:
  - the configured `build.outDir`
  - `.output/`
  - common tooling and fixture directories such as `public/`, `test/`, `tests/`, `e2e/`, `cypress/`, `.storybook/`, `storybook-static/`, `coverage/`, and `fixtures/`
- Removed stale inline-script replacement from document serving so requests always use live on-disk HTML.
- Added a patch changeset.

## Behavioral Notes
This PR does not implement full multi-entry MPA client builds.

The current Vite integration still has a single browser-entry build model, so the supported behavior is intentionally narrower:
- multiple HTML files are allowed only when they share one external module entry
- inline module scripts are unsupported
- incompatible setups now fail fast instead of producing silently broken builds

## Testing
- [x] `bun run lint:fix`
- [x] `bun fmt`
- [x] `bun typecheck`
- [x] `bun test`
- [x] Added regression tests for:
  - custom `build.outDir` exclusion
  - tooling/fixture HTML exclusion
  - divergent external module entries
  - inline module script rejection
  - unmatched document fallback behavior
  - normalized specificity ordering for sibling `index.html` and leaf pages
