### PR TITLE
feat: add explicit client module boundaries

### DIFF
--- a/.changeset/client-boundary-manifests.md
+++ b/.changeset/client-boundary-manifests.md
@@ -1,0 +1,10 @@
+---
+"litzjs": minor
+---
+
+Add explicit `*.client.*` route module boundaries for browser manifests.
+
+Route, layout, resource, and API modules can now place client-safe definitions in a sibling
+`*.client.ts`, `*.client.tsx`, `*.client.js`, or `*.client.jsx` file. The Vite client manifests
+prefer those files and skip the legacy AST projection transform for the paired server module,
+leaving projection as a compatibility path only for modules without an explicit client boundary.

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -818,7 +818,7 @@ export async function discoverServerEntry(
 }
 
 function isClientBoundaryModule(file: string): boolean {
-  return /\.[cm]?client\.(ts|tsx|js|jsx)$/.test(file);
+  return /\.client\.(ts|tsx|js|jsx)$/.test(file);
 }
 
 function resolveClientBoundaryModule(root: string, file: string): string | null {
@@ -827,8 +827,7 @@ function resolveClientBoundaryModule(root: string, file: string): string | null 
   }
 
   const parsed = path.parse(file);
-  const extensionCandidates =
-    parsed.ext === ".tsx" || parsed.ext === ".jsx" ? [parsed.ext, ".tsx", ".jsx"] : [parsed.ext];
+  const extensionCandidates = getClientBoundaryExtensionCandidates(parsed.ext);
 
   for (const extension of new Set(extensionCandidates)) {
     const candidate = path.join(parsed.dir, `${parsed.name}.client${extension}`);
@@ -839,6 +838,18 @@ function resolveClientBoundaryModule(root: string, file: string): string | null 
   }
 
   return null;
