### PR TITLE
fix(vite): extend watch and HMR to cover .js and .jsx route modules

### DIFF
--- a/.changeset/js-jsx-watch-hmr-support.md
+++ b/.changeset/js-jsx-watch-hmr-support.md
@@ -1,0 +1,9 @@
+---
+"litzjs": patch
+---
+
+Extend dev watcher and HMR to cover `.js` and `.jsx` route-like modules.
+
+Previously, the default manifest glob patterns only matched `.ts` and `.tsx` files, and the `hotUpdate()` hook filtered on the same extensions. This meant `.js` and `.jsx` route, resource, and API files were discovered at startup (AST parsing supports all four extensions) but were silently ignored during file edits.
+
+The default patterns for routes, resources, and API routes now include `.js` and `.jsx`, and the `hotUpdate()` extension guard is expanded to match, so edits to JavaScript route modules trigger watch refresh and client hot-update exactly as TypeScript ones do.

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -183,12 +183,12 @@ export function litz(options: LitzPluginOptions = {}): PluginOption {
   let apiManifest: DiscoveredApiRoute[] = [];
   let clientProjectedFiles = new Set<string>();
   const routePatterns = options.routes ?? [
-    "src/routes/**/*.{ts,tsx}",
-    "!src/routes/api/**/*.{ts,tsx}",
-    "!src/routes/resources/**/*.{ts,tsx}",
+    "src/routes/**/*.{ts,tsx,js,jsx}",
+    "!src/routes/api/**/*.{ts,tsx,js,jsx}",
+    "!src/routes/resources/**/*.{ts,tsx,js,jsx}",
   ];
-  const resourcePatterns = options.resources ?? ["src/routes/resources/**/*.{ts,tsx}"];
-  const apiPatterns = options.api ?? ["src/routes/api/**/*.{ts,tsx}"];
+  const resourcePatterns = options.resources ?? ["src/routes/resources/**/*.{ts,tsx,js,jsx}"];
+  const apiPatterns = options.api ?? ["src/routes/api/**/*.{ts,tsx,js,jsx}"];
   // Write a placeholder Nitro renderer file so the nitro plugin can resolve
   // it during its `config` hook. The file is re-written in `configResolved`
   // once the actual server entry path is known.
@@ -635,7 +635,7 @@ export async function renderView(node, metadata = {}) {
         return;
       }
 
-      if (!/\.(ts|tsx)$/.test(options.file)) {
+      if (!/\.(ts|tsx|js|jsx)$/.test(options.file)) {
         return;
       }
 

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -429,6 +429,180 @@ describe("dev server hot updates", () => {
     }
   });
 
+  test("returns client modules for projected .jsx route updates in the client environment", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "litz-hot-update-jsx-"));
+
+    try {
+      mkdirSync(path.join(root, "src"), { recursive: true });
+      writeFileSync(path.join(root, "src", "main.tsx"), "export {};\n", "utf8");
+      mkdirSync(path.join(root, "src", "routes"), { recursive: true });
+      writeFileSync(
+        path.join(root, "src", "routes", "index.jsx"),
+        'import { defineRoute } from "litzjs";\n\nexport const route = defineRoute("/", {\n  component() {\n    return null;\n  },\n});\n',
+        "utf8",
+      );
+
+      const plugin = (litz() as Plugin[]).find((candidate) => candidate.name === "litzjs/vite");
+
+      if (!plugin?.configResolved || !plugin.hotUpdate) {
+        throw new Error("Expected litzjs/vite hot-update hooks to be available.");
+      }
+
+      const configResolved =
+        typeof plugin.configResolved === "function"
+          ? plugin.configResolved
+          : plugin.configResolved.handler;
+      const hotUpdate =
+        typeof plugin.hotUpdate === "function" ? plugin.hotUpdate : plugin.hotUpdate.handler;
+      const routeFile = path.join(root, "src", "routes", "index.jsx");
+      const clientModule = {
+        id: `/@fs/${routeFile.split(path.sep).join("/")}`,
+      };
+      const pluginContext = {} as never;
+
+      await configResolved.call(pluginContext, {
+        root,
+        command: "serve",
+        build: {
+          outDir: "dist",
+        },
+        environments: {
+          client: {
+            build: {
+              outDir: path.join("dist", "client"),
+            },
+          },
+          rsc: {
+            build: {
+              outDir: path.join("dist", "server"),
+              rollupOptions: {
+                output: {
+                  codeSplitting: false,
+                },
+              },
+            },
+          },
+        },
+      } as never);
+
+      const result = await hotUpdate.call(
+        {
+          environment: {
+            name: "client",
+            moduleGraph: {
+              getModulesByFile(file: string) {
+                return file === routeFile ? new Set([clientModule]) : undefined;
+              },
+              getModuleById(id: string) {
+                return id === clientModule.id ? clientModule : undefined;
+              },
+            },
+          },
+        } as never,
+        {
+          type: "update",
+          file: routeFile,
+          modules: [clientModule] as never,
+          timestamp: Date.now(),
+          read: () => "",
+          server: {} as never,
+        },
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result?.[0]).toBe(clientModule as never);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("returns client modules for projected .js route updates in the client environment", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "litz-hot-update-js-"));
+
+    try {
+      mkdirSync(path.join(root, "src"), { recursive: true });
+      writeFileSync(path.join(root, "src", "main.tsx"), "export {};\n", "utf8");
+      mkdirSync(path.join(root, "src", "routes"), { recursive: true });
+      writeFileSync(
+        path.join(root, "src", "routes", "index.js"),
+        'import { defineRoute } from "litzjs";\n\nexport const route = defineRoute("/", {\n  component() {\n    return null;\n  },\n});\n',
+        "utf8",
+      );
+
+      const plugin = (litz() as Plugin[]).find((candidate) => candidate.name === "litzjs/vite");
+
+      if (!plugin?.configResolved || !plugin.hotUpdate) {
+        throw new Error("Expected litzjs/vite hot-update hooks to be available.");
+      }
+
+      const configResolved =
+        typeof plugin.configResolved === "function"
+          ? plugin.configResolved
+          : plugin.configResolved.handler;
+      const hotUpdate =
+        typeof plugin.hotUpdate === "function" ? plugin.hotUpdate : plugin.hotUpdate.handler;
+      const routeFile = path.join(root, "src", "routes", "index.js");
+      const clientModule = {
+        id: `/@fs/${routeFile.split(path.sep).join("/")}`,
+      };
+      const pluginContext = {} as never;
+
+      await configResolved.call(pluginContext, {
+        root,
+        command: "serve",
+        build: {
+          outDir: "dist",
+        },
+        environments: {
+          client: {
+            build: {
+              outDir: path.join("dist", "client"),
+            },
+          },
+          rsc: {
+            build: {
+              outDir: path.join("dist", "server"),
+              rollupOptions: {
+                output: {
+                  codeSplitting: false,
+                },
+              },
+            },
+          },
+        },
+      } as never);
+
+      const result = await hotUpdate.call(
+        {
+          environment: {
+            name: "client",
+            moduleGraph: {
+              getModulesByFile(file: string) {
+                return file === routeFile ? new Set([clientModule]) : undefined;
+              },
+              getModuleById(id: string) {
+                return id === clientModule.id ? clientModule : undefined;
+              },
+            },
+          },
+        } as never,
+        {
+          type: "update",
+          file: routeFile,
+          modules: [clientModule] as never,
+          timestamp: Date.now(),
+          read: () => "",
+          server: {} as never,
+        },
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result?.[0]).toBe(clientModule as never);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   test("does not hijack projected route updates outside the client environment", async () => {
     const root = mkdtempSync(path.join(tmpdir(), "litz-hot-update-"));
 
@@ -2303,6 +2477,45 @@ describe("manifest discovery", () => {
   });
 
   describe("discoverAllManifests", () => {
+    test("discovers .js and .jsx route-like modules with the default patterns", async () => {
+      const root = createTempProject();
+
+      try {
+        writeFileSync(
+          path.join(root, "src", "routes", "home.jsx"),
+          `import { defineRoute } from "litzjs";\nexport const route = defineRoute("/home", { component: Home });`,
+        );
+        writeFileSync(
+          path.join(root, "src", "routes", "resources", "data.js"),
+          `import { defineResource } from "litzjs";\nexport const resource = defineResource("/resource/data", { loader: async () => {} });`,
+        );
+        writeFileSync(
+          path.join(root, "src", "routes", "api", "health.js"),
+          `import { defineApiRoute } from "litzjs";\nexport const api = defineApiRoute("/api/health", { GET() { return Response.json({ ok: true }); } });`,
+        );
+
+        const result = await discoverAllManifests(
+          root,
+          [
+            "src/routes/**/*.{ts,tsx,js,jsx}",
+            "!src/routes/api/**/*.{ts,tsx,js,jsx}",
+            "!src/routes/resources/**/*.{ts,tsx,js,jsx}",
+          ],
+          ["src/routes/resources/**/*.{ts,tsx,js,jsx}"],
+          ["src/routes/api/**/*.{ts,tsx,js,jsx}"],
+        );
+
+        expect(result.routeManifest).toHaveLength(1);
+        expect(result.routeManifest[0]?.path).toBe("/home");
+        expect(result.resourceManifest).toHaveLength(1);
+        expect(result.resourceManifest[0]?.path).toBe("/resource/data");
+        expect(result.apiManifest).toHaveLength(1);
+        expect(result.apiManifest[0]?.path).toBe("/api/health");
+      } finally {
+        rmSync(root, { force: true, recursive: true });
+      }
+    });
+
     test("discovers routes, layouts, resources, and API routes from glob patterns", async () => {
       const root = createTempProject();
 


### PR DESCRIPTION
## Summary

Fixes #92

- Expanded the default manifest glob patterns for routes, resources, and API routes from `*.{ts,tsx}` to `*.{ts,tsx,js,jsx}` so the file watcher reacts to `.js`/`.jsx` edits the same way it does for TypeScript files.
- Widened the `hotUpdate()` extension guard from `/\.(ts|tsx)$/` to `/\.(ts|tsx|js|jsx)$/` so client HMR fires for JavaScript route modules when they are part of the projected file set.

## Root cause

AST discovery already supported `.js`, `.jsx`, `.ts`, and `.tsx` via `createModuleSourceFile`, but two independent filters — the default glob patterns and the `hotUpdate()` early-return guard — only covered `.ts`/`.tsx`. This caused the partial support described in the issue: startup discovery worked while file edits were silently dropped.

## Test plan

- [x] New regression test: `hotUpdate()` returns client modules for a `.jsx` route file with default plugin config
- [x] New regression test: `hotUpdate()` returns client modules for a `.js` route file with default plugin config
- [x] New regression test: `discoverAllManifests` discovers routes/resources/API routes from `.js` and `.jsx` files when patterns include those extensions
- [x] Full `tests/vite.test.ts` suite passes (60 tests)
- [x] `bun typecheck`, `bun fmt`, `bun lint:fix` all clean

## Changeset

A `patch` changeset is included at `.changeset/js-jsx-watch-hmr-support.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)