### PR TITLE
fix: move Nitro Vite pipeline behind adapter

### DIFF
--- a/.changeset/remove-core-nitro-pipeline.md
+++ b/.changeset/remove-core-nitro-pipeline.md
@@ -1,0 +1,5 @@
+---
+"litzjs": minor
+---
+
+Move Nitro production output behind the explicit `litzNitro()` adapter exported from `litzjs/vite/nitro`, leaving the core `litz()` Vite plugin free of the required Nitro plugin path.

--- a/README.md
+++ b/README.md
@@ -24,12 +24,11 @@ Inside a React + Vite app:
 
 ```bash
 bun add litzjs react react-dom
-bun add -d typescript vite @vitejs/plugin-rsc nitro
+bun add -d typescript vite @vitejs/plugin-rsc
 ```
 
-Litz currently expects the full peer dependency surface above. `nitro` is required for the
-current Vite-first production build pipeline even if your application code does not import it
-directly.
+The core Vite plugin does not require a deployment adapter. Install `nitro` only when you opt into
+the Nitro-backed production output shown below.
 
 ## Quick Start
 
@@ -922,7 +921,8 @@ The Vite plugin injects the discovered server manifest automatically into that e
 
 ### Production Output
 
-When you run `vite build`, Litz writes the browser assets to `.output/public`.
+When you run `vite build` with the optional Nitro adapter, Litz writes the browser assets to
+`.output/public`.
 
 Server output is always `.output/server/index.mjs`. The Vite plugin injects the discovered server
 manifest into `createServer(...)` automatically.
