### PR TITLE
fix: align setup docs and API contracts

### DIFF
--- a/.changeset/green-mails-carry.md
+++ b/.changeset/green-mails-carry.md
@@ -1,0 +1,7 @@
+---
+"litzjs": patch
+---
+
+Align the setup and API surface by documenting `nitro` as a required peer dependency, adding a
+`baseUrl` escape hatch to `defineApiRoute().fetch()` for server-side callers, attaching lightweight
+marker metadata in `server(...)`, and making `invalid()` accept an omitted options object.

--- a/README.md
+++ b/README.md
@@ -785,11 +785,12 @@ Supported method keys:
 method when needed.
 
 In the browser, the helper defaults to a relative URL. In server-side code or test environments,
-pass `baseUrl` when you need an absolute request target:
+pass `baseUrl` when you need an absolute request target. If `baseUrl` includes a path prefix, Litz
+preserves it when resolving the API path:
 
 ```ts
 const response = await api.fetch({
-  baseUrl: "https://example.com",
+  baseUrl: "https://example.com/root/",
   params: { id: "42" },
 });
 ```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,12 @@ Inside a React + Vite app:
 
 ```bash
 bun add litzjs react react-dom
+bun add -d typescript vite @vitejs/plugin-rsc nitro
 ```
+
+Litz currently expects the full peer dependency surface above. `nitro` is required for the
+current Vite-first production build pipeline even if your application code does not import it
+directly.
 
 ## Quick Start
 
@@ -776,7 +781,18 @@ Supported method keys:
 
 `ALL` acts as a fallback when there is no method-specific handler.
 
-`api.fetch(...)` accepts route params, search params, headers, and the HTTP method when needed.
+`api.fetch(...)` accepts route params, search params, headers, an optional `baseUrl`, and the HTTP
+method when needed.
+
+In the browser, the helper defaults to a relative URL. In server-side code or test environments,
+pass `baseUrl` when you need an absolute request target:
+
+```ts
+const response = await api.fetch({
+  baseUrl: "https://example.com",
+  params: { id: "42" },
+});
+```
 
 ## Input Validation
 
@@ -1060,6 +1076,8 @@ Middleware receives:
 - `view(...)` uses RSC as a transport, not as the whole app architecture.
 - Routes, resources, and API routes are discovered from top-level glob options.
 - Paths are explicit and absolute.
+- `server(...)` is a declarative marker on a normal JavaScript function, not an isolation boundary
+  or security boundary by itself.
 
 ## Try The Fixture
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1736,5 +1736,12 @@ function buildApiHref(
     return href;
   }
 
-  return new URL(href, baseUrl).toString();
+  const resolvedBaseUrl = new URL(baseUrl);
+  const relativeHref = href.startsWith("/") ? href.slice(1) : href;
+
+  if (!resolvedBaseUrl.pathname.endsWith("/")) {
+    resolvedBaseUrl.pathname = `${resolvedBaseUrl.pathname}/`;
+  }
+
+  return new URL(relativeHref, resolvedBaseUrl).toString();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -627,6 +627,7 @@ export type ApiFetchOptions<
 > = Omit<RequestInit, "method"> &
   PathRequestParams<TPath> &
   SearchRequest & {
+    baseUrl?: string | URL;
     method?: ApiFetchMethod<TMethods>;
   };
 
@@ -646,9 +647,16 @@ export type ResourceServerHandler<
     undefined,
 > = (context: ResourceHandlerContext<TContext, TPath, TInput>) => Promise<TResult> | TResult;
 
-export type ServerHandler<TContext = unknown, TResult extends ServerResult = ServerResult> =
+type ServerHandlerBase<TContext = unknown, TResult extends ServerResult = ServerResult> =
   | RouteServerHandler<TContext, TResult>
   | ResourceServerHandler<TContext, TResult>;
+
+export type ServerHandler<
+  TContext = unknown,
+  TResult extends ServerResult = ServerResult,
+> = ServerHandlerBase<TContext, TResult> & {
+  __litzServer?: true;
+};
 
 export type DefineRouteOptions<
   TPath extends string = string,