+}
+
+function getClientBoundaryExtensionCandidates(extension: string): readonly string[] {
+  if (extension === ".ts" || extension === ".tsx") {
+    return [extension, ".tsx"];
+  }
+
+  if (extension === ".js" || extension === ".jsx") {
+    return [extension, ".jsx"];
+  }
+
+  return [extension];
 }
 
 async function discoverRoutes(root: string, patterns: string[]): Promise<DiscoveredRoute[]> {

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -87,17 +87,20 @@ type DiscoveredRoute = {
   id: string;
   path: string;
   modulePath: string;
+  clientModulePath?: string | null;
 };
 
 type DiscoveredLayout = {
   id: string;
   path: string;
   modulePath: string;
+  clientModulePath?: string | null;
 };
 
 type DiscoveredResource = {
   path: string;
   modulePath: string;
+  clientModulePath?: string | null;
   hasLoader: boolean;
   hasAction: boolean;
   hasComponent: boolean;
@@ -106,6 +109,7 @@ type DiscoveredResource = {
 type DiscoveredApiRoute = {
   path: string;
   modulePath: string;
+  clientModulePath?: string | null;
 };
 
 type HtmlEntryInfo = {
@@ -424,6 +428,13 @@ export async function renderView(node, metadata = {}) {
 
       const refreshSingleFile = async (file: string) => {
         if (pendingFullDiscovery) {
+          return;
+        }
+
+        if (isClientBoundaryModule(file)) {
+          pendingFullDiscovery = true;
+          scheduleRefresh();
+
           return;
         }
 
@@ -806,6 +817,30 @@ export async function discoverServerEntry(
   return null;
 }
 
+function isClientBoundaryModule(file: string): boolean {
+  return /\.[cm]?client\.(ts|tsx|js|jsx)$/.test(file);
+}
+
+function resolveClientBoundaryModule(root: string, file: string): string | null {
+  if (isClientBoundaryModule(file)) {
+    return null;
+  }
+
+  const parsed = path.parse(file);
+  const extensionCandidates =
+    parsed.ext === ".tsx" || parsed.ext === ".jsx" ? [parsed.ext, ".tsx", ".jsx"] : [parsed.ext];
+
+  for (const extension of new Set(extensionCandidates)) {
+    const candidate = path.join(parsed.dir, `${parsed.name}.client${extension}`);
+
+    if (ts.sys.fileExists(candidate)) {
+      return normalizeRelativePath(root, candidate);
+    }
+  }
+
+  return null;
+}
+
 async function discoverRoutes(root: string, patterns: string[]): Promise<DiscoveredRoute[]> {
   const files = await glob(patterns, {
     cwd: root,
@@ -813,7 +848,9 @@ async function discoverRoutes(root: string, patterns: string[]): Promise<Discove
   });
 
   const discovered = await Promise.all(
-    files.map(async (file) => discoverRouteFromFile(root, file)),
+    files
+      .filter((file) => !isClientBoundaryModule(file))
+      .map(async (file) => discoverRouteFromFile(root, file)),
   );
 
   return discovered.filter((entry): entry is DiscoveredRoute => entry !== null);
@@ -826,7 +863,9 @@ async function discoverLayouts(root: string, patterns: string[]): Promise<Discov
   });
 
   const discovered = await Promise.all(
-    files.map(async (file) => discoverLayoutFromFile(root, file)),
+    files
+      .filter((file) => !isClientBoundaryModule(file))
+      .map(async (file) => discoverLayoutFromFile(root, file)),
   );
 
   return discovered.filter((entry): entry is DiscoveredLayout => entry !== null);
@@ -1084,6 +1123,7 @@ export async function discoverRouteFromFile(
     id: routeDefinition.path,
     path: routeDefinition.path,
     modulePath: relativeModulePath,
+    clientModulePath: resolveClientBoundaryModule(root, file),
   };
 }
 
@@ -1107,6 +1147,7 @@ export async function discoverLayoutFromFile(
     id: layoutDefinition.path,
     path: layoutDefinition.path,
     modulePath: normalizeRelativePath(root, file),
+    clientModulePath: resolveClientBoundaryModule(root, file),
   };
 }
 
@@ -1117,7 +1158,9 @@ async function discoverResources(root: string, patterns: string[]): Promise<Disc
   });
 
   const discovered = await Promise.all(
-    files.map(async (file) => discoverResourceFromFile(root, file)),
+    files
+      .filter((file) => !isClientBoundaryModule(file))
+      .map(async (file) => discoverResourceFromFile(root, file)),
   );
 
   return discovered.filter((entry): entry is DiscoveredResource => entry !== null);
@@ -1159,6 +1202,7 @@ export async function discoverResourceFromFile(
   return {
     path: resourceDefinition.path,
     modulePath: normalizeRelativePath(root, file),
+    clientModulePath: resolveClientBoundaryModule(root, file),
     hasLoader: hasObjectProperty(resourceDefinition.options, bindings, "loader"),
     hasAction: hasObjectProperty(resourceDefinition.options, bindings, "action"),
     hasComponent: hasObjectProperty(resourceDefinition.options, bindings, "component"),
@@ -1172,7 +1216,9 @@ async function discoverApiRoutes(root: string, patterns: string[]): Promise<Disc
   });
 
   const discovered = await Promise.all(
-    files.map(async (file) => discoverApiRouteFromFile(root, file)),
+    files
+      .filter((file) => !isClientBoundaryModule(file))
+      .map(async (file) => discoverApiRouteFromFile(root, file)),
   );
 
   return discovered.filter((entry): entry is DiscoveredApiRoute => entry !== null);
@@ -1192,6 +1238,7 @@ export async function discoverApiRouteFromFile(
   return {
     path: apiDefinition.path,
     modulePath: normalizeRelativePath(root, file),
+    clientModulePath: resolveClientBoundaryModule(root, file),
   };
 }
 
@@ -1209,8 +1256,9 @@ function createRouteManifestModule(
     const imports: string[] = [];
     const lines = manifest.map((route, index) => {
       const importName = `routeModule${index}`;
+      const modulePath = route.clientModulePath ?? route.modulePath;
       imports.push(
-        `import * as ${importName} from ${JSON.stringify(toProjectImportSpecifier(route.modulePath))};`,
+        `import * as ${importName} from ${JSON.stringify(toProjectImportSpecifier(modulePath))};`,
       );
 
       return [
@@ -1226,8 +1274,9 @@ function createRouteManifestModule(
   }
 
   const lines = manifest.map((route, index) => {
-    const importPath = toBrowserImportSpecifier(root, route.modulePath, base);
-    const resolvedModuleFile = path.resolve(root, route.modulePath);
+    const modulePath = route.clientModulePath ?? route.modulePath;
+    const importPath = toBrowserImportSpecifier(root, modulePath, base);
+    const resolvedModuleFile = path.resolve(root, modulePath);
 
     return [
       `  {`,
@@ -1250,9 +1299,9 @@ function createClientProjectedFileSet(
   apiRoutes: DiscoveredApiRoute[],
 ): Set<string> {
   return new Set(
-    [...routes, ...layouts, ...resources, ...apiRoutes].map((entry) =>
-      path.resolve(root, entry.modulePath),
-    ),
+    [...routes, ...layouts, ...resources, ...apiRoutes]
+      .filter((entry) => !entry.clientModulePath)
+      .map((entry) => path.resolve(root, entry.modulePath)),
   );
 }
 

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -528,7 +528,7 @@ export async function renderView(node, metadata = {}) {
       };
 
       const onFileAddOrUnlink = (file: string) => {
-        if (!/\.(ts|tsx)$/.test(file)) {
+        if (!isRouteLikeModuleFile(file)) {
           return;
         }
 
@@ -543,7 +543,7 @@ export async function renderView(node, metadata = {}) {
       };
 
       const onFileChange = (file: string) => {
-        if (!/\.(ts|tsx)$/.test(file)) {
+        if (!isRouteLikeModuleFile(file)) {
           return;
         }
 
@@ -819,6 +819,10 @@ export async function discoverServerEntry(
 
 function isClientBoundaryModule(file: string): boolean {
   return /\.client\.(ts|tsx|js|jsx)$/.test(file);
+}
+
+function isRouteLikeModuleFile(file: string): boolean {
+  return /\.(ts|tsx|js|jsx)$/.test(file);
 }
 
 function resolveClientBoundaryModule(root: string, file: string): string | null {

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -2656,6 +2656,34 @@ describe("manifest discovery", () => {
         rmSync(root, { force: true, recursive: true });
       }
     });
+
+    test("discovers a TSX client route boundary next to a TS server route", async () => {
+      const root = createTempProject();
+
+      try {
+        const file = path.join(root, "src", "routes", "profile.ts");
+
+        writeFileSync(
+          file,
+          `import { defineRoute } from "litzjs";\nexport const route = defineRoute("/profile", { loader: async () => {}, component: Profile });`,
+        );
+        writeFileSync(
+          path.join(root, "src", "routes", "profile.client.tsx"),
+          `import { defineRoute } from "litzjs";\nexport const route = defineRoute("/profile", { component: Profile });`,
+        );
+
+        const result = await discoverRouteFromFile(root, file);
+
+        expect(result).toEqual({
+          id: "/profile",
+          path: "/profile",
+          modulePath: "src/routes/profile.ts",
+          clientModulePath: "src/routes/profile.client.tsx",
+        });
+      } finally {
+        rmSync(root, { force: true, recursive: true });
+      }
+    });
   });
 
   describe("discoverLayoutFromFile", () => {
@@ -3074,6 +3102,33 @@ describe("manifest discovery", () => {
         expect(result.layoutManifest).toHaveLength(0);
         expect(result.resourceManifest).toHaveLength(0);
         expect(result.apiManifest).toHaveLength(0);
+      } finally {
+        rmSync(root, { force: true, recursive: true });
+      }
+    });
+
+    test("does not treat .cclient files as client boundary modules", async () => {
+      const root = createTempProject();
+
+      try {
+        writeFileSync(
+          path.join(root, "src", "routes", "typo.cclient.tsx"),
+          `import { defineRoute } from "litzjs";\nexport const route = defineRoute("/typo", { component: Typo });`,
+        );
+
+        const result = await discoverAllManifests(
+          root,
+          [
+            "src/routes/**/*.{ts,tsx}",
+            "!src/routes/api/**/*.{ts,tsx}",
+            "!src/routes/resources/**/*.{ts,tsx}",
+          ],
+          ["src/routes/resources/**/*.{ts,tsx}"],
+          ["src/routes/api/**/*.{ts,tsx}"],
+        );
+
+        expect(result.routeManifest).toHaveLength(1);
+        expect(result.routeManifest[0]?.path).toBe("/typo");
       } finally {
         rmSync(root, { force: true, recursive: true });
       }

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -509,6 +509,138 @@ describe("dev server hot updates", () => {
     }
   });
 
+  test("dev watcher refreshes manifests when .jsx client boundary files are added", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "litz-jsx-client-boundary-watch-"));
+
+    try {
+      mkdirSync(path.join(root, "src"), { recursive: true });
+      writeFileSync(path.join(root, "src", "main.tsx"), "export {};\n", "utf8");
+      mkdirSync(path.join(root, "src", "routes"), { recursive: true });
+      writeFileSync(
+        path.join(root, "src", "routes", "profile.js"),
+        [
+          'import { defineRoute } from "litzjs";',
+          "",
+          "export const route = defineRoute('/profile', {",
+          "  loader: async () => ({ kind: 'data', data: { ok: true } }),",
+          "  component() {",
+          "    return null;",
+          "  },",
+          "});",
+        ].join("\n"),
+        "utf8",
+      );
+
+      const plugin = (litz() as Plugin[]).find((candidate) => candidate.name === "litzjs/vite");
+
+      if (!plugin?.configResolved || !plugin.configureServer || !plugin.resolveId || !plugin.load) {
+        throw new Error("Expected litzjs/vite dev-server hooks to be available.");
+      }
+
+      const configResolved =
+        typeof plugin.configResolved === "function"
+          ? plugin.configResolved
+          : plugin.configResolved.handler;
+      const configureServer =
+        typeof plugin.configureServer === "function"
+          ? plugin.configureServer
+          : plugin.configureServer.handler;
+      const resolveId =
+        typeof plugin.resolveId === "function" ? plugin.resolveId : plugin.resolveId.handler;
+      const load = typeof plugin.load === "function" ? plugin.load : plugin.load.handler;
+      const watcherHandlers = new Map<string, (file: string) => void>();
+      const wsSend = mock(() => {});
+      const pluginContext = {} as never;
+
+      await configResolved.call(pluginContext, {
+        root,
+        command: "serve",
+        build: {
+          outDir: "dist",
+        },
+        environments: {
+          client: {
+            build: {
+              outDir: path.join("dist", "client"),
+            },
+          },
+          rsc: {
+            build: {
+              outDir: path.join("dist", "server"),
+              rollupOptions: {
+                output: {
+                  codeSplitting: false,
+                },
+              },
+            },
+          },
+        },
+      } as never);
+
+      await configureServer.call(pluginContext, {
+        watcher: {
+          on(event: string, handler: (file: string) => void) {
+            watcherHandlers.set(event, handler);
+          },
+        },
+        middlewares: {
+          use() {},
+        },
+        moduleGraph: {
+          getModuleById() {
+            return undefined;
+          },
+          invalidateModule() {},
+        },
+        ws: {
+          send: wsSend,
+        },
+      } as never);
+
+      const resolvedId = resolveId.call(
+        pluginContext,
+        "virtual:litzjs:route-manifest",
+        undefined,
+        {} as never,
+      );
+      const loadClientManifest = () =>
+        load.call(
+          {
+            environment: {
+              name: "client",
+            },
+          } as never,
+          resolvedId as string,
+          {} as never,
+        ) as string;
+
+      expect(loadClientManifest()).toContain("profile.js");
+
+      const clientBoundaryFile = path.join(root, "src", "routes", "profile.client.jsx");
+      writeFileSync(
+        clientBoundaryFile,
+        [
+          'import { defineRoute } from "litzjs";',
+          "",
+          "export const route = defineRoute('/profile', {",
+          "  component() {",
+          "    return null;",
+          "  },",
+          "});",
+        ].join("\n"),
+        "utf8",
+      );
+
+      watcherHandlers.get("add")?.(clientBoundaryFile);
+      await new Promise((resolve) => setTimeout(resolve, 75));
+
+      expect(loadClientManifest()).toContain("profile.client.jsx");
+      expect(wsSend).toHaveBeenCalledWith({ type: "full-reload" });
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   test("returns client modules for projected route updates in the client environment", async () => {
     const root = mkdtempSync(path.join(tmpdir(), "litz-hot-update-"));
 

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -398,6 +398,117 @@ describe("dev server hot updates", () => {
     }
   });
 
+  test("client route manifests import explicit client boundary modules without projection", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "litz-route-client-boundary-"));
+
+    try {
+      mkdirSync(path.join(root, "src"), { recursive: true });
+      writeFileSync(path.join(root, "src", "main.tsx"), "export {};\n", "utf8");
+      mkdirSync(path.join(root, "src", "routes"), { recursive: true });
+      writeFileSync(
+        path.join(root, "src", "routes", "index.tsx"),
+        [
+          'import { defineRoute } from "litzjs";',
+          "",
+          "export const route = defineRoute('/', {",
+          "  loader: async () => ({ kind: 'data', data: { ok: true } }),",
+          "  component() {",
+          "    return null;",
+          "  },",
+          "});",
+        ].join("\n"),
+        "utf8",
+      );
+      writeFileSync(
+        path.join(root, "src", "routes", "index.client.tsx"),
+        [
+          'import { defineRoute } from "litzjs";',
+          "",
+          "export const route = defineRoute('/', {",
+          "  component() {",
+          "    return null;",
+          "  },",
+          "});",
+        ].join("\n"),
+        "utf8",
+      );
+
+      const plugin = (litz() as Plugin[]).find((candidate) => candidate.name === "litzjs/vite");
+
+      if (!plugin?.configResolved || !plugin.resolveId || !plugin.load || !plugin.transform) {
+        throw new Error("Expected litzjs/vite route-manifest and transform hooks to be available.");
+      }
+
+      const configResolved =
+        typeof plugin.configResolved === "function"
+          ? plugin.configResolved
+          : plugin.configResolved.handler;
+      const resolveId =
+        typeof plugin.resolveId === "function" ? plugin.resolveId : plugin.resolveId.handler;
+      const load = typeof plugin.load === "function" ? plugin.load : plugin.load.handler;
+      const transform =
+        typeof plugin.transform === "function" ? plugin.transform : plugin.transform.handler;
+      const pluginContext = {} as never;
+
+      await configResolved.call(pluginContext, {
+        root,
+        command: "serve",
+        build: {
+          outDir: "dist",
+        },
+        environments: {
+          client: {
+            build: {
+              outDir: path.join("dist", "client"),
+            },
+          },
+          rsc: {
+            build: {
+              outDir: path.join("dist", "server"),
+              rollupOptions: {
+                output: {
+                  codeSplitting: false,
+                },
+              },
+            },
+          },
+        },
+      } as never);
+
+      const resolvedId = resolveId.call(
+        pluginContext,
+        "virtual:litzjs:route-manifest",
+        undefined,
+        {} as never,
+      );
+      const manifestSource = load.call(
+        {
+          environment: {
+            name: "client",
+          },
+        } as never,
+        resolvedId as string,
+        {} as never,
+      ) as string;
+      const routeFile = path.join(root, "src", "routes", "index.tsx");
+      const transformResult = await transform.call(
+        {
+          environment: {
+            name: "client",
+          },
+        } as never,
+        readFileSync(routeFile, "utf8"),
+        routeFile,
+      );
+
+      expect(manifestSource).toContain("index.client.tsx");
+      expect(manifestSource).not.toContain("index.tsx");
+      expect(transformResult).toBeNull();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   test("returns client modules for projected route updates in the client environment", async () => {
     const root = mkdtempSync(path.join(tmpdir(), "litz-hot-update-"));
 
@@ -2465,6 +2576,7 @@ describe("manifest discovery", () => {
           id: "/home",
           path: "/home",
           modulePath: "src/routes/home.tsx",
+          clientModulePath: null,
         });
       } finally {
         rmSync(root, { force: true, recursive: true });
@@ -2510,6 +2622,35 @@ describe("manifest discovery", () => {
           id: "/dashboard",
           path: "/dashboard",
           modulePath: "src/routes/dashboard.ts",
+          clientModulePath: null,
+        });
+      } finally {
+        rmSync(root, { force: true, recursive: true });
+      }
+    });
+
+    test("discovers an explicit client route boundary next to the server route", async () => {
+      const root = createTempProject();
+
+      try {
+        const file = path.join(root, "src", "routes", "settings.tsx");
+
+        writeFileSync(
+          file,
+          `import { defineRoute } from "litzjs";\nexport const route = defineRoute("/settings", { loader: async () => {}, component: Settings });`,
+        );
+        writeFileSync(
+          path.join(root, "src", "routes", "settings.client.tsx"),
+          `import { defineRoute } from "litzjs";\nexport const route = defineRoute("/settings", { component: Settings });`,
+        );
+
+        const result = await discoverRouteFromFile(root, file);
+
+        expect(result).toEqual({
+          id: "/settings",
+          path: "/settings",
+          modulePath: "src/routes/settings.tsx",
+          clientModulePath: "src/routes/settings.client.tsx",
         });
       } finally {
         rmSync(root, { force: true, recursive: true });
@@ -2535,6 +2676,7 @@ describe("manifest discovery", () => {
           id: "/app",
           path: "/app",
           modulePath: "src/routes/layout.tsx",
+          clientModulePath: null,
         });
       } finally {
         rmSync(root, { force: true, recursive: true });
@@ -2581,6 +2723,7 @@ describe("manifest discovery", () => {
           id: "/app",
           path: "/app",
           modulePath: "src/routes/app-layout.tsx",
+          clientModulePath: null,
         });
       } finally {
         rmSync(root, { force: true, recursive: true });
@@ -2605,6 +2748,7 @@ describe("manifest discovery", () => {
         expect(result).toEqual({
           path: "/resource/summary",
           modulePath: "src/routes/resources/summary.ts",
+          clientModulePath: null,
           hasLoader: true,
           hasAction: true,
           hasComponent: true,
@@ -2630,6 +2774,7 @@ describe("manifest discovery", () => {
         expect(result).toEqual({
           path: "/resource/data",
           modulePath: "src/routes/resources/data.ts",
+          clientModulePath: null,
           hasLoader: true,
           hasAction: false,
           hasComponent: false,
@@ -2666,6 +2811,7 @@ describe("manifest discovery", () => {
         expect(result).toEqual({
           path: "/resource/wrapped",
           modulePath: "src/routes/resources/wrapped.ts",
+          clientModulePath: null,
           hasLoader: true,
           hasAction: true,
           hasComponent: true,
@@ -2699,6 +2845,7 @@ describe("manifest discovery", () => {
         expect(result).toEqual({
           path: "/resource/bound-options",
           modulePath: "src/routes/resources/bound-options.ts",
+          clientModulePath: null,
           hasLoader: true,
           hasAction: true,
           hasComponent: true,
@@ -2726,6 +2873,7 @@ describe("manifest discovery", () => {
         expect(result).toEqual({
           path: "/api/health",
           modulePath: "src/routes/api/health.ts",
+          clientModulePath: null,
         });
       } finally {
         rmSync(root, { force: true, recursive: true });
@@ -2775,6 +2923,7 @@ describe("manifest discovery", () => {
         expect(result).toEqual({
           path: "/api/wrapped-health",
           modulePath: "src/routes/api/wrapped-health.ts",
+          clientModulePath: null,
         });
       } finally {
         rmSync(root, { force: true, recursive: true });
@@ -2804,6 +2953,7 @@ describe("manifest discovery", () => {
         expect(result).toEqual({
           path: "/api/js-health",
           modulePath: "src/routes/api/health.mjs",
+          clientModulePath: null,
         });
       } finally {
         rmSync(root, { force: true, recursive: true });


### PR DESCRIPTION
## Summary

Closes #109.

This adds an explicit `*.client.*` boundary convention for route-like modules so browser manifests can import client-safe definitions directly instead of requiring AST projection for every route, layout, resource, or API module.

Changes made:
- Discover sibling `*.client.ts`, `*.client.tsx`, `*.client.js`, and `*.client.jsx` files for route, layout, resource, and API modules.
- Exclude client boundary files from server-side manifest discovery so they do not become independent route-like entries.
- Prefer the client boundary module in client route manifests and remove paired server modules from the client projection set.
- Keep the existing AST projection transform as the compatibility path for modules without an explicit client boundary.
- Refresh manifests on client boundary module changes so dev mode sees boundary add/update/remove changes.
- Add regression coverage for boundary discovery and for skipping client projection when a boundary exists.
- Add a changeset documenting the new authoring model.

## Verification

- `bun fmt`
- `bun lint:fix`
- `bun lint`
- `bun typecheck`
- `bun test`