@@ -937,10 +937,14 @@ explicitly in `vite.config.ts`:
 ```ts
 import { defineConfig } from "vite";
 import { litz } from "litzjs/vite";
+import { litzNitro } from "litzjs/vite/nitro";
 
 export default defineConfig({
   plugins: [
     litz({
+      server: "app/server/entry.ts",
+    }),
+    litzNitro({
       server: "app/server/entry.ts",
     }),
   ],

--- a/fixtures/rsc-smoke/vite.config.ts
+++ b/fixtures/rsc-smoke/vite.config.ts
@@ -2,13 +2,14 @@ import path from "node:path";
 import { defineConfig } from "vite";
 
 import { litz } from "../../src/vite";
+import { litzNitro } from "../../src/vite-nitro";
 
 const rootDir = __dirname;
 const packageRoot = path.resolve(__dirname, "../..");
 
 export default defineConfig({
   root: rootDir,
-  plugins: [litz()],
+  plugins: [litz(), litzNitro()],
   resolve: {
     alias: [
       {
@@ -22,6 +23,10 @@ export default defineConfig({
       {
         find: /^litzjs\/vite$/,
         replacement: path.resolve(packageRoot, "src/vite.ts"),
+      },
+      {
+        find: /^litzjs\/vite\/nitro$/,
+        replacement: path.resolve(packageRoot, "src/vite-nitro.ts"),
       },
       {
         find: /^litzjs$/,

--- a/package.json
+++ b/package.json
@@ -48,6 +48,11 @@
       "types": "./dist/vite.d.ts",
       "import": "./dist/vite.mjs",
       "require": "./dist/vite.js"
+    },
+    "./vite/nitro": {
+      "types": "./dist/vite-nitro.d.ts",
+      "import": "./dist/vite-nitro.mjs",
+      "require": "./dist/vite-nitro.js"
     }
   },
   "publishConfig": {
@@ -98,5 +103,10 @@
     "react-dom": "^19",
     "typescript": "^6.0.2",
     "vite": "^8"
+  },
+  "peerDependenciesMeta": {
+    "nitro": {
+      "optional": true
+    }
   }
 }

--- a/src/vite-nitro.ts
+++ b/src/vite-nitro.ts
@@ -98,6 +98,16 @@ export function litzNitro(options: LitzNitroPluginOptions = {}): PluginOption {
       finalNitroOutDir = path.resolve(root, ".output");
 
       const serverEntryPath = await discoverServerEntry(root, options.server);
+
+      if (serverEntryPath === null) {
+        throw new Error(
+          [
+            "litzNitro() could not find a server entry for the Nitro renderer.",
+            'Create src/server.ts or src/server/index.ts, or pass the same custom server path to litzNitro({ server: "..." }) that you pass to litz({ server: "..." }).',
+          ].join(" "),
+        );
+      }
+
       writeNitroRendererSync(root, serverEntryPath);
     },
 

--- a/src/vite-nitro.ts
+++ b/src/vite-nitro.ts
@@ -1,0 +1,223 @@
+import type { Plugin, PluginOption } from "vite";
+
+import { nitro as nitroVitePlugin } from "nitro/vite";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+import type { LitzRouteRule } from "./vite";
+
+import { normalizeBasePath, resolveBasePathname } from "./base-path";
+import { discoverServerEntry } from "./vite";
+
+export interface LitzNitroPluginOptions {
+  /** Path to a custom server entry file. Defaults to `src/server.ts` or `src/server/index.ts`. */
+  readonly server?: string;
+  /**
+   * Deployment preset. Determines the server output format and runtime
+   * adapter (e.g. `"node-server"`, `"cloudflare-pages"`, `"vercel"`).
+   */
+  readonly preset?: string;
+  /**
+   * Per-route rules for caching, headers, redirects, pre-rendering, and
+   * proxying. Keys are path patterns (e.g. `"/api/**"`).
+   */
+  readonly routeRules?: Readonly<Record<string, LitzRouteRule>>;
+  /**
+   * Compress static assets with gzip, brotli, or zstd. Pass `true` to
+   * enable all supported algorithms, or an object to pick individually.
+   */
+  readonly compressPublicAssets?:
+    | boolean
+    | {
+        readonly gzip?: boolean;
+        readonly brotli?: boolean;
+        readonly zstd?: boolean;
+      };
+  /** Base URL path for the application (e.g. `"/app/"`). */
+  readonly baseURL?: string;
+  /** Generate source maps for the server build. */
+  readonly sourcemap?: boolean;
+  /** Minify the server build output. */
+  readonly minify?: boolean;
+}
+
+const LITZ_NITRO_RENDERER_FILENAME = "nitro-renderer.ts";
+
+export function litzNitro(options: LitzNitroPluginOptions = {}): PluginOption {
+  let root = process.cwd();
+  let configuredBase = "/";
+  let intermediateBuildOutDir = path.resolve(root, "dist");
+  let finalNitroOutDir = path.resolve(root, ".output");
+
+  // Nitro resolves its renderer during its config hook, before Vite config is
+  // fully resolved, so the file must exist before constructing Nitro plugins.
+  writeNitroRendererSync(root, null);
+
+  const nitroPlugins = nitroVitePlugin({
+    scanDirs: [],
+    renderer: {
+      handler: path.resolve(root, ".litzjs", LITZ_NITRO_RENDERER_FILENAME),
+    },
+    preset: options.preset,
+    // LitzRouteRule is intentionally a framework-agnostic subset of Nitro's
+    // NitroRouteConfig. The types are structurally compatible at runtime.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    routeRules: options.routeRules as any,
+    compressPublicAssets: options.compressPublicAssets,
+    baseURL: options.baseURL,
+    sourcemap: options.sourcemap,
+    minify: options.minify,
+  });
+
+  // Prevent Nitro from hijacking the RSC-managed environments. Nitro's
+  // `nitro:env` plugin auto-detects any environment with a build entry and
+  // replaces its `createEnvironment` with a `FetchableDevEnvironment`, which
+  // removes the module runner that the RSC plugin (and Litz's dev handlers)
+  // rely on. We wrap that hook so it returns early for `rsc` and `ssr`.
+  const rscManagedEnvironments = new Set(["rsc", "ssr"]);
+
+  for (const plugin of nitroPlugins) {
+    if (plugin.name === "nitro:env" && typeof plugin.configEnvironment === "function") {
+      const original = plugin.configEnvironment;
+      plugin.configEnvironment = function (name, ...args) {
+        if (rscManagedEnvironments.has(name)) return;
+        return original.call(this, name, ...args);
+      };
+      break;
+    }
+  }
+
+  const litzNitroPlugin: Plugin = {
+    name: "litzjs/nitro",
+    sharedDuringBuild: true,
+
+    async configResolved(config) {
+      root = config.root;
+      configuredBase = normalizeBasePath(config.base);
+      intermediateBuildOutDir = path.resolve(root, config.build.outDir || "dist");
+      finalNitroOutDir = path.resolve(root, ".output");
+
+      const serverEntryPath = await discoverServerEntry(root, options.server);
+      writeNitroRendererSync(root, serverEntryPath);
+    },
+
+    configureServer(server) {
+      // Mark Litz internal requests so Nitro's dev middleware skips them.
+      // Nitro's `nitroDevMiddlewarePre` checks `req._nitroHandled` and calls
+      // `next()` when set, letting the core Litz plugin process the request.
+      server.middlewares.use((request, _response, next) => {
+        const requestUrl = request.url ? new URL(request.url, "http://litzjs.local") : null;
+        const pathname = requestUrl
+          ? resolveBasePathname(requestUrl.pathname, configuredBase)
+          : "/";
+
+        if (pathname.startsWith("/_litzjs/")) {
+          (request as unknown as Record<string, unknown>)._nitroHandled = true;
+        }
+        next();
+      });
+    },
+  };
+
+  const cleanupPlugin: Plugin = {
+    name: "litzjs/nitro-cleanup",
+    sharedDuringBuild: true,
+    buildApp: {
+      order: "post",
+      async handler() {
+        cleanupIntermediateBuildArtifacts(root, intermediateBuildOutDir, finalNitroOutDir);
+      },
+    },
+  };
+
+  return [litzNitroPlugin, ...nitroPlugins, cleanupPlugin] as Plugin[];
+}
+
+function hasCompletedNitroBuild(nitroOutDir: string): boolean {
+  return (
+    existsSync(path.join(nitroOutDir, "nitro.json")) &&
+    existsSync(path.join(nitroOutDir, "public")) &&
+    existsSync(path.join(nitroOutDir, "server"))
+  );
+}
+
+function shouldRemoveIntermediateBuildArtifacts(
+  root: string,
+  intermediateBuildOutDir: string,
+  nitroOutDir: string,
+): boolean {
+  if (!existsSync(intermediateBuildOutDir)) {
+    return false;
+  }
+
+  if (intermediateBuildOutDir === root || intermediateBuildOutDir === nitroOutDir) {
+    return false;
+  }
+
+  const relativeToRoot = path.relative(root, intermediateBuildOutDir);
+
+  if (!relativeToRoot || relativeToRoot.startsWith("..") || path.isAbsolute(relativeToRoot)) {
+    return false;
+  }
+
+  const relativeToNitroOutDir = path.relative(nitroOutDir, intermediateBuildOutDir);
+
+  return relativeToNitroOutDir.startsWith("..") || path.isAbsolute(relativeToNitroOutDir);
+}
+
+function cleanupIntermediateBuildArtifacts(
+  root: string,
+  intermediateBuildOutDir: string,
+  nitroOutDir: string,
+): void {
+  if (!hasCompletedNitroBuild(nitroOutDir)) {
+    return;
+  }
+
+  if (!shouldRemoveIntermediateBuildArtifacts(root, intermediateBuildOutDir, nitroOutDir)) {
+    return;
+  }
+
+  rmSync(intermediateBuildOutDir, { force: true, recursive: true });
+}
+
+// Writes a physical `.ts` file that Nitro can resolve during its `config` hook.
+function writeNitroRendererSync(root: string, serverEntryPath: string | null): void {
+  const litzjsDir = path.resolve(root, ".litzjs");
+
+  mkdirSync(litzjsDir, { recursive: true });
+
+  const rendererPath = path.resolve(litzjsDir, LITZ_NITRO_RENDERER_FILENAME);
+
+  if (serverEntryPath === null) {
+    writeFileSync(
+      rendererPath,
+      [
+        "// Placeholder - replaced once the server entry is discovered.",
+        'import { defineHandler } from "nitro/h3";',
+        "",
+        "export default defineHandler(() => new Response('Not ready', { status: 503 }));",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    return;
+  }
+
+  const serverImportPath = path.resolve(root, serverEntryPath).replaceAll("\\", "/");
+
+  writeFileSync(
+    rendererPath,
+    [
+      "// Auto-generated by litzjs - do not edit.",
+      'import { defineHandler } from "nitro/h3";',
+      `import server from "${serverImportPath}";`,
+      "",
+      "export default defineHandler(async (event) => {",
+      "  return server.fetch(event.req);",
+      "});",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+}

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -11,8 +11,6 @@ import type { TLSSocket } from "node:tls";
 import type { Connect, InlineConfig, Plugin, PluginOption, ViteDevServer } from "vite";
 
 import vitePluginRsc from "@vitejs/plugin-rsc";
-import { nitro as nitroVitePlugin } from "nitro/vite";
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import picomatch from "picomatch";
@@ -83,33 +81,6 @@ export interface LitzPluginOptions {
   readonly server?: string;
   /** Options forwarded to `@vitejs/plugin-rsc`. */
   readonly rsc?: Omit<RscPluginOptions, "entries" | "serverHandler">;
-  /**
-   * Deployment preset. Determines the server output format and runtime
-   * adapter (e.g. `"node-server"`, `"cloudflare-pages"`, `"vercel"`).
-   */
-  readonly preset?: string;
-  /**
-   * Per-route rules for caching, headers, redirects, pre-rendering, and
-   * proxying. Keys are path patterns (e.g. `"/api/**"`).
-   */
-  readonly routeRules?: Readonly<Record<string, LitzRouteRule>>;
-  /**
-   * Compress static assets with gzip, brotli, or zstd. Pass `true` to
-   * enable all supported algorithms, or an object to pick individually.
-   */
-  readonly compressPublicAssets?:
-    | boolean
-    | {
-        readonly gzip?: boolean;
-        readonly brotli?: boolean;
-        readonly zstd?: boolean;
-      };
-  /** Base URL path for the application (e.g. `"/app/"`). */
-  readonly baseURL?: string;
-  /** Generate source maps for the server build. */
-  readonly sourcemap?: boolean;
-  /** Minify the server build output. */
-  readonly minify?: boolean;
 }
 
 type DiscoveredRoute = {
@@ -161,7 +132,6 @@ const LITZ_BROWSER_ENTRY_ID = "virtual:litzjs:browser-entry";
 const RESOLVED_LITZ_BROWSER_ENTRY_ID = "\0virtual:litzjs:browser-entry";
 const LITZ_RSC_RENDERER_ID = "virtual:litzjs:rsc-renderer";
 const RESOLVED_LITZ_RSC_RENDERER_ID = "\0virtual:litzjs:rsc-renderer";
-const LITZ_NITRO_RENDERER_FILENAME = "nitro-renderer.ts";
 
 /**
  * Creates the Litz Vite plugin array. Returns the `@vitejs/plugin-rsc` plugins
@@ -175,8 +145,6 @@ export function litz(options: LitzPluginOptions = {}): PluginOption {
   let htmlEntries: HtmlEntryInfo[] = [];
   let serverEntryPath: string | null = null;
   let serverEntryFilePath: string | null = null;
-  let intermediateBuildOutDir = path.resolve(root, "dist");
-  let finalNitroOutDir = path.resolve(root, ".output");
   let routeManifest: DiscoveredRoute[] = [];
   let layoutManifest: DiscoveredLayout[] = [];
   let resourceManifest: DiscoveredResource[] = [];
@@ -189,10 +157,6 @@ export function litz(options: LitzPluginOptions = {}): PluginOption {
   ];
   const resourcePatterns = options.resources ?? ["src/routes/resources/**/*.{ts,tsx,js,jsx}"];
   const apiPatterns = options.api ?? ["src/routes/api/**/*.{ts,tsx,js,jsx}"];
-  // Write a placeholder Nitro renderer file so the nitro plugin can resolve
-  // it during its `config` hook. The file is re-written in `configResolved`
-  // once the actual server entry path is known.
-  writeNitroRendererSync(root, null);
   const rscPlugins = vitePluginRsc({
     ...options.rsc,
     entries: {
@@ -225,17 +189,11 @@ export function litz(options: LitzPluginOptions = {}): PluginOption {
     async configResolved(config) {
       root = config.root;
       configuredBase = normalizeBasePath(config.base);
-      intermediateBuildOutDir = path.resolve(root, config.build.outDir || "dist");
-      finalNitroOutDir = path.resolve(root, ".output");
 
       htmlEntries = await discoverHtmlEntries(root, config.build.outDir || "dist");
       browserEntryPath = resolveBrowserEntryPath(htmlEntries);
       serverEntryPath = await discoverServerEntry(root, options.server);
       serverEntryFilePath = serverEntryPath ? path.resolve(root, serverEntryPath) : null;
-
-      // Re-write with the actual server entry path now that it has been
-      // discovered.
-      writeNitroRendererSync(root, serverEntryPath);
 
       ({ routeManifest, layoutManifest, resourceManifest, apiManifest } =
         await discoverAllManifests(root, routePatterns, resourcePatterns, apiPatterns));
@@ -588,20 +546,6 @@ export async function renderView(node, metadata = {}) {
       server.watcher.on("change", onFileChange);
       server.watcher.on("unlink", onFileAddOrUnlink);
 
-      // Mark Litz internal requests so Nitro's dev middleware skips them.
-      // Nitro's `nitroDevMiddlewarePre` checks `req._nitroHandled` and calls
-      // `next()` when set, letting our handlers below process the request.
-      server.middlewares.use((request, _response, next) => {
-        const requestUrl = request.url ? new URL(request.url, "http://litzjs.local") : null;
-        const pathname = requestUrl
-          ? resolveBasePathname(requestUrl.pathname, configuredBase)
-          : "/";
-
-        if (pathname.startsWith("/_litzjs/")) {
-          (request as unknown as Record<string, unknown>)._nitroHandled = true;
-        }
-        next();
-      });
       server.middlewares.use((request, response, next) => {
         void handleLitzResourceRequest(
           server,
@@ -689,56 +633,11 @@ export async function renderView(node, metadata = {}) {
     },
   };
 
-  const nitroPlugins = nitroVitePlugin({
-    scanDirs: [],
-    renderer: {
-      handler: path.resolve(root, ".litzjs", LITZ_NITRO_RENDERER_FILENAME),
-    },
-    preset: options.preset,
-    // LitzRouteRule is intentionally a framework-agnostic subset of Nitro's
-    // NitroRouteConfig. The types are structurally compatible at runtime.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    routeRules: options.routeRules as any,
-    compressPublicAssets: options.compressPublicAssets,
-    baseURL: options.baseURL,
-    sourcemap: options.sourcemap,
-    minify: options.minify,
-  });
-
-  // Prevent Nitro from hijacking the RSC-managed environments. Nitro's
-  // `nitro:env` plugin auto-detects any environment with a build entry and
-  // replaces its `createEnvironment` with a `FetchableDevEnvironment`, which
-  // removes the module runner that the RSC plugin (and Litz's dev handlers)
-  // rely on. We wrap that hook so it returns early for `rsc` and `ssr`.
-  const rscManagedEnvironments = new Set(["rsc", "ssr"]);
-
-  for (const plugin of nitroPlugins) {
-    if (plugin.name === "nitro:env" && typeof plugin.configEnvironment === "function") {
-      const original = plugin.configEnvironment;
-      plugin.configEnvironment = function (name, ...args) {
-        if (rscManagedEnvironments.has(name)) return;
-        return original.call(this, name, ...args);
-      };
-      break;
-    }
-  }
-
-  const cleanupPlugin: Plugin = {
-    name: "litzjs/build-cleanup",
-    sharedDuringBuild: true,
-    buildApp: {
-      order: "post",
-      async handler() {
-        cleanupIntermediateBuildArtifacts(root, intermediateBuildOutDir, finalNitroOutDir);
-      },
-    },
-  };
-
   // The explicit cast prevents a "Plugin<any>[]" leak caused by Nitro's
   // module augmentation that adds a generic parameter to Vite's Plugin
   // interface, which triggers an "excessive stack depth" error when
   // consumers pass the result into `defineConfig({ plugins: [litz()] })`.
-  return [...rscPlugins, litzPlugin, ...nitroPlugins, cleanupPlugin] as Plugin[];
+  return [...rscPlugins, litzPlugin] as Plugin[];
 }
 
 export async function buildLitzApp(inlineConfig: InlineConfig = {}): Promise<void> {
@@ -1655,54 +1554,6 @@ function toBrowserImportSpecifier(root: string, relativeModulePath: string, base
 
 function toProjectImportSpecifier(relativeModulePath: string): string {
   return `/${relativeModulePath}`;
-}
-
-function hasCompletedNitroBuild(nitroOutDir: string): boolean {
-  return (
-    existsSync(path.join(nitroOutDir, "nitro.json")) &&
-    existsSync(path.join(nitroOutDir, "public")) &&
-    existsSync(path.join(nitroOutDir, "server"))
-  );
-}
-
-function shouldRemoveIntermediateBuildArtifacts(
-  root: string,
-  intermediateBuildOutDir: string,
-  nitroOutDir: string,
-): boolean {
-  if (!existsSync(intermediateBuildOutDir)) {
-    return false;
-  }
-
-  if (intermediateBuildOutDir === root || intermediateBuildOutDir === nitroOutDir) {
-    return false;
-  }
-
-  const relativeToRoot = path.relative(root, intermediateBuildOutDir);
-
-  if (!relativeToRoot || relativeToRoot.startsWith("..") || path.isAbsolute(relativeToRoot)) {
-    return false;
-  }
-
-  const relativeToNitroOutDir = path.relative(nitroOutDir, intermediateBuildOutDir);
-
-  return relativeToNitroOutDir.startsWith("..") || path.isAbsolute(relativeToNitroOutDir);
-}
-
-function cleanupIntermediateBuildArtifacts(
-  root: string,
-  intermediateBuildOutDir: string,
-  nitroOutDir: string,
-): void {
-  if (!hasCompletedNitroBuild(nitroOutDir)) {
-    return;
-  }
-
-  if (!shouldRemoveIntermediateBuildArtifacts(root, intermediateBuildOutDir, nitroOutDir)) {
-    return;
-  }
-
-  rmSync(intermediateBuildOutDir, { force: true, recursive: true });
 }
 
 // ── Dev Server Request Handlers ──────────────────────────────────────────────
@@ -2940,56 +2791,4 @@ async function runDevMiddlewareChain<TContext, TResult>(options: {
   };
 
   return dispatch(0, options.context);
-}
-
-// ── Nitro Renderer ───────────────────────────────────────────────────────────
-// Writes a physical `.ts` file that Nitro can resolve during its `config` hook.
-// Nitro uses Node.js module resolution (not Vite's virtual modules), so the
-// renderer must exist on disk.
-
-/**
- * Writes the Nitro renderer entry file to `.litzjs/nitro-renderer.ts`.
- *
- * When `serverEntryPath` is `null` (initial call before discovery), writes a
- * placeholder that exports a no-op handler. Once the server entry is known,
- * re-writes with the actual import so Nitro delegates to the Litz server.
- */
-function writeNitroRendererSync(root: string, serverEntryPath: string | null): void {
-  const litzjsDir = path.resolve(root, ".litzjs");
-
-  mkdirSync(litzjsDir, { recursive: true });
-
-  const rendererPath = path.resolve(litzjsDir, LITZ_NITRO_RENDERER_FILENAME);
-
-  if (serverEntryPath === null) {
-    writeFileSync(
-      rendererPath,
-      [
-        "// Placeholder — replaced once the server entry is discovered.",
-        'import { defineHandler } from "nitro/h3";',
-        "",
-        "export default defineHandler(() => new Response('Not ready', { status: 503 }));",
-        "",
-      ].join("\n"),
-      "utf8",
-    );
-    return;
-  }
-
-  const serverImportPath = path.resolve(root, serverEntryPath).replaceAll("\\", "/");
-
-  writeFileSync(
-    rendererPath,
-    [
-      "// Auto-generated by litzjs — do not edit.",
-      'import { defineHandler } from "nitro/h3";',
-      `import server from "${serverImportPath}";`,
-      "",
-      "export default defineHandler(async (event) => {",
-      "  return server.fetch(event.req);",
-      "});",
-      "",
-    ].join("\n"),
-    "utf8",
-  );
 }

--- a/tests/docs-package-names.test.ts
+++ b/tests/docs-package-names.test.ts
@@ -80,8 +80,11 @@ describe("docs package names", () => {
     expect(installationDoc).toContain("bun add -d typescript vite @vitejs/plugin-rsc");
     expect(installationDoc).toContain("bun add -d nitro");
     expect(installationDoc).toContain("npm install -D typescript vite @vitejs/plugin-rsc");
+    expect(installationDoc).toContain("npm install -D nitro");
     expect(installationDoc).toContain("yarn add -D typescript vite @vitejs/plugin-rsc");
+    expect(installationDoc).toContain("yarn add -D nitro");
     expect(installationDoc).toContain("pnpm add -D typescript vite @vitejs/plugin-rsc");
+    expect(installationDoc).toContain("pnpm add -D nitro");
 
     expect(installationDoc).toContain("Compatibility matrix");
     expect(installationDoc).toContain('packageName: "react"');

--- a/tests/docs-package-names.test.ts
+++ b/tests/docs-package-names.test.ts
@@ -39,7 +39,7 @@ describe("getting started docs flow", () => {
     expect(firstAppDoc).toContain('defineRoute("/docs/first-app"');
     expect(firstAppDoc).toContain("mkdir hello-litz");
     expect(firstAppDoc).toContain("bun add litzjs react react-dom");
-    expect(firstAppDoc).toContain("bun add -d typescript vite @vitejs/plugin-rsc nitro");
+    expect(firstAppDoc).toContain("bun add -d typescript vite @vitejs/plugin-rsc");
     expect(firstAppDoc).toContain('import { litz } from "litzjs/vite";');
     expect(firstAppDoc).toContain(
       'Open <code className="text-sky-400">http://localhost:5173</code>.',
@@ -69,7 +69,7 @@ describe("docs package names", () => {
     expect(installationDoc).not.toMatch(/pnpm add litz(?!js)/);
   });
 
-  test("installation docs list the full peer dependency surface and compatibility matrix", () => {
+  test("installation docs list the core peer dependency surface and optional Nitro adapter", () => {
     const installationDoc = normalizeWhitespace(readDoc("www/src/routes/docs/installation.tsx"));
 
     expect(installationDoc).toContain("bun add react react-dom");
@@ -78,7 +78,7 @@ describe("docs package names", () => {
     expect(installationDoc).toContain("pnpm add react react-dom");
 
     expect(installationDoc).toContain("bun add -d typescript vite @vitejs/plugin-rsc");
-    expect(installationDoc).toContain("nitro");
+    expect(installationDoc).toContain("bun add -d nitro");
     expect(installationDoc).toContain("npm install -D typescript vite @vitejs/plugin-rsc");
     expect(installationDoc).toContain("yarn add -D typescript vite @vitejs/plugin-rsc");
     expect(installationDoc).toContain("pnpm add -D typescript vite @vitejs/plugin-rsc");
@@ -232,8 +232,10 @@ describe("docs package names", () => {
     const viteExports = [
       "buildLitzApp",
       "LitzPluginOptions",
+      "LitzNitroPluginOptions",
       "cleanupRscPluginArtifacts",
       "litz",
+      "litzNitro",
       "transformServerModuleSource",
     ];
 

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -32,6 +32,7 @@ import {
   handleLitzRouteRequest,
   litz,
 } from "../src/vite";
+import { litzNitro } from "../src/vite-nitro";
 
 describe("vite production server helpers", () => {
   test("build completes without warnings", () => {
@@ -81,6 +82,13 @@ describe("vite production server helpers", () => {
     }
   });
 
+  test("keeps Nitro out of the core litz plugin path", () => {
+    const plugins = litz() as Plugin[];
+
+    expect(plugins.some((plugin) => plugin.name.startsWith("nitro"))).toBe(false);
+    expect(plugins.some((plugin) => plugin.name === "litzjs/nitro")).toBe(false);
+  });
+
   test("normalizes generated Nitro renderer import paths before embedding them", async () => {
     const previousCwd = process.cwd();
     const projectRoot = mkdtempSync(path.join(tmpdir(), "litz\\nitro-workspace-"));
@@ -92,10 +100,12 @@ describe("vite production server helpers", () => {
       writeFileSync(path.join(projectRoot, "src", "server.ts"), "export default null;\n", "utf8");
       process.chdir(projectRoot);
 
-      const plugin = (litz() as Plugin[]).find((candidate) => candidate.name === "litzjs/vite");
+      const plugin = (litzNitro() as Plugin[]).find(
+        (candidate) => candidate.name === "litzjs/nitro",
+      );
 
       if (!plugin?.configResolved) {
-        throw new Error("Expected litzjs/vite configResolved hook to be available.");
+        throw new Error("Expected litzjs/nitro configResolved hook to be available.");
       }
 
       const configResolved =

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -155,6 +155,52 @@ describe("vite production server helpers", () => {
     }
   });
 
+  test("fails fast when litzNitro cannot discover a server entry", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "litz-nitro-missing-server-"));
+
+    try {
+      mkdirSync(path.join(root, "app", "server"), { recursive: true });
+      writeFileSync(path.join(root, "app", "server", "entry.ts"), "export default null;\n", "utf8");
+
+      const plugin = (litzNitro() as Plugin[]).find(
+        (candidate) => candidate.name === "litzjs/nitro",
+      );
+
+      if (!plugin?.configResolved) {
+        throw new Error("Expected litzjs/nitro configResolved hook to be available.");
+      }
+
+      const configResolved =
+        typeof plugin.configResolved === "function"
+          ? plugin.configResolved
+          : plugin.configResolved.handler;
+      let error: unknown;
+
+      try {
+        await configResolved.call(
+          {} as never,
+          {
+            root,
+            base: "/",
+            command: "serve",
+            build: {
+              outDir: "dist",
+            },
+            environments: {},
+          } as never,
+        );
+      } catch (caughtError) {
+        error = caughtError;
+      }
+
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain("litzNitro() could not find a server entry");
+      expect((error as Error).message).toContain('litzNitro({ server: "..." })');
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   test("emits route-scoped CSS assets for lazy route entries", () => {
     const repoRoot = process.cwd();
     const sourceFixtureRoot = path.join(repoRoot, "fixtures", "rsc-smoke");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
       "litzjs": ["./src/index.ts"],
       "litzjs/client": ["./src/client/index.ts"],
       "litzjs/server": ["./src/server/index.ts"],
-      "litzjs/vite": ["./src/vite.ts"]
+      "litzjs/vite": ["./src/vite.ts"],
+      "litzjs/vite/nitro": ["./src/vite-nitro.ts"]
     },
     "moduleDetection": "force",
     "isolatedModules": true,

--- a/tsdown.config.mts
+++ b/tsdown.config.mts
@@ -7,6 +7,7 @@ export default defineConfig({
     server: "./src/server/index.ts",
     "server/nitro": "./src/server/nitro.ts",
     vite: "./src/vite.ts",
+    "vite-nitro": "./src/vite-nitro.ts",
   },
   format: ["cjs", "esm"],
   platform: "neutral",

--- a/www/src/routes/docs/api-reference.tsx
+++ b/www/src/routes/docs/api-reference.tsx
@@ -1096,6 +1096,44 @@ await buildLitzApp({
   },
 ];
 
+const viteNitroGroups: readonly ReferenceGroupSpec[] = [
+  {
+    title: "Nitro adapter exports",
+    intro: "Import these from `litzjs/vite/nitro` when you want Nitro-backed production output.",
+    entries: [
+      {
+        name: "LitzNitroPluginOptions",
+        signature: `type LitzNitroPluginOptions = {
+  server?: string;
+  preset?: string;
+  routeRules?: Record<string, LitzRouteRule>;
+  compressPublicAssets?: boolean | { gzip?: boolean; brotli?: boolean; zstd?: boolean };
+  baseURL?: string;
+  sourcemap?: boolean;
+  minify?: boolean;
+};`,
+        summary: "Options accepted by the optional Nitro Vite plugin factory.",
+      },
+      {
+        name: "litzNitro",
+        signature: `litzNitro(options?: LitzNitroPluginOptions): PluginOption`,
+        summary:
+          "Adds the Nitro production adapter without making Nitro part of the core `litz()` plugin path.",
+        example: {
+          language: "ts",
+          code: `import { defineConfig } from "vite";
+import { litz } from "litzjs/vite";
+import { litzNitro } from "litzjs/vite/nitro";
+
+export default defineConfig({
+  plugins: [litz(), litzNitro({ preset: "node-server" })],
+});`,
+        },
+      },
+    ],
+  },
+];
+
 function SignatureBlock({ signature }: { signature: string }) {
   return (
     <pre className="border border-neutral-800 bg-neutral-950/70 p-4 text-sm leading-6 text-sky-200 whitespace-pre-wrap overflow-x-auto mb-4">
@@ -1228,6 +1266,13 @@ function ApiReference() {
         importPath={`"litzjs/vite"`}
         description="Build-time Vite integration and advanced bundling helpers."
         groups={viteGroups}
+      />
+
+      <PackageSection
+        title="litzjs/vite/nitro"
+        importPath={`"litzjs/vite/nitro"`}
+        description="Optional Nitro deployment adapter for Vite production builds."
+        groups={viteNitroGroups}
       />
 
       <div className="flex justify-start pt-8 border-t border-neutral-800">

--- a/www/src/routes/docs/first-app.tsx
+++ b/www/src/routes/docs/first-app.tsx
@@ -47,12 +47,11 @@ bun init -y`}
         <CodeBlock
           language="bash"
           code={`bun add litzjs react react-dom
-bun add -d typescript vite @vitejs/plugin-rsc nitro @types/react @types/react-dom`}
+bun add -d typescript vite @vitejs/plugin-rsc @types/react @types/react-dom`}
         />
         <p className="text-neutral-400 mt-4 mb-4">
-          <code className="text-sky-400">nitro</code> is part of the required peer dependency
-          surface for the current Vite-first build pipeline, even if your app code never imports it
-          directly.
+          Install <code className="text-sky-400">nitro</code> only when you opt into the optional
+          Nitro deployment adapter.
         </p>
       </section>
 

--- a/www/src/routes/docs/installation.tsx
+++ b/www/src/routes/docs/installation.tsx
@@ -38,8 +38,7 @@ const compatibilityRows: readonly CompatibilityRow[] = [
   {
     packageName: "nitro",
     supportedVersion: "^3",
-    notes:
-      "Required peer dependency for the production server build pipeline and the optional Nitro integration export.",
+    notes: "Optional peer dependency for the Nitro deployment adapter.",
   },
 ];
 
@@ -74,29 +73,32 @@ function DocsInstallationPage() {
       </section>
 
       <section className="mb-12">
-        <h2 className="text-2xl font-semibold text-neutral-100 mb-4">Required peer dependencies</h2>
+        <h2 className="text-2xl font-semibold text-neutral-100 mb-4">Peer dependencies</h2>
         <p className="text-neutral-400 mb-4">
-          Litz expects your app to provide the full peer dependency surface below. If your React +
-          Vite app already includes some of these packages, keep them within the supported ranges in
-          the compatibility matrix.
+          Litz expects your app to provide the core peer dependencies below. If your React + Vite
+          app already includes some of these packages, keep them within the supported ranges in the
+          compatibility matrix.
         </p>
         <CodeBlock
           language="bash"
           code={`# With Bun
 bun add react react-dom