@@ -1371,8 +1379,8 @@ export function defineApiRoute<
     methods: methods as TMethods,
     fetch(...args: MaybeRequiredArg<TPath, ApiFetchOptions<TPath, TMethods>>) {
       const options = (args[0] ?? {}) as ApiFetchOptions<TPath, TMethods>;
-      const { params, search, method, ...init } = options;
-      const href = buildApiHref(path, params, search);
+      const { params, search, method, baseUrl, ...init } = options;
+      const href = buildApiHref(path, params, search, baseUrl);
 
       return fetch(href, {
         ...init,
@@ -1576,8 +1584,10 @@ export function server<
   handler: (
     context: RouteHandlerContext<NoInferType<TContext>, NoInferType<TPath>, TInput>,
   ) => Promise<TResult> | TResult,
-): RouteServerHandler<TContext, TResult, TPath, TInput> {
-  return handler;
+): RouteServerHandler<TContext, TResult, TPath, TInput> & { __litzServer: true } {
+  return Object.assign(handler, {
+    __litzServer: true as const,
+  });
 }
 
 export function withHeaders<TResponse extends Response>(
@@ -1637,13 +1647,15 @@ export function view<TNode extends React.ReactNode>(
   };
 }
 
-export function invalid<TData = unknown>(options: {
-  headers?: HeadersInit;
-  status?: number;
-  fields?: Record<string, string>;
-  formError?: string;
-  data?: TData;
-}): InvalidResult<TData> {
+export function invalid<TData = unknown>(
+  options: {
+    headers?: HeadersInit;
+    status?: number;
+    fields?: Record<string, string>;
+    formError?: string;
+    data?: TData;
+  } = {},
+): InvalidResult<TData> {
   return {
     kind: "invalid",
     headers: options.headers,
@@ -1713,10 +1725,16 @@ function buildApiHref(
   pathPattern: string,
   params?: Record<string, string>,
   search?: SearchParamsInput,
+  baseUrl?: string | URL,
 ): string {
   const pathname = interpolatePath(pathPattern, params ?? {}, "API");
   const searchParams = createSearchParams(search);
   const searchString = searchParams.toString();
+  const href = searchString ? `${pathname}?${searchString}` : pathname;
 
-  return searchString ? `${pathname}?${searchString}` : pathname;
+  if (!baseUrl) {
+    return href;
+  }
+
+  return new URL(href, baseUrl).toString();
 }

--- a/tests/api-route-fetch.test.ts
+++ b/tests/api-route-fetch.test.ts
@@ -53,6 +53,28 @@ describe("defineApiRoute().fetch", () => {
       search: { tab: "details" },
     });
 
-    expect(capturedInput).toBe("https://example.com/api/projects/42?tab=details");
+    expect(capturedInput).toBe("https://example.com/root/api/projects/42?tab=details");
+  });
+
+  test("preserves baseUrl path prefixes when resolving API requests", async () => {
+    let capturedInput: RequestInfo | URL | undefined;
+
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      capturedInput = input;
+      return new Response(null, { status: 204 });
+    }) as typeof fetch;
+
+    const api = defineApiRoute("/api/projects/:id", {
+      GET() {
+        return new Response(null, { status: 204 });
+      },
+    });
+
+    await api.fetch({
+      baseUrl: "https://example.com/root",
+      params: { id: "42" },
+    });
+
+    expect(capturedInput).toBe("https://example.com/root/api/projects/42");
   });
 });

--- a/tests/api-route-fetch.test.ts
+++ b/tests/api-route-fetch.test.ts
@@ -32,4 +32,27 @@ describe("defineApiRoute().fetch", () => {
 
     expect(capturedInput).toBe("/api/projects?tag=framework&tag=bun&term=litz");
   });
+
+  test("supports an explicit baseUrl for server-side and test callers", async () => {
+    let capturedInput: RequestInfo | URL | undefined;
+
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      capturedInput = input;
+      return new Response(null, { status: 204 });
+    }) as typeof fetch;
+
+    const api = defineApiRoute("/api/projects/:id", {
+      GET() {
+        return new Response(null, { status: 204 });
+      },
+    });
+
+    await api.fetch({
+      baseUrl: "https://example.com/root/",
+      params: { id: "42" },
+      search: { tab: "details" },
+    });
+
+    expect(capturedInput).toBe("https://example.com/api/projects/42?tab=details");
+  });
 });

