### PR TITLE
fix: warn on route discovery near misses

### DIFF
--- a/.changeset/route-discovery-warnings.md
+++ b/.changeset/route-discovery-warnings.md
@@ -1,0 +1,7 @@
+---
+"litzjs": patch
+---
+
+Warn when matched route-like files import Litz discovery factories but do not export the expected static binding.
+
+The Vite plugin now reports actionable discovery warnings for near-miss route, layout, resource, and API modules that import `defineRoute`, `defineLayout`, `defineResource`, or `defineApiRoute` from `litzjs` but either omit the required export name or use a path that cannot be read statically.

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -1148,7 +1148,9 @@ function importsNamedLitzFactory(sourceFile: ts.SourceFile, factoryName: string)
       return false;
     }
 
-    return namedBindings.elements.some((element) => element.name.text === factoryName);
+    return namedBindings.elements.some(
+      (element) => (element.propertyName?.text ?? element.name.text) === factoryName,
+    );
   });
 }
 

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -1075,6 +1075,7 @@ function discoverExportedRouteLikeDefinition(
   const sourceFile = createModuleSourceFile(filePath, source);
   const bindings = new Map<string, ts.Expression>();
   const exportedBindings = new Map<string, string>();
+  const importsFactory = importsNamedLitzFactory(sourceFile, factoryName);
 
   for (const statement of sourceFile.statements) {
     if (ts.isVariableStatement(statement)) {
@@ -1110,14 +1111,62 @@ function discoverExportedRouteLikeDefinition(
   const exportedBinding = exportedBindings.get(exportName);
 
   if (!exportedBinding) {
+    if (importsFactory) {
+      warnRouteLikeDiscoveryFailure(filePath, exportName, factoryName, "missing-export");
+    }
+
     return null;
   }
 
-  return resolveRouteLikeFactoryCall(
+  const definition = resolveRouteLikeFactoryCall(
     ts.factory.createIdentifier(exportedBinding),
     bindings,
     factoryName,
     new Set(),
+  );
+
+  if (!definition && importsFactory) {
+    warnRouteLikeDiscoveryFailure(filePath, exportName, factoryName, "unsupported-definition");
+  }
+
+  return definition;
+}
+
+function importsNamedLitzFactory(sourceFile: ts.SourceFile, factoryName: string): boolean {
+  return sourceFile.statements.some((statement) => {
+    if (
+      !ts.isImportDeclaration(statement) ||
+      !ts.isStringLiteral(statement.moduleSpecifier) ||
+      statement.moduleSpecifier.text !== "litzjs"
+    ) {
+      return false;
+    }
+
+    const namedBindings = statement.importClause?.namedBindings;
+
+    if (!namedBindings || !ts.isNamedImports(namedBindings)) {
+      return false;
+    }
+
+    return namedBindings.elements.some((element) => element.name.text === factoryName);
+  });
+}
+
+function warnRouteLikeDiscoveryFailure(
+  filePath: string,
+  exportName: string,
+  factoryName: string,
+  reason: "missing-export" | "unsupported-definition",
+): void {
+  const expected = `export const ${exportName} = ${factoryName}("/path", ...)`;
+  const detail =
+    reason === "missing-export"
+      ? `does not export the expected "${exportName}" binding`
+      : `exports "${exportName}", but the path could not be read from a static ${factoryName} call`;
+
+  console.warn(
+    `[litzjs] ${filePath} imports ${factoryName} from "litzjs" but ${detail}. ` +
+      `Discovery requires ${expected}, or an exported alias that resolves to that static call.`,
   );
 }
 

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -1008,7 +1008,7 @@ function hasObjectProperty(
 function resolveRouteLikeFactoryCall(
   expression: ts.Expression,
   bindings: ReadonlyMap<string, ts.Expression>,
-  factoryName: string,
+  factoryNames: ReadonlySet<string>,
   seenBindings: Set<string>,
 ): DiscoveredRouteLikeDefinition | null {
   const unwrapped = unwrapManifestExpression(expression);
@@ -1026,13 +1026,13 @@ function resolveRouteLikeFactoryCall(
 
     const nextSeenBindings = new Set(seenBindings);
     nextSeenBindings.add(unwrapped.text);
-    return resolveRouteLikeFactoryCall(binding, bindings, factoryName, nextSeenBindings);
+    return resolveRouteLikeFactoryCall(binding, bindings, factoryNames, nextSeenBindings);
   }
 
   if (
     ts.isCallExpression(unwrapped) &&
     ts.isIdentifier(unwrapped.expression) &&
-    unwrapped.expression.text === factoryName
+    factoryNames.has(unwrapped.expression.text)
   ) {
     const routeLikePath = getStringLiteralValue(unwrapped.arguments[0]);
 
@@ -1056,7 +1056,7 @@ function resolveRouteLikeFactoryCall(
     discoveredDefinition = resolveRouteLikeFactoryCall(
       child,
       bindings,
-      factoryName,
+      factoryNames,
       new Set(seenBindings),
     );
 
@@ -1075,7 +1075,9 @@ function discoverExportedRouteLikeDefinition(
   const sourceFile = createModuleSourceFile(filePath, source);
   const bindings = new Map<string, ts.Expression>();
   const exportedBindings = new Map<string, string>();
-  const importsFactory = importsNamedLitzFactory(sourceFile, factoryName);
+  const importedFactoryNames = getImportedLitzFactoryNames(sourceFile, factoryName);
+  const factoryNames = new Set([factoryName, ...importedFactoryNames]);
+  const importsFactory = importedFactoryNames.size > 0;
 
   for (const statement of sourceFile.statements) {
     if (ts.isVariableStatement(statement)) {
@@ -1121,7 +1123,7 @@ function discoverExportedRouteLikeDefinition(
   const definition = resolveRouteLikeFactoryCall(
     ts.factory.createIdentifier(exportedBinding),
     bindings,
-    factoryName,
+    factoryNames,
     new Set(),
   );
 
@@ -1132,26 +1134,32 @@ function discoverExportedRouteLikeDefinition(
   return definition;
 }
 
-function importsNamedLitzFactory(sourceFile: ts.SourceFile, factoryName: string): boolean {
-  return sourceFile.statements.some((statement) => {
+function getImportedLitzFactoryNames(sourceFile: ts.SourceFile, factoryName: string): Set<string> {
+  const factoryNames = new Set<string>();
+
+  for (const statement of sourceFile.statements) {
     if (
       !ts.isImportDeclaration(statement) ||
       !ts.isStringLiteral(statement.moduleSpecifier) ||
       statement.moduleSpecifier.text !== "litzjs"
     ) {
-      return false;
+      continue;
     }
 
     const namedBindings = statement.importClause?.namedBindings;
 
     if (!namedBindings || !ts.isNamedImports(namedBindings)) {
-      return false;
+      continue;
     }
 
-    return namedBindings.elements.some(
-      (element) => (element.propertyName?.text ?? element.name.text) === factoryName,
-    );
-  });
+    for (const element of namedBindings.elements) {
+      if ((element.propertyName?.text ?? element.name.text) === factoryName) {
+        factoryNames.add(element.name.text);
+      }
+    }
+  }
+
+  return factoryNames;
 }
 
 function warnRouteLikeDiscoveryFailure(

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -2846,6 +2846,35 @@ describe("manifest discovery", () => {
       }
     });
 
+    test("warns when a route-like file imports an aliased defineRoute without exporting route", async () => {
+      const root = createTempProject();
+      const warnings: string[] = [];
+      const originalWarn = console.warn;
+      console.warn = (message?: unknown) => {
+        warnings.push(String(message));
+      };
+
+      try {
+        const file = path.join(root, "src", "routes", "aliased-missing-export.tsx");
+
+        writeFileSync(
+          file,
+          `import { defineRoute as makeRoute } from "litzjs";\nexport const dashboard = makeRoute("/dashboard", { component: Dashboard });`,
+        );
+
+        const result = await discoverRouteFromFile(root, file);
+
+        expect(result).toBeNull();
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0]).toContain(
+          `imports defineRoute from "litzjs" but does not export the expected "route" binding`,
+        );
+      } finally {
+        console.warn = originalWarn;
+        rmSync(root, { force: true, recursive: true });
+      }
+    });
+
     test("warns when an exported route uses an unsupported dynamic path", async () => {
       const root = createTempProject();
       const warnings: string[] = [];

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -2875,6 +2875,37 @@ describe("manifest discovery", () => {
       }
     });
 
+    test("discovers an exported route that uses an aliased defineRoute import", async () => {
+      const root = createTempProject();
+      const warnings: string[] = [];
+      const originalWarn = console.warn;
+      console.warn = (message?: unknown) => {
+        warnings.push(String(message));
+      };
+
+      try {
+        const file = path.join(root, "src", "routes", "aliased-route.tsx");
+
+        writeFileSync(
+          file,
+          `import { defineRoute as makeRoute } from "litzjs";\nexport const route = makeRoute("/aliased", { component: Aliased });`,
+        );
+
+        const result = await discoverRouteFromFile(root, file);
+
+        expect(result).toEqual({
+          id: "/aliased",
+          path: "/aliased",
+          modulePath: "src/routes/aliased-route.tsx",
+          clientModulePath: null,
+        });
+        expect(warnings).toHaveLength(0);
+      } finally {
+        console.warn = originalWarn;
+        rmSync(root, { force: true, recursive: true });
+      }
+    });
+
     test("warns when an exported route uses an unsupported dynamic path", async () => {
       const root = createTempProject();
       const warnings: string[] = [];

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -2816,6 +2816,64 @@ describe("manifest discovery", () => {
         rmSync(root, { force: true, recursive: true });
       }
     });
+
+    test("warns when a route-like file imports defineRoute without exporting route", async () => {
+      const root = createTempProject();
+      const warnings: string[] = [];
+      const originalWarn = console.warn;
+      console.warn = (message?: unknown) => {
+        warnings.push(String(message));
+      };
+
+      try {
+        const file = path.join(root, "src", "routes", "missing-export.tsx");
+
+        writeFileSync(
+          file,
+          `import { defineRoute } from "litzjs";\nexport const dashboard = defineRoute("/dashboard", { component: Dashboard });`,
+        );
+
+        const result = await discoverRouteFromFile(root, file);
+
+        expect(result).toBeNull();
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0]).toContain(
+          `imports defineRoute from "litzjs" but does not export the expected "route" binding`,
+        );
+      } finally {
+        console.warn = originalWarn;
+        rmSync(root, { force: true, recursive: true });
+      }
+    });
+
+    test("warns when an exported route uses an unsupported dynamic path", async () => {
+      const root = createTempProject();
+      const warnings: string[] = [];
+      const originalWarn = console.warn;
+      console.warn = (message?: unknown) => {
+        warnings.push(String(message));
+      };
+
+      try {
+        const file = path.join(root, "src", "routes", "dynamic-path.tsx");
+
+        writeFileSync(
+          file,
+          `import { defineRoute } from "litzjs";\nconst path = "/dynamic";\nexport const route = defineRoute(path, { component: Dynamic });`,
+        );
+
+        const result = await discoverRouteFromFile(root, file);
+
+        expect(result).toBeNull();
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0]).toContain(
+          `exports "route", but the path could not be read from a static defineRoute call`,
+        );
+      } finally {
+        console.warn = originalWarn;
+        rmSync(root, { force: true, recursive: true });
+      }
+    });
   });
 
   describe("discoverLayoutFromFile", () => {
@@ -3116,6 +3174,35 @@ describe("manifest discovery", () => {
           clientModulePath: null,
         });
       } finally {
+        rmSync(root, { force: true, recursive: true });
+      }
+    });
+
+    test("warns when an API file imports defineApiRoute without exporting api", async () => {
+      const root = createTempProject();
+      const warnings: string[] = [];
+      const originalWarn = console.warn;
+      console.warn = (message?: unknown) => {
+        warnings.push(String(message));
+      };
+
+      try {
+        const file = path.join(root, "src", "routes", "api", "missing-export.ts");
+
+        writeFileSync(
+          file,
+          `import { defineApiRoute } from "litzjs";\nexport const health = defineApiRoute("/api/health", { GET() { return Response.json({ ok: true }); } });`,
+        );
+
+        const result = await discoverApiRouteFromFile(root, file);
+
+        expect(result).toBeNull();
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0]).toContain(
+          `imports defineApiRoute from "litzjs" but does not export the expected "api" binding`,
+        );
+      } finally {
+        console.warn = originalWarn;
         rmSync(root, { force: true, recursive: true });
       }
     });

--- a/www/src/routes/docs/routing.tsx
+++ b/www/src/routes/docs/routing.tsx
@@ -176,6 +176,43 @@ function SettingsPage() {
           however you like. The plugin only cares about the exported{" "}
           <code className="text-sky-400">route</code> binding, not the directory structure.
         </p>
+        <p className="text-neutral-400 mb-4">
+          Discovery is intentionally static. The supported declaration forms are:
+        </p>
+        <CodeBlock
+          language="tsx"
+          code={`export const route = defineRoute("/dashboard", {
+  component: DashboardPage,
+});
+
+const dashboardRoute = defineRoute("/dashboard", {
+  component: DashboardPage,
+});
+
+export { dashboardRoute as route };`}
+        />
+        <p className="text-neutral-400 mt-4 mb-4">
+          The path must be a string literal or no-substitution template literal in the{" "}
+          <code className="text-sky-400">defineRoute</code> call. Local aliases and simple wrappers
+          are supported only when they resolve back to that static call.
+        </p>
+        <p className="text-neutral-400 mb-4">
+          These forms are not discovered and will warn during dev or build when the file imports{" "}
+          <code className="text-sky-400">defineRoute</code> from{" "}
+          <code className="text-sky-400">"litzjs"</code>:
+        </p>
+        <CodeBlock
+          language="tsx"
+          code={`const path = "/dashboard";
+
+export const route = defineRoute(path, {
+  component: DashboardPage,
+});
+
+export const dashboardRoute = defineRoute("/dashboard", {
+  component: DashboardPage,
+});`}
+        />
       </section>
 
       <div className="flex justify-between pt-8 border-t border-neutral-800">

--- a/www/src/routes/docs/troubleshooting.tsx
+++ b/www/src/routes/docs/troubleshooting.tsx
@@ -81,6 +81,20 @@ import { litz } from "litzjs/vite";`}
             <code className="text-sky-400">defineRoute("/path", ...)</code>.
           </li>
           <li>
+            Keep the route path static. Discovery reads string literals in{" "}
+            <code className="text-sky-400">defineRoute</code>,{" "}
+            <code className="text-sky-400">defineLayout</code>,{" "}
+            <code className="text-sky-400">defineResource</code>, and{" "}
+            <code className="text-sky-400">defineApiRoute</code> calls; paths stored in variables
+            are ignored.
+          </li>
+          <li>
+            Treat <code className="text-sky-400">[litzjs]</code> discovery warnings as registration
+            failures. They mean a matched file imports a Litz route factory but does not export the
+            required binding name, or the exported binding does not resolve to a static factory
+            call.
+          </li>
+          <li>
             Keep page routes inside the configured route globs. The default is{" "}
             <code className="text-sky-400">{"src/routes/**/*.{ts,tsx}"}</code>, excluding the{" "}
             <code className="text-sky-400">api</code> and{" "}


### PR DESCRIPTION
## Summary

Closes #110.

Adds actionable Vite discovery warnings for route-like modules that look like they should be registered but are silently skipped today. A matched file now warns when it imports the relevant Litz factory from `litzjs` but either:

- does not export the required binding name (`route`, `layout`, `resource`, or `api`), or
- exports the required binding but the definition does not resolve to a static factory call with a literal path.

This keeps helper files without Litz route factories quiet while making likely accidental discovery failures visible during dev/build.

## Docs

Updated Routing and Troubleshooting docs to describe:

- supported discovery forms (`export const route = ...` and alias exports),
- static path requirements, and
- unsupported dynamic-path / wrong-export patterns that now produce warnings.

## Tests

- `bun fmt`
- `bun lint:fix`
- `bun test tests/vite.test.ts`
- `bun typecheck`
- `bun test`

A patch changeset is included.
