### PR TITLE
[codex] Make server manifest wiring explicit

### DIFF
--- a/.changeset/explicit-server-manifest.md
+++ b/.changeset/explicit-server-manifest.md
@@ -1,0 +1,7 @@
+---
+"litzjs": patch
+---
+
+Replace custom server entry manifest injection with explicit manifest wiring.
+
+Custom server entries now import `serverManifest` from `virtual:litzjs:server-manifest` and pass it to `createServer({ manifest: serverManifest })` directly. The Vite plugin still generates a default server entry with explicit manifest wiring when no custom server entry is configured, but it no longer rewrites user server files or rejects indirect `createServer` wrappers.

--- a/.changeset/explicit-server-manifest.md
+++ b/.changeset/explicit-server-manifest.md
@@ -2,6 +2,6 @@
 "litzjs": patch
 ---
 
-Replace custom server entry manifest injection with explicit manifest wiring.
+Replace custom server entry injection with explicit manifest and base wiring.
 
-Custom server entries now import `serverManifest` from `virtual:litzjs:server-manifest` and pass it to `createServer({ manifest: serverManifest })` directly. The Vite plugin still generates a default server entry with explicit manifest wiring when no custom server entry is configured, but it no longer rewrites user server files or rejects indirect `createServer` wrappers.
+Custom server entries now import `serverManifest` from `virtual:litzjs:server-manifest` and `base` from `virtual:litzjs:base`, then pass both to `createServer({ base, manifest: serverManifest })` directly. The Vite plugin still generates a default server entry with explicit manifest and base wiring when no custom server entry is configured, but it no longer rewrites user server files or rejects indirect `createServer` wrappers.

--- a/.changeset/explicit-server-manifest.md
+++ b/.changeset/explicit-server-manifest.md
@@ -1,7 +1,7 @@
 ---
-"litzjs": patch
+"litzjs": major
 ---
 
 Replace custom server entry injection with explicit manifest and base wiring.
 
-Custom server entries now import `serverManifest` from `virtual:litzjs:server-manifest` and `base` from `virtual:litzjs:base`, then pass both to `createServer({ base, manifest: serverManifest })` directly. The Vite plugin still generates a default server entry with explicit manifest and base wiring when no custom server entry is configured, but it no longer rewrites user server files or rejects indirect `createServer` wrappers.
+Custom server entries now import `serverManifest` from `virtual:litzjs:server-manifest` and `base` from `virtual:litzjs:base`, then pass both to `createServer({ base, manifest: serverManifest })` directly. Existing custom server entries must be updated to include those explicit imports; otherwise they will continue to call `createServer` with an empty manifest. The Vite plugin still generates a default server entry with explicit manifest and base wiring when no custom server entry is configured, but it no longer rewrites user server files or rejects indirect `createServer` wrappers.

--- a/fixtures/rsc-smoke/src/server.ts
+++ b/fixtures/rsc-smoke/src/server.ts
@@ -1,6 +1,8 @@
 import { createServer } from "litzjs/server";