--- a/tests/docs-package-names.test.ts
+++ b/tests/docs-package-names.test.ts
@@ -39,6 +39,7 @@ describe("getting started docs flow", () => {
     expect(firstAppDoc).toContain('defineRoute("/docs/first-app"');
     expect(firstAppDoc).toContain("mkdir hello-litz");
     expect(firstAppDoc).toContain("bun add litzjs react react-dom");
+    expect(firstAppDoc).toContain("bun add -d typescript vite @vitejs/plugin-rsc nitro");
     expect(firstAppDoc).toContain('import { litz } from "litzjs/vite";');
     expect(firstAppDoc).toContain(
       'Open <code className="text-sky-400">http://localhost:5173</code>.',
@@ -77,6 +78,7 @@ describe("docs package names", () => {
     expect(installationDoc).toContain("pnpm add react react-dom");
 
     expect(installationDoc).toContain("bun add -d typescript vite @vitejs/plugin-rsc");
+    expect(installationDoc).toContain("nitro");
     expect(installationDoc).toContain("npm install -D typescript vite @vitejs/plugin-rsc");
     expect(installationDoc).toContain("yarn add -D typescript vite @vitejs/plugin-rsc");
     expect(installationDoc).toContain("pnpm add -D typescript vite @vitejs/plugin-rsc");
@@ -87,10 +89,12 @@ describe("docs package names", () => {
     expect(installationDoc).toContain('packageName: "typescript"');
     expect(installationDoc).toContain('packageName: "vite"');
     expect(installationDoc).toContain('packageName: "@vitejs/plugin-rsc"');
+    expect(installationDoc).toContain('packageName: "nitro"');
     expect(installationDoc).toContain("^19");
     expect(installationDoc).toContain("^6.0.2");
     expect(installationDoc).toContain("^8");
     expect(installationDoc).toContain("^0.5.21");
+    expect(installationDoc).toContain("^3");
     expect(installationDoc).toContain("Runtime compatibility notes");
     expect(installationDoc).toContain("does not publish a single runtime engine floor");
   });
@@ -257,6 +261,14 @@ describe("docs package names", () => {
     expect(apiReferenceDoc).toContain("resource.Component");
     expect(apiReferenceDoc).toContain(
       'Import from <code className="text-sky-400">{importPath}</code>.',
+    );
+    expect(apiReferenceDoc).toContain("baseUrl?: string | URL;");
+    expect(apiReferenceDoc).toContain("Adds an absolute base URL for server-side or test callers");
+    expect(apiReferenceDoc).toContain(
+      "same callable handler with lightweight marker metadata attached",
+    );
+    expect(apiReferenceDoc).toContain(
+      "invalid<TData = unknown>(options?: { headers?: HeadersInit; status?: number; fields?: Record<string, string>; formError?: string; data?: TData }): InvalidResult<TData>",
     );
     expect(apiReferenceDoc).toContain(
       "Most apps only need `litz(...)`, but the helper exports are public",

--- a/tests/result-helpers.test.ts
+++ b/tests/result-helpers.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+
+import { invalid, server } from "../src/index";
+
+describe("result helpers", () => {
+  test("invalid() supports an omitted options object", () => {
+    expect(invalid()).toEqual({
+      kind: "invalid",
+      headers: undefined,
+      status: undefined,
+      fields: undefined,
+      formError: undefined,
+      data: undefined,
+    });
+  });
+
+  test("server() attaches framework marker metadata without changing callability", async () => {
+    const handler = server(async () => invalid());
+
+    expect(handler.__litzServer).toBe(true);
+    const result = await handler({} as never);
+
+    expect(result).toEqual(invalid());
+  });
+});

--- a/www/src/routes/docs/api-reference.tsx
+++ b/www/src/routes/docs/api-reference.tsx
@@ -113,6 +113,7 @@ function UserCard() {
           "`definition` is shaped by `DefineApiRouteOptions`, so it can include any subset of `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `OPTIONS`, `HEAD`, `ALL`, plus `middleware` and `input`.",
           "`api.fetch(...)` interpolates path params, serializes search params, and forwards the remaining `RequestInit` fields to the platform `fetch`.",
           "Use `baseUrl` when calling it from server-side code or test environments that require absolute request URLs.",
+          "If `baseUrl` includes a path prefix, the resolved request preserves that prefix.",
         ],
         example: {
           language: "ts",
@@ -678,6 +679,7 @@ function SaveFiltersButton() {
         details: [
           "When the API path contains params, the `options.params` object is required.",
           "Pass `baseUrl` for server-side or test callers that cannot use relative fetch URLs.",
+          "Base URL path prefixes are preserved when building the final request URL.",
         ],
       },
       {
@@ -877,6 +879,7 @@ export const route = defineRoute("/posts/:id", {
         details: [
           "`method` is limited to the declared method keys, excluding `ALL`.",
           "Adds an absolute base URL for server-side or test callers that need one.",
+          "Path prefixes on that base URL are preserved in the resolved request target.",
         ],
       },
       {

--- a/www/src/routes/docs/api-reference.tsx
+++ b/www/src/routes/docs/api-reference.tsx
@@ -112,6 +112,7 @@ function UserCard() {
         details: [
           "`definition` is shaped by `DefineApiRouteOptions`, so it can include any subset of `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `OPTIONS`, `HEAD`, `ALL`, plus `middleware` and `input`.",
           "`api.fetch(...)` interpolates path params, serializes search params, and forwards the remaining `RequestInit` fields to the platform `fetch`.",
+          "Use `baseUrl` when calling it from server-side code or test environments that require absolute request URLs.",
         ],
         example: {
           language: "ts",
@@ -132,10 +133,10 @@ const response = await api.fetch({
         name: "server",
         signature: `server(handler): ServerHandler<TContext, TResult> & { __litzServer?: true }`,
         summary:
-          "Marks a route or resource handler as server-only without changing its runtime behavior.",
+          "Marks a route or resource handler for the framework while preserving its normal callable shape.",
         details: [
-          "Use it around loaders and actions so the bundler can keep that logic on the server side.",
-          "The returned function is still the same callable handler shape; the marker is metadata for the framework.",
+          "Use it around loaders and actions so Litz can treat that function as an explicit server handler during build and runtime wiring.",
+          "The returned value is the same callable handler with lightweight marker metadata attached; it is not a sandbox or security boundary by itself.",
         ],
       },
     ],
@@ -674,7 +675,10 @@ function SaveFiltersButton() {
   fetch(options?: ApiFetchOptions<TPath, TMethods>): Promise<Response>;
 };`,
         summary: "Returned API route object with typed handlers and a fetch helper.",
-        details: ["When the API path contains params, the `options.params` object is required."],
+        details: [
+          "When the API path contains params, the `options.params` object is required.",
+          "Pass `baseUrl` for server-side or test callers that cannot use relative fetch URLs.",
+        ],
       },
       {
         name: "LitzResource",
@@ -865,11 +869,15 @@ export const route = defineRoute("/posts/:id", {
         signature: `type ApiFetchOptions<TPath, TMethods> = Omit<RequestInit, "method"> & {
     params?: PathParams<TPath>;
     search?: URLSearchParams | SearchParamRecord;
+    baseUrl?: string | URL;
     method?: ApiFetchMethod<TMethods>;
   };`,
         summary:
           "Options accepted by `api.fetch(...)`, including typed path params and allowed methods.",
-        details: ["`method` is limited to the declared method keys, excluding `ALL`."],
+        details: [
+          "`method` is limited to the declared method keys, excluding `ALL`.",
+          "Adds an absolute base URL for server-side or test callers that need one.",
+        ],
       },
       {
         name: "RouteServerHandler",
@@ -883,8 +891,9 @@ export const route = defineRoute("/posts/:id", {
       },
       {
         name: "ServerHandler",
-        signature: `type ServerHandler<TContext = unknown, TResult extends ServerResult = ServerResult> = RouteServerHandler<TContext, TResult> | ResourceServerHandler<TContext, TResult>;`,
-        summary: "Union of route and resource server handler signatures.",
+        signature: `type ServerHandler<TContext = unknown, TResult extends ServerResult = ServerResult> = (RouteServerHandler<TContext, TResult> | ResourceServerHandler<TContext, TResult>) & { __litzServer?: true };`,
+        summary:
+          "Union of route and resource server handler signatures plus optional framework marker metadata.",
       },
     ],
   },

--- a/www/src/routes/docs/api-routes.tsx
+++ b/www/src/routes/docs/api-routes.tsx
@@ -82,7 +82,12 @@ const data = await response.json();`}
         />
         <p className="text-neutral-400 mt-4 mb-4">
           <code className="text-sky-400">{"api.fetch(...)"}</code> accepts route params, search
-          params, headers, and an HTTP method when needed.
+          params, headers, an optional <code className="text-sky-400">baseUrl</code>, and an HTTP
+          method when needed.
+        </p>
+        <p className="text-neutral-400 mb-4">
+          In browser code the helper can use relative URLs. In server-side code or tests, pass{" "}
+          <code className="text-sky-400">baseUrl</code> when your runtime requires an absolute URL.
         </p>
       </section>
 

--- a/www/src/routes/docs/api-routes.tsx
+++ b/www/src/routes/docs/api-routes.tsx
@@ -88,6 +88,7 @@ const data = await response.json();`}
         <p className="text-neutral-400 mb-4">
           In browser code the helper can use relative URLs. In server-side code or tests, pass{" "}
           <code className="text-sky-400">baseUrl</code> when your runtime requires an absolute URL.
+          If that base includes a path prefix, Litz preserves it when resolving the request.
         </p>
       </section>
 

--- a/www/src/routes/docs/first-app.tsx
+++ b/www/src/routes/docs/first-app.tsx
@@ -47,8 +47,13 @@ bun init -y`}
         <CodeBlock
           language="bash"
           code={`bun add litzjs react react-dom
-bun add -d typescript vite @vitejs/plugin-rsc @types/react @types/react-dom`}
+bun add -d typescript vite @vitejs/plugin-rsc nitro @types/react @types/react-dom`}
         />
+        <p className="text-neutral-400 mt-4 mb-4">
+          <code className="text-sky-400">nitro</code> is part of the required peer dependency
+          surface for the current Vite-first build pipeline, even if your app code never imports it
+          directly.
+        </p>
       </section>
 
       <section className="mb-12">

--- a/www/src/routes/docs/installation.tsx
+++ b/www/src/routes/docs/installation.tsx
@@ -35,6 +35,12 @@ const compatibilityRows: readonly CompatibilityRow[] = [
     supportedVersion: "^0.5.21",
     notes: "Required peer dependency for the React Server Components pipeline.",
   },
+  {
+    packageName: "nitro",
+    supportedVersion: "^3",
+    notes:
+      "Required peer dependency for the production server build pipeline and the optional Nitro integration export.",
+  },
 ];
 
 export const route = defineRoute("/docs/installation", {
@@ -78,19 +84,19 @@ function DocsInstallationPage() {
           language="bash"
           code={`# With Bun
 bun add react react-dom
-bun add -d typescript vite @vitejs/plugin-rsc
+bun add -d typescript vite @vitejs/plugin-rsc nitro
 
 # With npm
 npm install react react-dom
-npm install -D typescript vite @vitejs/plugin-rsc
+npm install -D typescript vite @vitejs/plugin-rsc nitro
 
 # With Yarn
 yarn add react react-dom
-yarn add -D typescript vite @vitejs/plugin-rsc
+yarn add -D typescript vite @vitejs/plugin-rsc nitro
 
 # With pnpm
 pnpm add react react-dom
-pnpm add -D typescript vite @vitejs/plugin-rsc`}
+pnpm add -D typescript vite @vitejs/plugin-rsc nitro`}
         />
         <ul className="text-neutral-400 space-y-1 list-disc list-inside mt-4 mb-4">
           <li>
@@ -100,7 +106,8 @@ pnpm add -D typescript vite @vitejs/plugin-rsc`}
           <li>
             Install <code className="text-sky-400">typescript</code>,{" "}
             <code className="text-sky-400">vite</code>, and{" "}
-            <code className="text-sky-400">@vitejs/plugin-rsc</code> as development tooling.
+            <code className="text-sky-400">@vitejs/plugin-rsc</code>, and{" "}
+            <code className="text-sky-400">nitro</code> as development tooling.
           </li>
           <li>
             Treat all five packages as required peers even if your starter template already added


### PR DESCRIPTION
## Summary

This PR addresses issue #105 by tightening the setup/docs/API surface where the current consumer story was inconsistent.

Changes in scope:
- document `nitro` consistently as part of the required peer dependency surface
- add a `baseUrl` escape hatch to `defineApiRoute().fetch()` for server-side and test callers
- make `server(...)` attach lightweight marker metadata so the public contract matches the implementation more closely
- allow `invalid()` to omit its options object so the API reference is copy-paste correct

Out of scope:
- `create-litz`
- dedicated runtime adapter packages
- stronger route ergonomics / app-level URL abstractions
- metadata/head/document primitives

Closes #105.

## Implementation details

### API surface

- Extended `ApiFetchOptions` with `baseUrl?: string | URL`
- Updated `defineApiRoute().fetch()` to resolve absolute URLs when `baseUrl` is provided
- Updated `server(...)` to attach `__litzServer: true` marker metadata while preserving callability
- Updated `invalid()` to default its options object to `{}` for zero-argument usage

### Docs

- Updated the README installation section to include the full peer dependency surface, including `nitro`
- Updated the website installation and first-app guides to include `nitro`
- Clarified `api.fetch(...)` usage in the API routes docs and API reference
- Tightened `server(...)` wording in the API reference so it no longer implies stronger isolation semantics than the implementation provides

### Tests

- Added `api.fetch()` coverage for explicit `baseUrl`
- Added regression coverage for `invalid()` without options
- Added regression coverage for `server(...)` marker metadata
- Updated docs assertions for the peer dependency matrix and API reference copy

## Verification

- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun test`
