### PR TITLE
[codex] Make client entry explicit

### DIFF
--- a/.changeset/explicit-client-entry.md
+++ b/.changeset/explicit-client-entry.md
@@ -1,0 +1,7 @@
+---
+"litzjs": minor
+---
+
+Stop inferring the browser entry from HTML module scripts. Litz now uses an explicit `clientEntry`
+option, defaulting to `src/main.tsx`, and leaves explicit MPA HTML document requests for Vite to
+serve while retaining `index.html` fallback for extensionless app routes during development.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Add the Litz Vite plugin. By default, Litz discovers:
 - routes from `src/routes/**/*.{ts,tsx}`
 - API routes from `src/routes/api/**/*.{ts,tsx}`
 - resources from `src/routes/resources/**/*.{ts,tsx}`
+- the browser entry from `src/main.tsx`
 - a custom server entry from `src/server.ts`, falling back to `src/server/index.ts`
 
 `vite.config.ts`
@@ -56,6 +57,7 @@ You can still override discovery explicitly when you need a different project la
 export default defineConfig({
   plugins: [
     litz({
+      clientEntry: "app/main.tsx",
       routes: ["app/pages/**/*.{ts,tsx}"],
       resources: ["app/resources/**/*.{ts,tsx}"],
       api: ["app/api/**/*.{ts,tsx}"],
@@ -64,6 +66,11 @@ export default defineConfig({
   ],
 });
 ```
+
+Litz does not infer the browser entry by scanning HTML module scripts. Keep standard Vite
+`index.html` behavior and point Litz at a different browser entry with `clientEntry` when your
+project does not use `src/main.tsx`. During development, Vite serves explicit HTML documents such as
+`/about.html`; Litz only falls back to `index.html` for extensionless app routes.
 
 Mount the Litz app from your browser entry.
 

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -77,6 +77,8 @@ export interface LitzPluginOptions {
   readonly api?: string[];
   /** Glob patterns for resource files. */
   readonly resources?: string[];
+  /** Browser entry imported by Litz's generated client runtime module. */
+  readonly clientEntry?: string;
   /** Path to a custom server entry file. */
   readonly server?: string;
   /** Options forwarded to `@vitejs/plugin-rsc`. */
@@ -112,15 +114,6 @@ type DiscoveredApiRoute = {
   clientModulePath?: string | null;
 };
 
-type HtmlEntryInfo = {
-  /** The path to the HTML file relative to root */
-  htmlPath: string;
-  /** The module entry type */
-  type: "external" | "inline";
-  /** For external: the module path; for inline: a placeholder virtual id */
-  modulePath: string;
-};
-
 // Virtual module IDs. Each pair has a bare ID (used in import statements) and a
 // resolved ID prefixed with `\0` — the Vite convention that marks a module as
 // virtual so it is never resolved from disk.
@@ -147,8 +140,7 @@ const RESOLVED_LITZ_RSC_RENDERER_ID = "\0virtual:litzjs:rsc-renderer";
 export function litz(options: LitzPluginOptions = {}): PluginOption {
   let root = process.cwd();
   let configuredBase = "/";
-  let browserEntryPath = "src/main.tsx";
-  let htmlEntries: HtmlEntryInfo[] = [];
+  const browserEntryPath = options.clientEntry ?? "src/main.tsx";
   let serverEntryPath: string | null = null;
   let routeManifest: DiscoveredRoute[] = [];
   let layoutManifest: DiscoveredLayout[] = [];
@@ -195,8 +187,6 @@ export function litz(options: LitzPluginOptions = {}): PluginOption {
       root = config.root;
       configuredBase = normalizeBasePath(config.base);
 
-      htmlEntries = await discoverHtmlEntries(root, config.build.outDir || "dist");
-      browserEntryPath = resolveBrowserEntryPath(htmlEntries);
       serverEntryPath = await discoverServerEntry(root, options.server);
 
       ({ routeManifest, layoutManifest, resourceManifest, apiManifest } =
@@ -585,14 +575,7 @@ export async function renderView(node, metadata = {}) {
         void handleLitzApiRequest(server, apiManifest, request, response, next, configuredBase);
       });
       server.middlewares.use((request, response, next) => {
-        void handleLitzDocumentRequest(
-          server,
-          htmlEntries,
-          request,
-          response,
-          next,
-          configuredBase,
-        );
+        void handleLitzDocumentRequest(server, request, response, next, configuredBase);
       });
     },
 
@@ -680,126 +663,6 @@ export async function discoverAllManifests(
     resourceManifest: nextResourceManifest,
     apiManifest: sortByPathSpecificity(nextApiManifest),
   };
-}
-
-/**
- * Discovers all HTML entry files in the project root.
- * Supports HTML entry discovery for Litz's shared-client runtime.
- * Compatible entries may include:
- * - Root index.html with external module script
- * - Multiple HTML files that all share the same external module script
- * - Inline module scripts, which are discovered for validation purposes
- */
-export async function discoverHtmlEntries(
-  root: string,
-  buildOutDir = "dist",
-): Promise<HtmlEntryInfo[]> {
-  const entries: HtmlEntryInfo[] = [];
-  const htmlFiles = await glob("**/*.html", {
-    cwd: root,
-    absolute: true,
-    ignore: createHtmlEntryIgnorePatterns(root, buildOutDir),
-  });
-
-  for (const htmlFile of htmlFiles) {
-    try {
-      const html = await readFile(htmlFile, "utf8");
-      const relativePath = normalizeRelativePath(root, htmlFile);
-
-      const moduleScriptTag = html.match(
-        /<script\b(?=[^>]*\btype=["']module["'])[^>]*><\/script>/i,
-      );
-      const externalMatch = moduleScriptTag?.[0].match(/\bsrc=["']([^"']+)["']/i);
-
-      if (externalMatch?.[1]) {
-        const scriptSrc = externalMatch[1];
-        const modulePath = scriptSrc.startsWith("/") ? scriptSrc.slice(1) : scriptSrc;
-        entries.push({
-          htmlPath: relativePath,
-          type: "external",
-          modulePath,
-        });
-        continue;
-      }
-
-      const inlineMatch = html.match(/<script[^>]+type=["']module["'][^>]*>([\s\S]*?)<\/script>/i);
-
-      if (inlineMatch?.[1]?.trim()) {
-        entries.push({
-          htmlPath: relativePath,
-          type: "inline",
-          modulePath: `virtual:litzjs:inline-entry:${relativePath}`,
-        });
-      }
-    } catch {
-      // Skip files that can't be read
-    }
-  }
-
-  if (entries.length === 0) {
-    entries.push({
-      htmlPath: "index.html",
-      type: "external",
-      modulePath: "src/main.tsx",
-    });
-  }
-
-  return entries;
-}
-
-function createHtmlEntryIgnorePatterns(root: string, buildOutDir: string): string[] {
-  const ignorePatterns = [
-    "node_modules/**",
-    ".output/**",
-    "public/**",
-    "test/**",
-    "tests/**",
-    "e2e/**",
-    "cypress/**",
-    "coverage/**",
-    ".storybook/**",
-    "storybook-static/**",
-    "fixtures/**",
-  ];
-  const absoluteBuildOutDir = path.resolve(root, buildOutDir);
-  const relativeBuildOutDir = normalizeRelativePath(root, absoluteBuildOutDir);
-
-  if (
-    relativeBuildOutDir &&
-    relativeBuildOutDir !== "." &&
-    !relativeBuildOutDir.startsWith("../") &&
-    !path.isAbsolute(relativeBuildOutDir)
-  ) {
-    ignorePatterns.push(`${relativeBuildOutDir}/**`);
-  }
-
-  return ignorePatterns;
-}
-
-export function resolveBrowserEntryPath(entries: HtmlEntryInfo[]): string {
-  const inlineEntries = entries.filter((entry) => entry.type === "inline");
-
-  if (inlineEntries.length > 0) {
-    const files = inlineEntries.map((entry) => entry.htmlPath).join(", ");
-    throw new Error(
-      `[litzjs] Inline module scripts are not supported in HTML entries: ${files}. ` +
-        `Use an external script such as <script type="module" src="src/main.tsx"></script>.`,
-    );
-  }
-
-  const externalModulePaths = [...new Set(entries.map((entry) => entry.modulePath))];
-
-  if (externalModulePaths.length > 1) {
-    const entrySummary = entries
-      .map((entry) => `${entry.htmlPath} -> ${entry.modulePath}`)
-      .join(", ");
-    throw new Error(
-      `[litzjs] Multiple HTML entry module scripts are not supported by the current Vite integration. ` +
-        `All HTML entries must share the same external module script. Found: ${entrySummary}.`,
-    );
-  }
-
-  return externalModulePaths[0] ?? "src/main.tsx";
 }
 
 export async function discoverServerEntry(
@@ -1870,7 +1733,6 @@ export async function handleLitzRouteRequest(
 
 export async function handleLitzDocumentRequest(
   server: ViteDevServer,
-  htmlEntries: HtmlEntryInfo[],
   request: IncomingMessage,
   response: ServerResponse,
   next: Connect.NextFunction,
@@ -1912,14 +1774,12 @@ export async function handleLitzDocumentRequest(
   }
 
   try {
-    const htmlEntry = findHtmlEntryForPath(pathname, htmlEntries);
-
-    if (!htmlEntry) {
+    if (pathname === "/") {
       next();
       return;
     }
 
-    const templatePath = path.join(server.config.root, htmlEntry.htmlPath);
+    const templatePath = path.join(server.config.root, "index.html");
     const template = await readFile(templatePath, "utf8");
 
     const html = await server.transformIndexHtml(url, template);
@@ -1930,51 +1790,6 @@ export async function handleLitzDocumentRequest(
     server.ssrFixStacktrace(error as Error);
     next(error as Error);
   }
-}
-
-/**
- * Finds the appropriate HTML entry for a given request path.
- * Supports Vite's standard MPA patterns:
- * - / -> index.html
- * - /about -> about.html
- * - /nested/path -> nested/path.html or nested/path/index.html
- *
- * Entries are sorted by specificity (more specific paths first) to ensure
- * that /about/team matches /about/team.html before /about.html.
- */
-function findHtmlEntryForPath(pathname: string, entries: HtmlEntryInfo[]): HtmlEntryInfo | null {
-  if (entries.length === 0) {
-    return null;
-  }
-
-  const countNormalizedUrlSegments = (htmlPath: string) =>
-    htmlPath
-      .replace(/\.html$/, "")
-      .replace(/\/index$/, "")
-      .split("/")
-      .filter(Boolean).length;
-
-  // Sort by specificity: more URL path segments = more specific.
-  const sortedEntries = [...entries].sort((a, b) => {
-    return countNormalizedUrlSegments(b.htmlPath) - countNormalizedUrlSegments(a.htmlPath);
-  });
-
-  for (const entry of sortedEntries) {
-    const htmlPath = entry.htmlPath;
-    const normalizedPath = htmlPath.replace(/\.html$/, "").replace(/\/index$/, "");
-
-    if (normalizedPath === "index" && pathname === "/") {
-      return entry;
-    }
-
-    const entryPath = normalizedPath === "index" ? "/" : `/${normalizedPath}`;
-    if (pathname === entryPath || pathname.startsWith(`${entryPath}/`)) {
-      return entry;
-    }
-  }
-
-  const indexEntry = entries.find((e) => e.htmlPath === "index.html");
-  return indexEntry ?? null;
 }
 
 export async function handleLitzApiRequest(

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -1773,15 +1773,28 @@ export async function handleLitzDocumentRequest(
     return;
   }
 
+  if (pathname === "/") {
+    next();
+    return;
+  }
+
+  const templatePath = path.join(server.config.root, "index.html");
+  let template: string;
+
   try {
-    if (pathname === "/") {
+    template = await readFile(templatePath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
       next();
       return;
     }
 
-    const templatePath = path.join(server.config.root, "index.html");
-    const template = await readFile(templatePath, "utf8");
+    server.ssrFixStacktrace(error as Error);
+    next(error as Error);
+    return;
+  }
 
+  try {
     const html = await server.transformIndexHtml(url, template);
     response.statusCode = 200;
     response.setHeader("content-type", "text/html; charset=utf-8");

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -21,7 +21,6 @@ import {
   buildLitzApp,
   discoverAllManifests,
   discoverApiRouteFromFile,
-  discoverHtmlEntries,
   discoverLayoutFromFile,
   discoverResourceFromFile,
   discoverRouteFromFile,
@@ -1203,24 +1202,16 @@ describe("dev server hot updates", () => {
     }
   });
 
-  test("uses a shared external HTML module script for the generated browser entry", async () => {
-    const root = mkdtempSync(path.join(tmpdir(), "litz-browser-entry-html-shared-"));
+  test("uses the configured client entry for the generated browser entry", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "litz-browser-entry-client-entry-"));
 
     try {
       mkdirSync(path.join(root, "src"), { recursive: true });
-      writeFileSync(
-        path.join(root, "index.html"),
-        '<!doctype html><html><body><script type="module" src="/src/entry.tsx"></script></body></html>\n',
-        "utf8",
-      );
-      writeFileSync(
-        path.join(root, "about.html"),
-        '<!doctype html><html><body><script type="module" src="/src/entry.tsx"></script></body></html>\n',
-        "utf8",
-      );
       writeFileSync(path.join(root, "src", "entry.tsx"), "export {};\n", "utf8");
 
-      const plugin = (litz() as Plugin[]).find((candidate) => candidate.name === "litzjs/vite");
+      const plugin = (litz({ clientEntry: "src/entry.tsx" }) as Plugin[]).find(
+        (candidate) => candidate.name === "litzjs/vite",
+      );
 
       if (!plugin?.configResolved || !plugin.resolveId || !plugin.load) {
         throw new Error("Expected litzjs/vite browser-entry hooks to be available.");
@@ -1285,110 +1276,14 @@ describe("dev server hot updates", () => {
     }
   });
 
-  test("discovers external module scripts when src appears before type", async () => {
-    const root = mkdtempSync(path.join(tmpdir(), "litz-browser-entry-attr-order-"));
+  test("does not inspect HTML module scripts when resolving the default browser entry", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "litz-browser-entry-vite-html-"));
 
     try {
       mkdirSync(path.join(root, "src"), { recursive: true });
       writeFileSync(
         path.join(root, "index.html"),
-        '<!doctype html><html><body><script src="./src/main.tsx" type="module"></script></body></html>\n',
-        "utf8",
-      );
-      writeFileSync(path.join(root, "src", "main.tsx"), "export {};\n", "utf8");
-
-      const entries = await discoverHtmlEntries(root);
-
-      expect(entries).toEqual([
-        {
-          htmlPath: "index.html",
-          type: "external",
-          modulePath: "./src/main.tsx",
-        },
-      ]);
-    } finally {
-      rmSync(root, { force: true, recursive: true });
-    }
-  });
-
-  test("ignores HTML files inside a custom build output directory", async () => {
-    const root = mkdtempSync(path.join(tmpdir(), "litz-browser-entry-custom-outdir-"));
-
-    try {
-      mkdirSync(path.join(root, "src"), { recursive: true });
-      mkdirSync(path.join(root, "build"), { recursive: true });
-      writeFileSync(
-        path.join(root, "index.html"),
-        '<!doctype html><html><body><script type="module" src="/src/main.tsx"></script></body></html>\n',
-        "utf8",
-      );
-      writeFileSync(path.join(root, "src", "main.tsx"), "export {};\n", "utf8");
-      writeFileSync(
-        path.join(root, "build", "index.html"),
-        '<!doctype html><html><body><script type="module" src="/build/assets/app.js"></script></body></html>\n',
-        "utf8",
-      );
-
-      const entries = await discoverHtmlEntries(root, "build");
-
-      expect(entries).toEqual([
-        {
-          htmlPath: "index.html",
-          type: "external",
-          modulePath: "src/main.tsx",
-        },
-      ]);
-    } finally {
-      rmSync(root, { force: true, recursive: true });
-    }
-  });
-
-  test("ignores HTML files inside tool and fixture directories", async () => {
-    const root = mkdtempSync(path.join(tmpdir(), "litz-browser-entry-tooling-html-"));
-
-    try {
-      mkdirSync(path.join(root, "src"), { recursive: true });
-      mkdirSync(path.join(root, "cypress"), { recursive: true });
-      mkdirSync(path.join(root, ".storybook"), { recursive: true });
-      writeFileSync(
-        path.join(root, "index.html"),
-        '<!doctype html><html><body><script type="module" src="/src/main.tsx"></script></body></html>\n',
-        "utf8",
-      );
-      writeFileSync(path.join(root, "src", "main.tsx"), "export {};\n", "utf8");
-      writeFileSync(
-        path.join(root, "cypress", "fixture.html"),
-        '<!doctype html><html><body><script type="module" src="/cypress/fixture.js"></script></body></html>\n',
-        "utf8",
-      );
-      writeFileSync(
-        path.join(root, ".storybook", "preview-head.html"),
-        '<!doctype html><html><body><script type="module" src="/storybook/preview.js"></script></body></html>\n',
-        "utf8",
-      );
-
-      const entries = await discoverHtmlEntries(root);
-
-      expect(entries).toEqual([
-        {
-          htmlPath: "index.html",
-          type: "external",
-          modulePath: "src/main.tsx",
-        },
-      ]);
-    } finally {
-      rmSync(root, { force: true, recursive: true });
-    }
-  });
-
-  test("rejects HTML entries that use different external module scripts", async () => {
-    const root = mkdtempSync(path.join(tmpdir(), "litz-browser-entry-html-mismatch-"));
-
-    try {
-      mkdirSync(path.join(root, "src"), { recursive: true });
-      writeFileSync(
-        path.join(root, "index.html"),
-        '<!doctype html><html><body><script type="module" src="/src/main.tsx"></script></body></html>\n',
+        '<!doctype html><html><body><script type="module">console.log("inline");</script></body></html>\n',
         "utf8",
       );
       writeFileSync(
@@ -1410,108 +1305,34 @@ describe("dev server hot updates", () => {
           ? plugin.configResolved
           : plugin.configResolved.handler;
 
-      let error: unknown;
-
-      try {
-        await configResolved.call(
-          {} as never,
-          {
-            root,
-            base: "/",
-            command: "serve",
-            build: {
-              outDir: "dist",
-            },
-            environments: {
-              client: {
-                build: {
-                  outDir: path.join("dist", "client"),
-                },
+      await configResolved.call(
+        {} as never,
+        {
+          root,
+          base: "/",
+          command: "serve",
+          build: {
+            outDir: "dist",
+          },
+          environments: {
+            client: {
+              build: {
+                outDir: path.join("dist", "client"),
               },
-              rsc: {
-                build: {
-                  outDir: path.join("dist", "server"),
-                  rollupOptions: {
-                    output: {
-                      codeSplitting: false,
-                    },
+            },
+            rsc: {
+              build: {
+                outDir: path.join("dist", "server"),
+                rollupOptions: {
+                  output: {
+                    codeSplitting: false,
                   },
                 },
               },
             },
-          } as never,
-        );
-      } catch (caughtError) {
-        error = caughtError;
-      }
-
-      expect(error).toBeInstanceOf(Error);
-      expect((error as Error).message).toContain(
-        "All HTML entries must share the same external module script",
+          },
+        } as never,
       );
-    } finally {
-      rmSync(root, { force: true, recursive: true });
-    }
-  });
-
-  test("rejects HTML entries that use inline module scripts", async () => {
-    const root = mkdtempSync(path.join(tmpdir(), "litz-browser-entry-html-inline-"));
-
-    try {
-      writeFileSync(
-        path.join(root, "index.html"),
-        '<!doctype html><html><body><script type="module">console.log("inline");</script></body></html>\n',
-        "utf8",
-      );
-
-      const plugin = (litz() as Plugin[]).find((candidate) => candidate.name === "litzjs/vite");
-
-      if (!plugin?.configResolved) {
-        throw new Error("Expected litzjs/vite configResolved hook to be available.");
-      }
-
-      const configResolved =
-        typeof plugin.configResolved === "function"
-          ? plugin.configResolved
-          : plugin.configResolved.handler;
-
-      let error: unknown;
-
-      try {
-        await configResolved.call(
-          {} as never,
-          {
-            root,
-            base: "/",
-            command: "serve",
-            build: {
-              outDir: "dist",
-            },
-            environments: {
-              client: {
-                build: {
-                  outDir: path.join("dist", "client"),
-                },
-              },
-              rsc: {
-                build: {
-                  outDir: path.join("dist", "server"),
-                  rollupOptions: {
-                    output: {
-                      codeSplitting: false,
-                    },
-                  },
-                },
-              },
-            },
-          } as never,
-        );
-      } catch (caughtError) {
-        error = caughtError;
-      }
-
-      expect(error).toBeInstanceOf(Error);
-      expect((error as Error).message).toContain("Inline module scripts are not supported");
     } finally {
       rmSync(root, { force: true, recursive: true });
     }
@@ -1883,8 +1704,8 @@ function createMockResponse(): ServerResponse & { getBody(): string } {
 }
 
 describe("document entry resolution", () => {
-  test("prefers the more specific non-index entry over a sibling index entry", async () => {
-    const root = mkdtempSync(path.join(tmpdir(), "litz-document-specificity-"));
+  test("calls next for explicit MPA HTML paths so Vite can serve them", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "litz-document-vite-mpa-"));
 
     try {
       mkdirSync(path.join(root, "about", "team"), { recursive: true });
@@ -1911,28 +1732,10 @@ describe("document entry resolution", () => {
       const response = createMockResponse();
       const next = mock(() => {});
 
-      await handleLitzDocumentRequest(
-        server,
-        [
-          {
-            htmlPath: "about/team/index.html",
-            type: "external",
-            modulePath: "src/main.tsx",
-          },
-          {
-            htmlPath: "about/team/foo.html",
-            type: "external",
-            modulePath: "src/main.tsx",
-          },
-        ],
-        request,
-        response,
-        next,
-      );
+      await handleLitzDocumentRequest(server, request, response, next);
 
-      expect(response.statusCode).toBe(200);
-      expect(response.getBody()).toContain("team foo");
-      expect(next).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(response.getBody()).toBe("");
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -1957,16 +1760,7 @@ describe("document entry resolution", () => {
       const response = createMockResponse();
       const next = mock(() => {});
 
-      await handleLitzDocumentRequest(
-        server,
-        [
-          { htmlPath: "index.html", type: "external", modulePath: "src/main.tsx" },
-          { htmlPath: "about.html", type: "external", modulePath: "src/main.tsx" },
-        ],
-        request,
-        response,
-        next,
-      );
+      await handleLitzDocumentRequest(server, request, response, next);
 
       expect(response.statusCode).toBe(200);
       expect(response.getBody()).toContain("index");
@@ -1995,16 +1789,7 @@ describe("document entry resolution", () => {
       const response = createMockResponse();
       const next = mock(() => {});
 
-      await handleLitzDocumentRequest(
-        server,
-        [
-          { htmlPath: "about.html", type: "external", modulePath: "src/main.tsx" },
-          { htmlPath: "contact.html", type: "external", modulePath: "src/main.tsx" },
-        ],
-        request,
-        response,
-        next,
-      );
+      await handleLitzDocumentRequest(server, request, response, next);
 
       expect(next).toHaveBeenCalledTimes(1);
       expect(response.getBody()).toBe("");

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -1730,11 +1730,14 @@ describe("document entry resolution", () => {
         headers: { accept: "text/html" },
       });
       const response = createMockResponse();
-      const next = mock(() => {});
+      const next = mock((error?: unknown) => {
+        void error;
+      });
 
       await handleLitzDocumentRequest(server, request, response, next);
 
       expect(next).toHaveBeenCalledTimes(1);
+      expect(next.mock.calls[0]?.[0]).toBeUndefined();
       expect(response.getBody()).toBe("");
     } finally {
       rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Closes #112.

This PR stops the Litz Vite plugin from reimplementing Vite HTML entry discovery for the generated browser entry. The generated client runtime now imports an explicit `clientEntry` option, defaulting to `src/main.tsx`, instead of scanning HTML module scripts.

## Changes

- Added `clientEntry` to `LitzPluginOptions` with a documented default of `src/main.tsx`.
- Removed HTML entry scanning, inline module script rejection, shared-script validation, and custom MPA HTML path matching from the Vite plugin.
- Simplified dev document handling so explicit HTML document requests fall through to Vite, while extensionless app routes can still fall back to `index.html`.
- Updated tests to clarify that MPA HTML documents are served by Vite and that HTML scripts are not inspected for client entry resolution.
- Added a changeset describing the behavior change.

## Impact

Projects that use the default `src/main.tsx` entry require no config change. Projects with a different browser entry should set `litz({ clientEntry: "path/to/entry.tsx" })` instead of relying on an HTML script tag to configure Litz.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`