-bun add -d typescript vite @vitejs/plugin-rsc nitro
+bun add -d typescript vite @vitejs/plugin-rsc
 
 # With npm
 npm install react react-dom
-npm install -D typescript vite @vitejs/plugin-rsc nitro
+npm install -D typescript vite @vitejs/plugin-rsc
 
 # With Yarn
 yarn add react react-dom
-yarn add -D typescript vite @vitejs/plugin-rsc nitro
+yarn add -D typescript vite @vitejs/plugin-rsc
 
 # With pnpm
 pnpm add react react-dom
-pnpm add -D typescript vite @vitejs/plugin-rsc nitro`}
+pnpm add -D typescript vite @vitejs/plugin-rsc
+
+# Optional Nitro deployment adapter
+bun add -d nitro`}
         />
         <ul className="text-neutral-400 space-y-1 list-disc list-inside mt-4 mb-4">
           <li>
@@ -106,12 +108,11 @@ pnpm add -D typescript vite @vitejs/plugin-rsc nitro`}
           <li>
             Install <code className="text-sky-400">typescript</code>,{" "}
             <code className="text-sky-400">vite</code>, and{" "}
-            <code className="text-sky-400">@vitejs/plugin-rsc</code>, and{" "}
-            <code className="text-sky-400">nitro</code> as development tooling.
+            <code className="text-sky-400">@vitejs/plugin-rsc</code> as development tooling.
           </li>
           <li>
-            Treat all five packages as required peers even if your starter template already added
-            some of them for you.
+            Add <code className="text-sky-400">nitro</code> only when your Vite config uses{" "}
+            <code className="text-sky-400">litzNitro()</code>.
           </li>
         </ul>
 

--- a/www/src/routes/docs/installation.tsx
+++ b/www/src/routes/docs/installation.tsx
@@ -98,7 +98,10 @@ pnpm add react react-dom
 pnpm add -D typescript vite @vitejs/plugin-rsc
 
 # Optional Nitro deployment adapter
-bun add -d nitro`}
+bun add -d nitro
+npm install -D nitro
+yarn add -D nitro
+pnpm add -D nitro`}
         />
         <ul className="text-neutral-400 space-y-1 list-disc list-inside mt-4 mb-4">
           <li>


### PR DESCRIPTION
Closes #107.

## Summary
- Remove the always-on Nitro Vite plugin wiring from the core `litz()` plugin path.
- Add an explicit `litzNitro()` adapter export at `litzjs/vite/nitro` that preserves Nitro renderer generation, RSC environment protection, dev middleware handoff, and post-build cleanup.
- Mark `nitro` as an optional peer dependency and add the new package export/build entry.
- Update README, docs site content, fixture config, tests, and changeset for the minimal core setup plus optional Nitro deployment adapter.

## Verification
- `bun fmt`
- `bun lint:fix`
- `bun typecheck`
- `bun run test`