+import { serverManifest } from "virtual:litzjs:server-manifest";
 
 export default createServer({
+  manifest: serverManifest,
   onError: (error) => {
     console.error("An error occurred:", error);
   },

--- a/fixtures/rsc-smoke/src/server.ts
+++ b/fixtures/rsc-smoke/src/server.ts
@@ -1,7 +1,9 @@
 import { createServer } from "litzjs/server";
+import { base } from "virtual:litzjs:base";
 import { serverManifest } from "virtual:litzjs:server-manifest";
 
 export default createServer({
+  base,
   manifest: serverManifest,
   onError: (error) => {
     console.error("An error occurred:", error);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -121,11 +121,11 @@ type ApiModule = {
   };
 };
 
-type ServerManifest = {
-  routes?: RouteModule[];
-  resources?: ResourceModule[];
-  apiRoutes?: ApiModule[];
-};
+export interface ServerManifest {
+  readonly routes?: RouteModule[];
+  readonly resources?: ResourceModule[];
+  readonly apiRoutes?: ApiModule[];
+}
 
 let rscRendererPromise:
   | Promise<{

--- a/src/virtual-modules.d.ts
+++ b/src/virtual-modules.d.ts
@@ -26,3 +26,7 @@ declare module "virtual:litzjs:resource-manifest" {
     hasComponent: boolean;
   }>;
 }
+
+declare module "virtual:litzjs:server-manifest" {
+  export const serverManifest: import("litzjs/server").ServerManifest;
+}

--- a/src/virtual-modules.d.ts
+++ b/src/virtual-modules.d.ts
@@ -30,3 +30,7 @@ declare module "virtual:litzjs:resource-manifest" {
 declare module "virtual:litzjs:server-manifest" {
   export const serverManifest: import("litzjs/server").ServerManifest;
 }
+
+declare module "virtual:litzjs:base" {
+  export const base: string;
+}

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -144,7 +144,6 @@ export function litz(options: LitzPluginOptions = {}): PluginOption {
   let browserEntryPath = "src/main.tsx";
   let htmlEntries: HtmlEntryInfo[] = [];
   let serverEntryPath: string | null = null;
-  let serverEntryFilePath: string | null = null;
   let routeManifest: DiscoveredRoute[] = [];
   let layoutManifest: DiscoveredLayout[] = [];
   let resourceManifest: DiscoveredResource[] = [];
@@ -193,7 +192,6 @@ export function litz(options: LitzPluginOptions = {}): PluginOption {
       htmlEntries = await discoverHtmlEntries(root, config.build.outDir || "dist");
       browserEntryPath = resolveBrowserEntryPath(htmlEntries);
       serverEntryPath = await discoverServerEntry(root, options.server);
-      serverEntryFilePath = serverEntryPath ? path.resolve(root, serverEntryPath) : null;
 
       ({ routeManifest, layoutManifest, resourceManifest, apiManifest } =
         await discoverAllManifests(root, routePatterns, resourcePatterns, apiPatterns));
@@ -236,7 +234,7 @@ export function litz(options: LitzPluginOptions = {}): PluginOption {
       return null;
     },
 
-    // Return generated code for each virtual module. The route/resource
+    // Return generated code for each virtual module. The route/resource/server
     // manifests are built from the discovered filesystem entries; the RSC and
     // browser entries wire up the framework's server and client entry points.
     load(id) {
@@ -594,23 +592,6 @@ export async function renderView(node, metadata = {}) {
 
     async transform(code, id) {
       const cleanId = normalizeViteModuleId(id);
-
-      if (
-        this.environment.name === "nitro" &&
-        serverEntryFilePath &&
-        cleanId === serverEntryFilePath
-      ) {
-        const transformed = injectServerManifestIntoServerEntry(cleanId, code, configuredBase);
-
-        if (!transformed) {
-          return null;
-        }
-
-        return {
-          code: transformed,
-          map: null,
-        };
-      }
 
       if (this.environment.name !== "client") {
         return null;
@@ -1262,188 +1243,6 @@ function createClientProjectedFileSet(
       path.resolve(root, entry.modulePath),
     ),
   );
-}
-
-/**
- * Build-time transform that injects the server manifest into the user's server
- * entry. Uses the TypeScript compiler API to find all `createServer()` calls
- * (imported from `litzjs/server`) and wraps their options argument with a
- * helper that merges in the route/resource/API manifest. Returns `null` if no
- * `createServer` import is found.
- */
-function injectServerManifestIntoServerEntry(
-  filePath: string,
-  source: string,
-  base: string,
-): string | null {
-  const scriptKind = filePath.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS;
-  const sourceFile = ts.createSourceFile(
-    filePath,
-    source,
-    ts.ScriptTarget.Latest,
-    true,
-    scriptKind,
-  );
-  const createServerImportNames = new Set<string>();
-  const createServerNamespaceNames = new Set<string>();
-
-  for (const statement of sourceFile.statements) {
-    if (!ts.isImportDeclaration(statement) || !ts.isStringLiteral(statement.moduleSpecifier)) {
-      continue;
-    }
-
-    if (statement.moduleSpecifier.text !== "litzjs/server") {
-      continue;
-    }
-
-    const namedBindings = statement.importClause?.namedBindings;
-
-    if (!namedBindings) {
-      continue;
-    }
-
-    if (ts.isNamespaceImport(namedBindings)) {
-      createServerNamespaceNames.add(namedBindings.name.text);
-      continue;
-    }
-
-    if (ts.isNamedImports(namedBindings)) {
-      for (const element of namedBindings.elements) {
-        if ((element.propertyName?.text ?? element.name.text) === "createServer") {
-          createServerImportNames.add(element.name.text);
-        }
-      }
-    }
-  }
-
-  if (createServerImportNames.size === 0 && createServerNamespaceNames.size === 0) {
-    return null;
-  }
-
-  let transformedCount = 0;
-
-  const result = ts.transform(sourceFile, [
-    (context) => {
-      const visit: ts.Visitor = (node) => {
-        if (ts.isCallExpression(node)) {
-          const expr = node.expression;
-
-          const isNamedCall = ts.isIdentifier(expr) && createServerImportNames.has(expr.text);
-
-          const isNamespaceCall =
-            ts.isPropertyAccessExpression(expr) &&
-            ts.isIdentifier(expr.expression) &&
-            createServerNamespaceNames.has(expr.expression.text) &&
-            expr.name.text === "createServer";
-
-          if (isNamedCall || isNamespaceCall) {
-            transformedCount++;
-            return ts.factory.updateCallExpression(node, expr, node.typeArguments, [
-              ts.factory.createCallExpression(
-                ts.factory.createIdentifier("__litzjsMergeServerOptions"),
-                undefined,
-                [node.arguments[0] ?? ts.factory.createIdentifier("undefined")],
-              ),
-            ]);
-          }
-        }
-
-        return ts.visitEachChild(node, visit, context);
-      };
-
-      return (node: ts.SourceFile) => ts.visitEachChild(node, visit, context);
-    },
-  ]);
-  const transformedSource = result.transformed[0] as ts.SourceFile;
-  result.dispose();
-
-  if (transformedCount === 0 && createServerImportNames.size > 0) {
-    throw new Error(
-      `Could not inject server manifest into the server entry at ${filePath}. ` +
-        `The server manifest injection requires a direct call to createServer() from "litzjs/server". ` +
-        `Ensure your server entry calls createServer() directly rather than through indirection.`,
-    );
-  }
-
-  if (transformedCount === 0) {
-    return null;
-  }
-
-  const importStatement = ts.factory.createImportDeclaration(
-    undefined,
-    ts.factory.createImportClause(
-      false,
-      undefined,
-      ts.factory.createNamedImports([
-        ts.factory.createImportSpecifier(
-          false,
-          ts.factory.createIdentifier("serverManifest"),
-          ts.factory.createIdentifier("__litzjsServerManifest"),
-        ),
-      ]),
-    ),
-    ts.factory.createStringLiteral(SERVER_MANIFEST_ID),
-    undefined,
-  );
-  const helperStatement = ts.factory.createVariableStatement(
-    undefined,
-    ts.factory.createVariableDeclarationList(
-      [
-        ts.factory.createVariableDeclaration(
-          ts.factory.createIdentifier("__litzjsMergeServerOptions"),
-          undefined,
-          undefined,
-          ts.factory.createArrowFunction(
-            undefined,
-            undefined,
-            [
-              ts.factory.createParameterDeclaration(
-                undefined,
-                undefined,
-                ts.factory.createIdentifier("options"),
-              ),
-            ],
-            undefined,
-            ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
-            ts.factory.createParenthesizedExpression(
-              ts.factory.createObjectLiteralExpression(
-                [
-                  ts.factory.createPropertyAssignment(
-                    ts.factory.createIdentifier("manifest"),
-                    ts.factory.createIdentifier("__litzjsServerManifest"),
-                  ),
-                  ts.factory.createSpreadAssignment(
-                    ts.factory.createBinaryExpression(
-                      ts.factory.createIdentifier("options"),
-                      ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
-                      ts.factory.createObjectLiteralExpression(),
-                    ),
-                  ),
-                  ts.factory.createPropertyAssignment(
-                    ts.factory.createIdentifier("base"),
-                    ts.factory.createStringLiteral(base),
-                  ),
-                ],
-                true,
-              ),
-            ),
-          ),
-        ),
-      ],
-      ts.NodeFlags.Const,
-    ),
-  );
-
-  const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
-
-  return [
-    printer.printNode(ts.EmitHint.Unspecified, importStatement, transformedSource),
-    printer.printNode(ts.EmitHint.Unspecified, helperStatement, transformedSource),
-    ...transformedSource.statements.map((statement) =>
-      printer.printNode(ts.EmitHint.Unspecified, statement, transformedSource),
-    ),
-    "",
-  ].join("\n\n");
 }
 
 function normalizeViteModuleId(id: string): string {

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -126,6 +126,8 @@ const RESOURCE_MANIFEST_ID = "virtual:litzjs:resource-manifest";
 const RESOLVED_RESOURCE_MANIFEST_ID = "\0virtual:litzjs:resource-manifest";
 const SERVER_MANIFEST_ID = "virtual:litzjs:server-manifest";
 const RESOLVED_SERVER_MANIFEST_ID = "\0virtual:litzjs:server-manifest";
+const BASE_ID = "virtual:litzjs:base";
+const RESOLVED_BASE_ID = "\0virtual:litzjs:base";
 const LITZ_RSC_ENTRY_ID = "virtual:litzjs:rsc-entry";
 const RESOLVED_LITZ_RSC_ENTRY_ID = "\0virtual:litzjs:rsc-entry";
 const LITZ_BROWSER_ENTRY_ID = "virtual:litzjs:browser-entry";
@@ -219,6 +221,10 @@ export function litz(options: LitzPluginOptions = {}): PluginOption {
         return RESOLVED_SERVER_MANIFEST_ID;
       }
 
+      if (id === BASE_ID) {
+        return RESOLVED_BASE_ID;
+      }
+
       if (id === LITZ_RSC_ENTRY_ID) {
         return RESOLVED_LITZ_RSC_ENTRY_ID;
       }
@@ -255,6 +261,10 @@ export function litz(options: LitzPluginOptions = {}): PluginOption {
         return createServerManifestModule(routeManifest, resourceManifest, apiManifest);
       }
 
+      if (id === RESOLVED_BASE_ID) {
+        return `export const base = ${JSON.stringify(configuredBase)};`;
+      }
+
       if (id === RESOLVED_LITZ_RSC_ENTRY_ID) {
         if (serverEntryPath) {
           return `export { default } from ${JSON.stringify(toProjectImportSpecifier(serverEntryPath))};`;
@@ -262,10 +272,11 @@ export function litz(options: LitzPluginOptions = {}): PluginOption {
 
         return `
 import { createServer } from "litzjs/server";
+import { base } from ${JSON.stringify(BASE_ID)};
 import { serverManifest } from ${JSON.stringify(SERVER_MANIFEST_ID)};
 
 export default createServer({
-  base: ${JSON.stringify(configuredBase)},
+  base,
   manifest: serverManifest,
   createContext() {
     return undefined;

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -815,6 +815,76 @@ describe("dev server hot updates", () => {
     }
   });
 
+  test("exposes the configured base through a virtual module", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "litz-base-module-"));
+
+    try {
+      mkdirSync(path.join(root, "src"), { recursive: true });
+      writeFileSync(path.join(root, "src", "main.tsx"), "export {};\n", "utf8");
+
+      const plugin = (litz() as Plugin[]).find((candidate) => candidate.name === "litzjs/vite");
+
+      if (!plugin?.configResolved || !plugin.resolveId || !plugin.load) {
+        throw new Error("Expected litzjs/vite base virtual module hooks to be available.");
+      }
+
+      const configResolved =
+        typeof plugin.configResolved === "function"
+          ? plugin.configResolved
+          : plugin.configResolved.handler;
+      const resolveId =
+        typeof plugin.resolveId === "function" ? plugin.resolveId : plugin.resolveId.handler;
+      const load = typeof plugin.load === "function" ? plugin.load : plugin.load.handler;
+      const pluginContext = {} as never;
+
+      await configResolved.call(pluginContext, {
+        root,
+        base: "/app/",
+        command: "serve",
+        build: {
+          outDir: "dist",
+        },
+        environments: {
+          client: {
+            build: {
+              outDir: path.join("dist", "client"),
+            },
+          },
+          rsc: {
+            build: {
+              outDir: path.join("dist", "server"),
+              rollupOptions: {
+                output: {
+                  codeSplitting: false,
+                },
+              },
+            },
+          },
+        },
+      } as never);
+
+      const resolvedId = resolveId.call(
+        pluginContext,
+        "virtual:litzjs:base",
+        undefined,
+        {} as never,
+      );
+      const baseSource = load.call(
+        {
+          environment: {
+            name: "nitro",
+          },
+        } as never,
+        resolvedId as string,
+        {} as never,
+      );
+
+      expect(baseSource).toBe('export const base = "/app";');
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   test("prefixes the generated browser entry import with the configured base", async () => {
     const root = mkdtempSync(path.join(tmpdir(), "litz-browser-entry-base-"));
 
@@ -1207,7 +1277,7 @@ describe("dev server hot updates", () => {
       writeFileSync(path.join(root, "src", "main.tsx"), "export {};\n", "utf8");
       writeFileSync(
         path.join(root, "src", "server.ts"),
-        'import { createServer } from "litzjs/server";\nimport { serverManifest } from "virtual:litzjs:server-manifest";\n\nexport default createServer({ manifest: serverManifest });\n',
+        'import { createServer } from "litzjs/server";\nimport { base } from "virtual:litzjs:base";\nimport { serverManifest } from "virtual:litzjs:server-manifest";\n\nexport default createServer({ base, manifest: serverManifest });\n',
         "utf8",
       );
 
@@ -1260,7 +1330,7 @@ describe("dev server hot updates", () => {
 
       const result = await transform.call(
         pluginContext,
-        'import { createServer } from "litzjs/server";\nimport { serverManifest } from "virtual:litzjs:server-manifest";\n\nexport default createServer({ manifest: serverManifest });\n',
+        'import { createServer } from "litzjs/server";\nimport { base } from "virtual:litzjs:base";\nimport { serverManifest } from "virtual:litzjs:server-manifest";\n\nexport default createServer({ base, manifest: serverManifest });\n',
         path.join(root, "src", "server.ts"),
       );
 

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -1199,15 +1199,15 @@ describe("dev server hot updates", () => {
     }
   });
 
-  test("injects the configured base into transformed server entries", async () => {
-    const root = mkdtempSync(path.join(tmpdir(), "litz-server-entry-base-"));
+  test("leaves custom server entries unchanged so manifests are wired explicitly", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "litz-server-entry-explicit-"));
 
     try {
       mkdirSync(path.join(root, "src"), { recursive: true });
       writeFileSync(path.join(root, "src", "main.tsx"), "export {};\n", "utf8");
       writeFileSync(
         path.join(root, "src", "server.ts"),
-        'import { createServer } from "litzjs/server";\n\nexport default createServer();\n',
+        'import { createServer } from "litzjs/server";\nimport { serverManifest } from "virtual:litzjs:server-manifest";\n\nexport default createServer({ manifest: serverManifest });\n',
         "utf8",
       );
 
@@ -1260,21 +1260,17 @@ describe("dev server hot updates", () => {
 
       const result = await transform.call(
         pluginContext,
-        'import { createServer } from "litzjs/server";\n\nexport default createServer();\n',
+        'import { createServer } from "litzjs/server";\nimport { serverManifest } from "virtual:litzjs:server-manifest";\n\nexport default createServer({ manifest: serverManifest });\n',
         path.join(root, "src", "server.ts"),
       );
 
-      expect(result).toEqual(
-        expect.objectContaining({
-          code: expect.stringContaining('base: "/app"'),
-        }),
-      );
+      expect(result).toBeNull();
     } finally {
       rmSync(root, { force: true, recursive: true });
     }
   });
 
-  test("injects manifest into server entries that use namespace imports", async () => {
+  test("leaves namespace createServer calls unchanged", async () => {
     const root = mkdtempSync(path.join(tmpdir(), "litz-server-entry-ns-"));
 
     try {
@@ -1339,17 +1335,13 @@ describe("dev server hot updates", () => {
         path.join(root, "src", "server.ts"),
       );
 
-      expect(result).toEqual(
-        expect.objectContaining({
-          code: expect.stringContaining("__litzjsMergeServerOptions"),
-        }),
-      );
+      expect(result).toBeNull();
     } finally {
       rmSync(root, { force: true, recursive: true });
     }
   });
 
-  test("throws when createServer is imported from litzjs/server but never called directly", async () => {
+  test("allows indirect createServer wrappers in custom server entries", async () => {
     const root = mkdtempSync(path.join(tmpdir(), "litz-server-entry-indirect-"));
 
     try {
@@ -1408,26 +1400,19 @@ describe("dev server hot updates", () => {
         } as never,
       );
 
-      let error: unknown;
+      const result = await transform.call(
+        pluginContext,
+        'import { createServer } from "litzjs/server";\nconst factory = createServer;\nexport default factory();\n',
+        path.join(root, "src", "server.ts"),
+      );
 
-      try {
-        await transform.call(
-          pluginContext,
-          'import { createServer } from "litzjs/server";\nconst factory = createServer;\nexport default factory();\n',
-          path.join(root, "src", "server.ts"),
-        );
-      } catch (caughtError) {
-        error = caughtError;
-      }
-
-      expect(error).toBeInstanceOf(Error);
-      expect((error as Error).message).toContain("server manifest");
+      expect(result).toBeNull();
     } finally {
       rmSync(root, { force: true, recursive: true });
     }
   });
 
-  test("skips injection without error when a namespace import from litzjs/server does not call createServer", async () => {
+  test("leaves namespace imports without createServer calls unchanged", async () => {
     const root = mkdtempSync(path.join(tmpdir(), "litz-server-entry-ns-no-cs-"));
 
     try {

--- a/www/src/routes/docs/api-reference.tsx
+++ b/www/src/routes/docs/api-reference.tsx
@@ -998,9 +998,11 @@ const serverGroups: readonly ReferenceGroupSpec[] = [
         example: {
           language: "ts",
           code: `import { createServer } from "litzjs/server";
+import { base } from "virtual:litzjs:base";
 import { serverManifest } from "virtual:litzjs:server-manifest";
 
 const server = createServer({
+  base,
   manifest: serverManifest,
   document: "<!doctype html><html><body><div id=\\"root\\"></div></body></html>",
 });

--- a/www/src/routes/docs/authentication.tsx
+++ b/www/src/routes/docs/authentication.tsx
@@ -28,8 +28,10 @@ function DocsAuthenticationPage() {
         <CodeBlock
           language="ts"
           code={`import { createServer } from "litzjs/server";
+import { serverManifest } from "virtual:litzjs:server-manifest";
 
 export default createServer({
+  manifest: serverManifest,
   createContext(request) {
     const token = request.headers
       .get("authorization")

--- a/www/src/routes/docs/authentication.tsx
+++ b/www/src/routes/docs/authentication.tsx
@@ -28,9 +28,11 @@ function DocsAuthenticationPage() {
         <CodeBlock
           language="ts"
           code={`import { createServer } from "litzjs/server";
+import { base } from "virtual:litzjs:base";
 import { serverManifest } from "virtual:litzjs:server-manifest";
 
 export default createServer({
+  base,
   manifest: serverManifest,
   createContext(request) {
     const token = request.headers

--- a/www/src/routes/docs/bun.tsx
+++ b/www/src/routes/docs/bun.tsx
@@ -26,8 +26,10 @@ function DocsBunPage() {
         <CodeBlock
           language="ts"
           code={`import { createServer } from "litzjs/server";
+import { serverManifest } from "virtual:litzjs:server-manifest";
 
 export default createServer({
+  manifest: serverManifest,
   async createContext(request) {
     const token = request.headers.get("authorization");
     return { userId: token ? verifyToken(token) : null };

--- a/www/src/routes/docs/bun.tsx
+++ b/www/src/routes/docs/bun.tsx
@@ -26,9 +26,11 @@ function DocsBunPage() {
         <CodeBlock
           language="ts"
           code={`import { createServer } from "litzjs/server";
+import { base } from "virtual:litzjs:base";
 import { serverManifest } from "virtual:litzjs:server-manifest";
 
 export default createServer({
+  base,
   manifest: serverManifest,
   async createContext(request) {
     const token = request.headers.get("authorization");

--- a/www/src/routes/docs/cloudflare-workers.tsx
+++ b/www/src/routes/docs/cloudflare-workers.tsx
@@ -36,8 +36,10 @@ function DocsDeploymentPage() {
         <CodeBlock
           language="ts"
           code={`import { createServer } from "litzjs/server";
+import { serverManifest } from "virtual:litzjs:server-manifest";
 
 export default createServer({
+  manifest: serverManifest,
   onError(error) {
     console.error("Litz docs server error", error);
   },

--- a/www/src/routes/docs/cloudflare-workers.tsx
+++ b/www/src/routes/docs/cloudflare-workers.tsx
@@ -36,9 +36,11 @@ function DocsDeploymentPage() {
         <CodeBlock
           language="ts"
           code={`import { createServer } from "litzjs/server";
+import { base } from "virtual:litzjs:base";
 import { serverManifest } from "virtual:litzjs:server-manifest";
 
 export default createServer({
+  base,
   manifest: serverManifest,
   onError(error) {
     console.error("Litz docs server error", error);

--- a/www/src/routes/docs/deno-deploy.tsx
+++ b/www/src/routes/docs/deno-deploy.tsx
@@ -46,9 +46,11 @@ function DocsDenoDeployPage() {
         <CodeBlock
           language="ts"
           code={`import { createServer } from "litzjs/server";
+import { base } from "virtual:litzjs:base";
 import { serverManifest } from "virtual:litzjs:server-manifest";
 
 export default createServer({
+  base,
   manifest: serverManifest,
   async createContext(request) {
     return { userId: request.headers.get("x-user-id") };

--- a/www/src/routes/docs/deno-deploy.tsx
+++ b/www/src/routes/docs/deno-deploy.tsx
@@ -46,8 +46,10 @@ function DocsDenoDeployPage() {
         <CodeBlock
           language="ts"
           code={`import { createServer } from "litzjs/server";
+import { serverManifest } from "virtual:litzjs:server-manifest";
 
 export default createServer({
+  manifest: serverManifest,
   async createContext(request) {
     return { userId: request.headers.get("x-user-id") };
   },

--- a/www/src/routes/docs/middleware.tsx
+++ b/www/src/routes/docs/middleware.tsx
@@ -159,8 +159,10 @@ export const api = defineApiRoute("/api/data", {
           language="tsx"
           code={`// server.ts
 import { createServer } from "litzjs/server";
+import { serverManifest } from "virtual:litzjs:server-manifest";
 
 export default createServer({
+  manifest: serverManifest,
   async createContext(request) {
     const session = await getSession(request);
     return { userId: session?.userId ?? null };

--- a/www/src/routes/docs/middleware.tsx
+++ b/www/src/routes/docs/middleware.tsx
@@ -159,9 +159,11 @@ export const api = defineApiRoute("/api/data", {
           language="tsx"
           code={`// server.ts
 import { createServer } from "litzjs/server";
+import { base } from "virtual:litzjs:base";
 import { serverManifest } from "virtual:litzjs:server-manifest";
 
 export default createServer({
+  base,
   manifest: serverManifest,
   async createContext(request) {
     const session = await getSession(request);

--- a/www/src/routes/docs/node.tsx
+++ b/www/src/routes/docs/node.tsx
@@ -21,14 +21,15 @@ function DocsNodePage() {
       <section className="mb-12">
         <h2 className="text-2xl font-semibold text-neutral-100 mb-4">Server entry</h2>
         <p className="text-neutral-400 mb-4">
-          Keep your Litz server entry small. Vite injects the discovered manifest during{" "}
-          <code className="text-sky-400">vite build</code>:
+          Keep your Litz server entry small and wire the generated manifest explicitly:
         </p>
         <CodeBlock
           language="ts"
           code={`import { createServer } from "litzjs/server";
+import { serverManifest } from "virtual:litzjs:server-manifest";
 
 export default createServer({
+  manifest: serverManifest,
   async createContext(request) {
     return {
       requestId: request.headers.get("x-request-id"),

--- a/www/src/routes/docs/node.tsx
+++ b/www/src/routes/docs/node.tsx
@@ -26,9 +26,11 @@ function DocsNodePage() {
         <CodeBlock
           language="ts"
           code={`import { createServer } from "litzjs/server";
+import { base } from "virtual:litzjs:base";
 import { serverManifest } from "virtual:litzjs:server-manifest";
 
 export default createServer({
+  base,
   manifest: serverManifest,
   async createContext(request) {
     return {

--- a/www/src/routes/docs/server-configuration.tsx
+++ b/www/src/routes/docs/server-configuration.tsx
@@ -26,14 +26,17 @@ function ServerConfiguration() {
           request handler: <code className="text-sky-400">Request → Response</code>.
         </p>
         <p className="text-neutral-400 mb-4">
-          Custom server entries should import the generated server manifest explicitly:
+          Custom server entries should import the generated server manifest and configured base
+          explicitly:
         </p>
         <CodeBlock
           language="tsx"
           code={`import { createServer } from "litzjs/server";
+import { base } from "virtual:litzjs:base";
 import { serverManifest } from "virtual:litzjs:server-manifest";
 
 export default createServer({
+  base,
   manifest: serverManifest,
 });`}
         />
@@ -136,7 +139,10 @@ export default createServer({
         <p className="text-neutral-400 mb-4">
           The Vite plugin exposes discovered routes, resources, and API routes through{" "}
           <code className="text-sky-400">virtual:litzjs:server-manifest</code>. Custom server
-          entries pass that value to <code className="text-sky-400">createServer</code>.
+          entries pass that value to <code className="text-sky-400">createServer</code>. The
+          configured Vite base path is available from{" "}
+          <code className="text-sky-400">virtual:litzjs:base</code> so server route matching uses
+          the same prefix as the client.
         </p>
         <p className="text-neutral-400 mb-4">
           Discovery paths are configured in <code className="text-sky-400">vite.config.ts</code>{" "}

--- a/www/src/routes/docs/server-configuration.tsx
+++ b/www/src/routes/docs/server-configuration.tsx
@@ -25,12 +25,17 @@ function ServerConfiguration() {
           <code className="text-sky-400">"litzjs/server"</code>. It creates a WinterCG-compatible
           request handler: <code className="text-sky-400">Request → Response</code>.
         </p>
-        <p className="text-neutral-400 mb-4">The simplest usage requires no arguments at all:</p>
+        <p className="text-neutral-400 mb-4">
+          Custom server entries should import the generated server manifest explicitly:
+        </p>
         <CodeBlock
           language="tsx"
           code={`import { createServer } from "litzjs/server";
+import { serverManifest } from "virtual:litzjs:server-manifest";
 
-export default createServer();`}
+export default createServer({
+  manifest: serverManifest,
+});`}
         />
       </section>
 
@@ -98,10 +103,9 @@ export default createServer();`}
           to <code className="text-sky-400">.output/public</code> and produces a server bundle.
         </p>
         <p className="text-neutral-400 mb-4">
-          Litz emits <code className="text-sky-400">.output/server/index.mjs</code> with the
-          discovered server manifest injected into{" "}
-          <code className="text-sky-400">createServer()</code>. Your platform is responsible for
-          serving <code className="text-sky-400">.output/public</code> as static files (via CDN,{" "}
+          Litz emits <code className="text-sky-400">.output/server/index.mjs</code> from your server
+          entry. Your platform is responsible for serving{" "}
+          <code className="text-sky-400">.output/public</code> as static files (via CDN,{" "}
           <code className="text-sky-400">express.static</code>, platform asset binding, etc.).
         </p>
         <p className="text-neutral-400 mb-4">
@@ -130,8 +134,9 @@ export default createServer();`}
       <section className="mb-12">
         <h2 className="text-2xl font-semibold text-neutral-100 mb-4">Discovery</h2>
         <p className="text-neutral-400 mb-4">
-          The Vite plugin auto-injects discovered routes, resources, and API routes into{" "}
-          <code className="text-sky-400">createServer</code>. You don't wire them manually.
+          The Vite plugin exposes discovered routes, resources, and API routes through{" "}
+          <code className="text-sky-400">virtual:litzjs:server-manifest</code>. Custom server
+          entries pass that value to <code className="text-sky-400">createServer</code>.
         </p>
         <p className="text-neutral-400 mb-4">
           Discovery paths are configured in <code className="text-sky-400">vite.config.ts</code>{" "}

--- a/www/src/routes/docs/troubleshooting.tsx
+++ b/www/src/routes/docs/troubleshooting.tsx
@@ -297,9 +297,11 @@ export default defineConfig({
 
 // src/server.ts
 import { createServer } from "litzjs/server";
+import { base } from "virtual:litzjs:base";
 import { serverManifest } from "virtual:litzjs:server-manifest";
 
 export default createServer({
+  base,
   manifest: serverManifest,
 });`}
         />

--- a/www/src/routes/docs/troubleshooting.tsx
+++ b/www/src/routes/docs/troubleshooting.tsx
@@ -297,8 +297,11 @@ export default defineConfig({
 
 // src/server.ts
 import { createServer } from "litzjs/server";
+import { serverManifest } from "virtual:litzjs:server-manifest";
 
-export default createServer();`}
+export default createServer({
+  manifest: serverManifest,
+});`}
         />
         <p className="text-neutral-400 mt-4">
           Use the deployment guide for your target runtime:{" "}

--- a/www/src/routes/docs/typescript.tsx
+++ b/www/src/routes/docs/typescript.tsx
@@ -145,6 +145,7 @@ function EditUser() {
         <CodeBlock
           language="ts"
           code={`import { createServer } from "litzjs/server";
+import { base } from "virtual:litzjs:base";
 import { serverManifest } from "virtual:litzjs:server-manifest";
 
 type AppContext = {
@@ -153,6 +154,7 @@ type AppContext = {
 };
 
 export default createServer<AppContext>({
+  base,
   manifest: serverManifest,
   createContext(request): AppContext {
     const token = request.headers.get("authorization");

--- a/www/src/routes/docs/typescript.tsx
+++ b/www/src/routes/docs/typescript.tsx
@@ -145,6 +145,7 @@ function EditUser() {
         <CodeBlock
           language="ts"
           code={`import { createServer } from "litzjs/server";
+import { serverManifest } from "virtual:litzjs:server-manifest";
 
 type AppContext = {
   userId: string | null;
@@ -152,6 +153,7 @@ type AppContext = {
 };
 
 export default createServer<AppContext>({
+  manifest: serverManifest,
   createContext(request): AppContext {
     const token = request.headers.get("authorization");
     const locale = request.headers.get("accept-language") ?? "en";

--- a/www/src/server.ts
+++ b/www/src/server.ts
@@ -1,6 +1,8 @@
 import { createServer } from "litzjs/server";
+import { serverManifest } from "virtual:litzjs:server-manifest";
 
 export default createServer({
+  manifest: serverManifest,
   onError: (error) => {
     console.error("An error occurred:", error);
   },

--- a/www/src/server.ts
+++ b/www/src/server.ts
@@ -1,7 +1,9 @@
 import { createServer } from "litzjs/server";
+import { base } from "virtual:litzjs:base";
 import { serverManifest } from "virtual:litzjs:server-manifest";
 
 export default createServer({
+  base,
   manifest: serverManifest,
   onError: (error) => {
     console.error("An error occurred:", error);


### PR DESCRIPTION
## Summary

Closes #108.

This replaces the hidden Vite AST transform that injected server options into custom server entries. Custom server entries now wire generated framework values explicitly by importing `base` from `virtual:litzjs:base` and `serverManifest` from `virtual:litzjs:server-manifest`, then passing both to `createServer({ base, manifest: serverManifest })`.

## What changed

- Removed the Nitro server-entry transform that searched for direct `createServer()` calls and rewrote their arguments.
- Added `virtual:litzjs:base` so custom server entries can preserve the configured Vite base path without duplicating config.
- Kept the generated default server entry behavior, but made it use the same explicit virtual `base` and `serverManifest` imports.
- Added virtual module typing for `virtual:litzjs:base` and `virtual:litzjs:server-manifest`.
- Updated the smoke fixture, docs server entry, deployment docs, configuration docs, API reference, and examples to show explicit manifest and base wiring.
- Added a patch changeset for the behavior change.

## Root cause

The previous production setup depended on AST mutation of user server files. That made otherwise valid patterns like wrappers, factories, re-exports, or non-standard imports fragile because the plugin had to recognize and rewrite a specific direct call shape. The old transform also injected `base`, so this PR now exposes `base` explicitly through a virtual module to preserve non-root base behavior.

## Validation

- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun test`
