### PR TITLE
fix: contain client runtime globals

### DIFF
--- a/.changeset/contain-client-runtime-globals.md
+++ b/.changeset/contain-client-runtime-globals.md
@@ -1,0 +1,5 @@
+---
+"litzjs": patch
+---
+
+Move normal client runtime state off `globalThis` and configure base URL, client bindings, and React contexts through module-local runtime state.

--- a/src/client/base-url.ts
+++ b/src/client/base-url.ts
@@ -1,7 +1,9 @@
 import { joinBasePath } from "../base-path";
 
-declare global {
-  var __litzjsBaseUrl: string | undefined;
+let configuredBaseUrl: string | undefined;
+
+export function configureClientBaseUrl(baseUrl: string | undefined): void {
+  configuredBaseUrl = baseUrl;
 }
 
 export function resolveClientTransportPath(pathname: string): string {
@@ -9,5 +11,5 @@ export function resolveClientTransportPath(pathname: string): string {
 }
 
 function resolveConfiguredBaseUrl(): string | undefined {
-  return globalThis.__litzjsBaseUrl;
+  return configuredBaseUrl;
 }

--- a/src/client/bindings.ts
+++ b/src/client/bindings.ts
@@ -69,18 +69,16 @@ export type LitzClientBindings = {
   ): React.ComponentType<any>;
 };
 
-declare global {
-  var __litzjsClientBindings: LitzClientBindings | null | undefined;
-}
+let clientBindings: LitzClientBindings | null = null;
 
 export function installClientBindings(bindings: LitzClientBindings): void {
-  globalThis.__litzjsClientBindings = bindings;
+  clientBindings = bindings;
 }
 
 export function getClientBindings(): LitzClientBindings | null {
-  return globalThis.__litzjsClientBindings ?? null;
+  return clientBindings;
 }
 
 export function resetClientBindings(): void {
-  globalThis.__litzjsClientBindings = null;
+  clientBindings = null;
 }

--- a/src/client/contexts.ts
+++ b/src/client/contexts.ts
@@ -1,35 +1,33 @@
 import * as React from "react";
 
-declare global {
-  var __litzjsNavigationContext:
-    | React.Context<{
-        navigate(href: string, options?: { replace?: boolean }): void;
-      } | null>
-    | undefined;
-  var __litzjsLocationContext:
-    | React.Context<{
-        href: string;
-        pathname: string;
+let navigationContext:
+  | React.Context<{
+      navigate(href: string, options?: { replace?: boolean }): void;
+    } | null>
+  | undefined;
+let locationContext:
+  | React.Context<{
+      href: string;
+      pathname: string;
+      search: URLSearchParams;
+      hash: string;
+    } | null>
+  | undefined;
+let matchesContext:
+  | React.Context<
+      Array<{
+        id: string;
+        path: string;
+        params: Record<string, string>;
         search: URLSearchParams;
-        hash: string;
-      } | null>
-    | undefined;
-  var __litzjsMatchesContext:
-    | React.Context<
-        Array<{
-          id: string;
-          path: string;
-          params: Record<string, string>;
-          search: URLSearchParams;
-        }>
-      >
-    | undefined;
-}
+      }>
+    >
+  | undefined;
 
 export function getNavigationContext(): React.Context<{
   navigate(href: string, options?: { replace?: boolean }): void;
 } | null> {
-  if (!globalThis.__litzjsNavigationContext) {
+  if (!navigationContext) {
     const createContext = (
       React as typeof React & {
         createContext?: typeof React.createContext;
@@ -40,12 +38,12 @@ export function getNavigationContext(): React.Context<{
       throw new Error("Litz client navigation is not available in this environment.");
     }
 
-    globalThis.__litzjsNavigationContext = createContext<{
+    navigationContext = createContext<{
       navigate(href: string, options?: { replace?: boolean }): void;
     } | null>(null);
   }
 
-  return globalThis.__litzjsNavigationContext;
+  return navigationContext;
 }
 
 export function getLocationContext(): React.Context<{
@@ -54,7 +52,7 @@ export function getLocationContext(): React.Context<{
   search: URLSearchParams;
   hash: string;
 } | null> {
-  if (!globalThis.__litzjsLocationContext) {
+  if (!locationContext) {
     const createContext = (
       React as typeof React & {
         createContext?: typeof React.createContext;
@@ -65,7 +63,7 @@ export function getLocationContext(): React.Context<{
       throw new Error("Litz client location is not available in this environment.");
     }
 
-    globalThis.__litzjsLocationContext = createContext<{
+    locationContext = createContext<{
       href: string;
       pathname: string;
       search: URLSearchParams;
@@ -73,7 +71,7 @@ export function getLocationContext(): React.Context<{
     } | null>(null);
   }
 
-  return globalThis.__litzjsLocationContext;
+  return locationContext;
 }
 
 export function getMatchesContext(): React.Context<
@@ -84,7 +82,7 @@ export function getMatchesContext(): React.Context<
     search: URLSearchParams;
   }>
 > {
-  if (!globalThis.__litzjsMatchesContext) {
+  if (!matchesContext) {
     const createContext = (
       React as typeof React & {
         createContext?: typeof React.createContext;
@@ -95,7 +93,7 @@ export function getMatchesContext(): React.Context<
       throw new Error("Litz client matches are not available in this environment.");
     }
 
-    globalThis.__litzjsMatchesContext = createContext<
+    matchesContext = createContext<
       Array<{
         id: string;
         path: string;
@@ -105,5 +103,5 @@ export function getMatchesContext(): React.Context<
     >([]);
   }
 
-  return globalThis.__litzjsMatchesContext;
+  return matchesContext;
 }

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -13,6 +13,7 @@ import {
 } from "../path-matching";
 import { createSearchParamRecord, type SearchParamRecord } from "../search-params";
 import { isAbortError } from "./abort-error";
+import { configureClientBaseUrl } from "./base-url";
 import { installClientBindings } from "./bindings";
 import { getLocationContext, getMatchesContext, getNavigationContext } from "./contexts";
 import {
@@ -150,6 +151,10 @@ export interface MountAppOptions {
   readonly notFound?: React.ComponentType;
   readonly scrollRestoration?: boolean;
   readonly focusManagement?: boolean;
+}
+
+export function configureClientRuntime(options: { baseUrl?: string | undefined }): void {
+  configureClientBaseUrl(options.baseUrl);
 }
 
 for (const entry of manifest) {

--- a/src/client/resources.tsx
+++ b/src/client/resources.tsx
@@ -97,12 +97,10 @@ const resourceStore = new Map<string, ResourceStoreEntry>();
 const resourceFormComponentCache = new Map<string, React.ComponentType<RouteFormProps>>();
 const resourceComponentCache = new Map<string, React.ComponentType<any>>();
 
-declare global {
-  var __litzjsResourceLocationContext: React.Context<ResourceLocationState | null> | undefined;
-  var __litzjsResourceStatusContext: React.Context<ResourceStatusState | null> | undefined;
-  var __litzjsResourceDataContext: React.Context<ResourceDataState | null> | undefined;
-  var __litzjsResourceActionsContext: React.Context<ResourceActionsState | null> | undefined;
-}
+let resourceLocationContext: React.Context<ResourceLocationState | null> | undefined;
+let resourceStatusContext: React.Context<ResourceStatusState | null> | undefined;
+let resourceDataContext: React.Context<ResourceDataState | null> | undefined;
+let resourceActionsContext: React.Context<ResourceActionsState | null> | undefined;
 
 function createRuntimeContext<T>(name: string): React.Context<T | null> {
   const createContext = (
@@ -119,39 +117,35 @@ function createRuntimeContext<T>(name: string): React.Context<T | null> {
 }
 
 function getResourceLocationContext(): React.Context<ResourceLocationState | null> {
-  if (!globalThis.__litzjsResourceLocationContext) {
-    globalThis.__litzjsResourceLocationContext =
-      createRuntimeContext<ResourceLocationState>("Litz resource location");
+  if (!resourceLocationContext) {
+    resourceLocationContext = createRuntimeContext<ResourceLocationState>("Litz resource location");
   }
 
-  return globalThis.__litzjsResourceLocationContext;
+  return resourceLocationContext;
 }
 
 function getResourceStatusContext(): React.Context<ResourceStatusState | null> {
-  if (!globalThis.__litzjsResourceStatusContext) {
-    globalThis.__litzjsResourceStatusContext =
-      createRuntimeContext<ResourceStatusState>("Litz resource status");
+  if (!resourceStatusContext) {
+    resourceStatusContext = createRuntimeContext<ResourceStatusState>("Litz resource status");
   }
 
-  return globalThis.__litzjsResourceStatusContext;
+  return resourceStatusContext;
 }
 
 function getResourceDataContext(): React.Context<ResourceDataState | null> {
-  if (!globalThis.__litzjsResourceDataContext) {
-    globalThis.__litzjsResourceDataContext =
-      createRuntimeContext<ResourceDataState>("Litz resource data");
+  if (!resourceDataContext) {
+    resourceDataContext = createRuntimeContext<ResourceDataState>("Litz resource data");
   }
 
-  return globalThis.__litzjsResourceDataContext;
+  return resourceDataContext;
 }
 
 function getResourceActionsContext(): React.Context<ResourceActionsState | null> {
-  if (!globalThis.__litzjsResourceActionsContext) {
-    globalThis.__litzjsResourceActionsContext =
-      createRuntimeContext<ResourceActionsState>("Litz resource actions");
+  if (!resourceActionsContext) {
+    resourceActionsContext = createRuntimeContext<ResourceActionsState>("Litz resource actions");
   }
 
-  return globalThis.__litzjsResourceActionsContext;
+  return resourceActionsContext;
 }
 
 function requireActiveResourceSlice<T extends { id: string }>(

--- a/src/client/route-runtime.tsx
+++ b/src/client/route-runtime.tsx
@@ -48,14 +48,11 @@ export type RouteRuntimeState = RouteLocationState &
   RouteDataState &
   RouteActionsState;
 
-declare global {
-  var __litzjsRouteLocationContext: React.Context<RouteLocationState | null> | undefined;
-  var __litzjsRouteStatusContext: React.Context<RouteStatusState | null> | undefined;
-  var __litzjsRouteDataContext: React.Context<RouteDataState | null> | undefined;
-  var __litzjsRouteActionsContext: React.Context<RouteActionsState | null> | undefined;
-}
-
 const routeFormComponentCache = new Map<string, React.ComponentType<RouteFormProps>>();
+let routeLocationContext: React.Context<RouteLocationState | null> | undefined;
+let routeStatusContext: React.Context<RouteStatusState | null> | undefined;
+let routeDataContext: React.Context<RouteDataState | null> | undefined;
+let routeActionsContext: React.Context<RouteActionsState | null> | undefined;
 
 function createRuntimeContext<T>(name: string): React.Context<T | null> {
   const createContext = (
@@ -72,38 +69,35 @@ function createRuntimeContext<T>(name: string): React.Context<T | null> {
 }
 
 function getRouteLocationContext(): React.Context<RouteLocationState | null> {
-  if (!globalThis.__litzjsRouteLocationContext) {
-    globalThis.__litzjsRouteLocationContext =
-      createRuntimeContext<RouteLocationState>("Litz route location");
+  if (!routeLocationContext) {
+    routeLocationContext = createRuntimeContext<RouteLocationState>("Litz route location");
   }
 
-  return globalThis.__litzjsRouteLocationContext;
+  return routeLocationContext;
 }
 
 function getRouteStatusContext(): React.Context<RouteStatusState | null> {
-  if (!globalThis.__litzjsRouteStatusContext) {
-    globalThis.__litzjsRouteStatusContext =
-      createRuntimeContext<RouteStatusState>("Litz route status");
+  if (!routeStatusContext) {
+    routeStatusContext = createRuntimeContext<RouteStatusState>("Litz route status");
   }
 
-  return globalThis.__litzjsRouteStatusContext;
+  return routeStatusContext;
 }
 
 function getRouteDataContext(): React.Context<RouteDataState | null> {
-  if (!globalThis.__litzjsRouteDataContext) {
-    globalThis.__litzjsRouteDataContext = createRuntimeContext<RouteDataState>("Litz route data");
+  if (!routeDataContext) {
+    routeDataContext = createRuntimeContext<RouteDataState>("Litz route data");
   }
 
-  return globalThis.__litzjsRouteDataContext;
+  return routeDataContext;
 }
 
 function getRouteActionsContext(): React.Context<RouteActionsState | null> {
-  if (!globalThis.__litzjsRouteActionsContext) {
-    globalThis.__litzjsRouteActionsContext =
-      createRuntimeContext<RouteActionsState>("Litz route actions");
+  if (!routeActionsContext) {
+    routeActionsContext = createRuntimeContext<RouteActionsState>("Litz route actions");
   }
 
-  return globalThis.__litzjsRouteActionsContext;
+  return routeActionsContext;
 }
 
 function requireActiveRouteSlice<T extends { id: string }>(routeId: string, value: T | null): T {

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -292,15 +292,17 @@ export default createServer({
       if (id === RESOLVED_LITZ_BROWSER_ENTRY_ID) {
         return `
 if (import.meta.hot) {
+  // Dev-only HMR bridge for Vite updates. Ordinary client runtime state is
+  // configured through configureClientRuntime instead of globalThis.
   globalThis.__litzjsViteHot = import.meta.hot;
 }
 
-// The imported app graph executes before this assignment, but the transport
-// helpers only read the value lazily during fetch calls, matching the existing
-// HMR global pattern above.
-globalThis.__litzjsBaseUrl = ${JSON.stringify(configuredBase)};
-
+import { configureClientRuntime } from "litzjs/client";
 import ${JSON.stringify(toBrowserImportSpecifier(root, browserEntryPath, configuredBase))};
+
+configureClientRuntime({
+  baseUrl: ${JSON.stringify(configuredBase)},
+});
 `;
       }
 

--- a/tests/client-bindings.test.ts
+++ b/tests/client-bindings.test.ts
@@ -93,25 +93,24 @@ function createBindings(): LitzClientBindings {
 
 describe("client binding singletons", () => {
   afterEach(() => {
-    delete globalThis.__litzjsClientBindings;
     resetClientBindings();
   });
 
-  test("stores installed client bindings on globalThis", () => {
+  test("stores installed client bindings in module-local runtime state", () => {
     const bindings = createBindings();
 
     installClientBindings(bindings);
 
     expect(getClientBindings()).toBe(bindings);
-    expect(globalThis.__litzjsClientBindings).toBe(bindings);
+    expect("__litzjsClientBindings" in globalThis).toBe(false);
   });
 
-  test("clears global client bindings on reset", () => {
+  test("clears client bindings on reset without writing to globalThis", () => {
     installClientBindings(createBindings());
 
     resetClientBindings();
 
     expect(getClientBindings()).toBeNull();
-    expect(globalThis.__litzjsClientBindings).toBeNull();
+    expect("__litzjsClientBindings" in globalThis).toBe(false);
   });
 });

--- a/tests/client-contexts.test.ts
+++ b/tests/client-contexts.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 
 import {
   getLocationContext,
@@ -7,33 +7,27 @@ import {
 } from "../src/client/contexts";
 
 describe("client context singletons", () => {
-  afterEach(() => {
-    delete globalThis.__litzjsNavigationContext;
-    delete globalThis.__litzjsLocationContext;
-    delete globalThis.__litzjsMatchesContext;
-  });
-
-  test("reuses the global navigation context across repeated access", () => {
+  test("reuses the module-local navigation context across repeated access", () => {
     const first = getNavigationContext();
     const second = getNavigationContext();
 
     expect(first).toBe(second);
-    expect(globalThis.__litzjsNavigationContext).toBe(first);
+    expect("__litzjsNavigationContext" in globalThis).toBe(false);
   });
 
-  test("reuses the global location context across repeated access", () => {
+  test("reuses the module-local location context across repeated access", () => {
     const first = getLocationContext();
     const second = getLocationContext();
 
     expect(first).toBe(second);
-    expect(globalThis.__litzjsLocationContext).toBe(first);
+    expect("__litzjsLocationContext" in globalThis).toBe(false);
   });
 
-  test("reuses the global matches context across repeated access", () => {
+  test("reuses the module-local matches context across repeated access", () => {
     const first = getMatchesContext();
     const second = getMatchesContext();
 
     expect(first).toBe(second);
-    expect(globalThis.__litzjsMatchesContext).toBe(first);
+    expect("__litzjsMatchesContext" in globalThis).toBe(false);
   });
 });

--- a/tests/loader-fetch.test.ts
+++ b/tests/loader-fetch.test.ts
@@ -3,10 +3,10 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { LoaderSettledResult } from "../src/client/loader-fetch";
 import type { LoaderHookResult } from "../src/index";
 
+import { configureClientBaseUrl } from "../src/client/base-url";
+
 const mockFetch = mock<typeof fetch>();
 const originalFetch = globalThis.fetch;
-const baseUrlTarget = globalThis as typeof globalThis & { __litzjsBaseUrl?: string };
-const originalBaseUrl = baseUrlTarget.__litzjsBaseUrl;
 
 import { processLoaderResults } from "../src/client/loader-fetch";
 
@@ -40,12 +40,12 @@ beforeEach(() => {
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
-  baseUrlTarget.__litzjsBaseUrl = originalBaseUrl;
+  configureClientBaseUrl(undefined);
 });
 
 describe("fetchRouteLoadersInParallel", () => {
   test("uses the configured client base for internal route loader requests", async () => {
-    baseUrlTarget.__litzjsBaseUrl = "/app/";
+    configureClientBaseUrl("/app/");
     mockFetch.mockResolvedValue(
       createTransportResponse({
         kind: "data",
@@ -66,7 +66,7 @@ describe("fetchRouteLoadersInParallel", () => {
   });
 
   test("uses the configured client base for internal route action requests", async () => {
-    baseUrlTarget.__litzjsBaseUrl = "/app/";
+    configureClientBaseUrl("/app/");
     mockFetch.mockResolvedValue(
       createTransportResponse({
         kind: "data",

--- a/tests/resource-runtime.test.tsx
+++ b/tests/resource-runtime.test.tsx
@@ -4,6 +4,7 @@ import { act } from "react";
 import { useFormStatus } from "react-dom";
 import { createRoot, type Root } from "react-dom/client";
 
+import { configureClientBaseUrl } from "../src/client/base-url";
 import { installClientBindings, resetClientBindings } from "../src/client/bindings";
 import {
   createResourceComponent,
@@ -27,9 +28,6 @@ type Deferred<T> = {
   promise: Promise<T>;
   resolve(value: T): void;
 };
-
-const baseUrlTarget = globalThis as typeof globalThis & { __litzjsBaseUrl?: string };
-const originalBaseUrl = baseUrlTarget.__litzjsBaseUrl;
 
 type IsExact<T, U> =
   (<Value>() => Value extends T ? 1 : 2) extends <Value>() => Value extends U ? 1 : 2
@@ -303,7 +301,7 @@ describe("resource runtime", () => {
     }
 
     globalThis.fetch = originalFetch;
-    baseUrlTarget.__litzjsBaseUrl = originalBaseUrl;
+    configureClientBaseUrl(undefined);
     resetClientBindings();
     container?.remove();
     cleanupDom?.();
@@ -402,7 +400,7 @@ describe("resource runtime", () => {
 
   test("uses the configured client base for internal resource requests", async () => {
     const requestUrls: string[] = [];
-    baseUrlTarget.__litzjsBaseUrl = "/app/";
+    configureClientBaseUrl("/app/");
 
     globalThis.fetch = (async (input: RequestInfo | URL) => {
       requestUrls.push(

--- a/tests/runtime-context-singletons.test.tsx
+++ b/tests/runtime-context-singletons.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import * as React from "react";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
@@ -24,6 +24,18 @@ const resourceRuntimeGlobalKeys = [
 
 async function importFresh<TModule>(path: string): Promise<TModule> {
   return (await import(`${path}?fresh=${Math.random().toString(36).slice(2)}`)) as TModule;
+}
+
+async function withoutConsoleError(callback: () => Promise<void>): Promise<void> {
+  const originalConsoleError = console.error;
+
+  console.error = () => {};
+
+  try {
+    await callback();
+  } finally {
+    console.error = originalConsoleError;
+  }
 }
 
 function createRouteRuntimeState(): RouteRuntimeState {
@@ -66,13 +78,29 @@ function createResourceRuntimeState(): ResourceRuntimeState {
   };
 }
 
-describe("runtime context isolation", () => {
-  afterEach(() => {
-    for (const key of [...routeRuntimeGlobalKeys, ...resourceRuntimeGlobalKeys]) {
-      Reflect.deleteProperty(globalThis, key);
-    }
-  });
+class ErrorBoundary extends React.Component<
+  {
+    onError(error: unknown): void;
+    children: React.ReactNode;
+  },
+  { hasError: boolean }
+> {
+  override state = { hasError: false };
 
+  static getDerivedStateFromError(): { hasError: boolean } {
+    return { hasError: true };
+  }
+
+  override componentDidCatch(error: unknown): void {
+    this.props.onError(error);
+  }
+
+  override render(): React.ReactNode {
+    return this.state.hasError ? null : this.props.children;
+  }
+}
+
+describe("runtime context isolation", () => {
   test("route runtime contexts stay module-local across fresh imports", async () => {
     const dom = installTestDom();
     const container = document.createElement("div");
@@ -96,6 +124,12 @@ describe("runtime context isolation", () => {
         return <div data-route-id={routeId} />;
       }
 
+      function ReaderB(): React.ReactElement {
+        const routeId = routeRuntimeB.useRequiredRouteLocation("/projects/:id").id;
+        observedRouteIds.push(routeId);
+        return <div data-route-id={routeId} />;
+      }
+
       await act(async () => {
         root.render(
           <routeRuntimeA.RouteRuntimeProvider value={createRouteRuntimeState()}>
@@ -106,6 +140,28 @@ describe("runtime context isolation", () => {
       });
 
       expect(observedRouteIds).toEqual(["/projects/:id"]);
+
+      const errors: unknown[] = [];
+
+      await withoutConsoleError(async () => {
+        await act(async () => {
+          root.render(
+            <ErrorBoundary onError={(error) => errors.push(error)}>
+              <routeRuntimeA.RouteRuntimeProvider value={createRouteRuntimeState()}>
+                <ReaderB />
+              </routeRuntimeA.RouteRuntimeProvider>
+            </ErrorBoundary>,
+          );
+          await flushDom();
+        });
+      });
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toBeInstanceOf(Error);
+      expect((errors[0] as Error).message).toBe(
+        'Route "/projects/:id" is being used outside the Litz runtime.',
+      );
+
       for (const key of routeRuntimeGlobalKeys) {
         expect(key in globalThis).toBe(false);
       }
@@ -142,6 +198,13 @@ describe("runtime context isolation", () => {
         return <div data-resource-id={resourceId} />;
       }
 
+      function ReaderB(): React.ReactElement {
+        const resourceId =
+          resourceRuntimeB.useRequiredResourceLocation("/resources/projects/:id").id;
+        observedResourceIds.push(resourceId);
+        return <div data-resource-id={resourceId} />;
+      }
+
       await act(async () => {
         root.render(
           <resourceRuntimeA.ResourceRuntimeProvider value={createResourceRuntimeState()}>
@@ -152,6 +215,28 @@ describe("runtime context isolation", () => {
       });
 
       expect(observedResourceIds).toEqual(["/resources/projects/:id"]);
+
+      const errors: unknown[] = [];
+
+      await withoutConsoleError(async () => {
+        await act(async () => {
+          root.render(
+            <ErrorBoundary onError={(error) => errors.push(error)}>
+              <resourceRuntimeA.ResourceRuntimeProvider value={createResourceRuntimeState()}>
+                <ReaderB />
+              </resourceRuntimeA.ResourceRuntimeProvider>
+            </ErrorBoundary>,
+          );
+          await flushDom();
+        });
+      });
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toBeInstanceOf(Error);
+      expect((errors[0] as Error).message).toBe(
+        'Resource "/resources/projects/:id" is being used outside its resource component.',
+      );
+
       for (const key of resourceRuntimeGlobalKeys) {
         expect(key in globalThis).toBe(false);
       }

--- a/tests/runtime-context-singletons.test.tsx
+++ b/tests/runtime-context-singletons.test.tsx
@@ -66,14 +66,14 @@ function createResourceRuntimeState(): ResourceRuntimeState {
   };
 }
 
-describe("runtime context singletons", () => {
+describe("runtime context isolation", () => {
   afterEach(() => {
     for (const key of [...routeRuntimeGlobalKeys, ...resourceRuntimeGlobalKeys]) {
-      delete globalThis[key];
+      Reflect.deleteProperty(globalThis, key);
     }
   });
 
-  test("route runtime contexts survive hot re-imports", async () => {
+  test("route runtime contexts stay module-local across fresh imports", async () => {
     const dom = installTestDom();
     const container = document.createElement("div");
     document.body.appendChild(container);
@@ -86,29 +86,29 @@ describe("runtime context singletons", () => {
       const routeRuntimeB = await importFresh<typeof import("../src/client/route-runtime")>(
         "../src/client/route-runtime",
       );
-      const observedRouteId: { current: string | null } = { current: null };
+      const observedRouteIds: string[] = [];
 
       expect(routeRuntimeA.RouteRuntimeProvider).not.toBe(routeRuntimeB.RouteRuntimeProvider);
 
-      function Reader(): React.ReactElement {
-        observedRouteId.current = routeRuntimeB.useRequiredRouteLocation("/projects/:id").id;
-        return <div data-route-id={observedRouteId.current} />;
+      function ReaderA(): React.ReactElement {
+        const routeId = routeRuntimeA.useRequiredRouteLocation("/projects/:id").id;
+        observedRouteIds.push(routeId);
+        return <div data-route-id={routeId} />;
       }
 
       await act(async () => {
         root.render(
           <routeRuntimeA.RouteRuntimeProvider value={createRouteRuntimeState()}>
-            <Reader />
+            <ReaderA />
           </routeRuntimeA.RouteRuntimeProvider>,
         );
         await flushDom();
       });
 
-      expect(observedRouteId.current).toEqual("/projects/:id");
-      expect(globalThis.__litzjsRouteLocationContext).toBeDefined();
-      expect(globalThis.__litzjsRouteStatusContext).toBeDefined();
-      expect(globalThis.__litzjsRouteDataContext).toBeDefined();
-      expect(globalThis.__litzjsRouteActionsContext).toBeDefined();
+      expect(observedRouteIds).toEqual(["/projects/:id"]);
+      for (const key of routeRuntimeGlobalKeys) {
+        expect(key in globalThis).toBe(false);
+      }
     } finally {
       await act(async () => {
         root.unmount();
@@ -118,7 +118,7 @@ describe("runtime context singletons", () => {
     }
   });
 
-  test("resource runtime contexts survive hot re-imports", async () => {
+  test("resource runtime contexts stay module-local across fresh imports", async () => {
     const dom = installTestDom();
     const container = document.createElement("div");
     document.body.appendChild(container);
@@ -129,32 +129,32 @@ describe("runtime context singletons", () => {
         await importFresh<typeof import("../src/client/resources")>("../src/client/resources");
       const resourceRuntimeB =
         await importFresh<typeof import("../src/client/resources")>("../src/client/resources");
-      const observedResourceId: { current: string | null } = { current: null };
+      const observedResourceIds: string[] = [];
 
       expect(resourceRuntimeA.ResourceRuntimeProvider).not.toBe(
         resourceRuntimeB.ResourceRuntimeProvider,
       );
 
-      function Reader(): React.ReactElement {
-        observedResourceId.current =
-          resourceRuntimeB.useRequiredResourceLocation("/resources/projects/:id").id;
-        return <div data-resource-id={observedResourceId.current} />;
+      function ReaderA(): React.ReactElement {
+        const resourceId =
+          resourceRuntimeA.useRequiredResourceLocation("/resources/projects/:id").id;
+        observedResourceIds.push(resourceId);
+        return <div data-resource-id={resourceId} />;
       }
 
       await act(async () => {
         root.render(
           <resourceRuntimeA.ResourceRuntimeProvider value={createResourceRuntimeState()}>
-            <Reader />
+            <ReaderA />
           </resourceRuntimeA.ResourceRuntimeProvider>,
         );
         await flushDom();
       });
 
-      expect(observedResourceId.current).toEqual("/resources/projects/:id");
-      expect(globalThis.__litzjsResourceLocationContext).toBeDefined();
-      expect(globalThis.__litzjsResourceStatusContext).toBeDefined();
-      expect(globalThis.__litzjsResourceDataContext).toBeDefined();
-      expect(globalThis.__litzjsResourceActionsContext).toBeDefined();
+      expect(observedResourceIds).toEqual(["/resources/projects/:id"]);
+      for (const key of resourceRuntimeGlobalKeys) {
+        expect(key in globalThis).toBe(false);
+      }
     } finally {
       await act(async () => {
         root.unmount();

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -1193,6 +1193,11 @@ describe("dev server hot updates", () => {
       ) as string;
 
       expect(browserEntrySource).toContain('import "/app/@fs/');
+      expect(browserEntrySource).toContain(
+        'import { configureClientRuntime } from "litzjs/client";',
+      );
+      expect(browserEntrySource).toContain('baseUrl: "/app"');
+      expect(browserEntrySource).not.toContain("__litzjsBaseUrl");
     } finally {
       rmSync(root, { force: true, recursive: true });
     }


### PR DESCRIPTION
## Summary
- Move client base URL, client bindings, and runtime React contexts from public `globalThis.__litzjs*` singletons into module-local runtime state.
- Add `configureClientRuntime()` for the generated browser entry to configure the client base URL explicitly.
- Keep Vite HMR globals isolated to dev-only hot update plumbing and document that in the generated browser entry.
- Add regression coverage for binding reset behavior, module-local context state, explicit base URL configuration, and browser entry output.

Closes #111

## Testing
- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun test tests/vite.test.ts`
- `bun typecheck`

## Changeset
- Added `.changeset/contain-client-runtime-globals.md` as a patch changeset.