### PR TITLE
fix: minimize default peer dependency surface

### DIFF
--- a/.changeset/tidy-peers-build.md
+++ b/.changeset/tidy-peers-build.md
@@ -1,0 +1,5 @@
+---
+"litzjs": patch
+---
+
+Reduce the default install peer surface by keeping `@vitejs/plugin-rsc` and `typescript` as implementation dependencies while documenting only React, React DOM, and Vite as the core app-provided packages. Clarify that Nitro is only needed for the optional `litzNitro()` adapter.

--- a/README.md
+++ b/README.md
@@ -24,11 +24,13 @@ Inside a React + Vite app:
 
 ```bash
 bun add litzjs react react-dom
-bun add -d typescript vite @vitejs/plugin-rsc
+bun add -d vite typescript
 ```
 
-The core Vite plugin does not require a deployment adapter. Install `nitro` only when you opt into
-the Nitro-backed production output shown below.
+Litz bundles the React Server Components plugin it uses internally, so the default setup does not
+ask applications to install `@vitejs/plugin-rsc` directly. The core Vite plugin also does not
+require a deployment adapter. Install `nitro` only when you opt into the Nitro-backed production
+output shown below.
 
 ## Quick Start
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,9 +5,10 @@
     "": {
       "name": "litz",
       "dependencies": {
-        "nitro": "3.0.260311-beta",
+        "@vitejs/plugin-rsc": "^0.5.21",
         "picomatch": "4.0.4",
         "tinyglobby": "0.2.15",
+        "typescript": "^6.0.2",
       },
       "devDependencies": {
         "@changesets/cli": "2.30.0",
@@ -16,9 +17,9 @@
         "@types/picomatch": "4.0.2",
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
-        "@vitejs/plugin-rsc": "0.5.21",
         "bun-types": "1.3.11",
         "happy-dom": "20.8.9",
+        "nitro": "3.0.260311-beta",
         "oxfmt": "0.42.0",
         "oxlint": "1.57.0",
         "oxlint-tsgolint": "0.18.1",
@@ -29,12 +30,14 @@
         "vite-plugin-pwa": "1.2.0",
       },
       "peerDependencies": {
-        "@vitejs/plugin-rsc": "^0.5.21",
+        "nitro": "^3",
         "react": "^19",
         "react-dom": "^19",
-        "typescript": "^6.0.2",
         "vite": "^8",
       },
+      "optionalPeers": [
+        "nitro",
+      ],
     },
   },
   "packages": {
@@ -1296,7 +1299,7 @@
 
     "typed-array-length": ["typed-array-length@1.0.7", "", { "dependencies": { "call-bind": "^1.0.7", "for-each": "^0.3.3", "gopd": "^1.0.1", "is-typed-array": "^1.1.13", "possible-typed-array-names": "^1.0.0", "reflect.getprototypeof": "^1.0.6" } }, "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
 

--- a/package.json
+++ b/package.json
@@ -73,8 +73,10 @@
     "fixture:build": "vite build --config fixtures/rsc-smoke/vite.config.ts"
   },
   "dependencies": {
+    "@vitejs/plugin-rsc": "^0.5.21",
     "picomatch": "4.0.4",
-    "tinyglobby": "0.2.15"
+    "tinyglobby": "0.2.15",
+    "typescript": "^6.0.2"
   },
   "devDependencies": {
     "@changesets/cli": "2.30.0",
@@ -83,7 +85,6 @@
     "@types/picomatch": "4.0.2",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
-    "@vitejs/plugin-rsc": "0.5.21",
     "bun-types": "1.3.11",
     "happy-dom": "20.8.9",
     "nitro": "3.0.260311-beta",
@@ -97,11 +98,9 @@
     "vite-plugin-pwa": "1.2.0"
   },
   "peerDependencies": {
-    "@vitejs/plugin-rsc": "^0.5.21",
     "nitro": "^3",
     "react": "^19",
     "react-dom": "^19",
-    "typescript": "^6.0.2",
     "vite": "^8"
   },
   "peerDependenciesMeta": {

--- a/tests/docs-package-names.test.ts
+++ b/tests/docs-package-names.test.ts
@@ -101,6 +101,9 @@ describe("docs package names", () => {
     expect(installationDoc).toContain("Optional capabilities");
     expect(installationDoc).toContain("@vitejs/plugin-rsc");
     expect(installationDoc).toContain("is bundled with");
+    expect(installationDoc).toContain("your app still needs its own TypeScript install");
+    expect(installationDoc).toContain("editor integration");
+    expect(installationDoc).toContain("local type-check scripts");
     expect(installationDoc).toContain("Runtime compatibility notes");
     expect(installationDoc).toContain("does not publish a single runtime engine floor");
   });

--- a/tests/docs-package-names.test.ts
+++ b/tests/docs-package-names.test.ts
@@ -39,7 +39,7 @@ describe("getting started docs flow", () => {
     expect(firstAppDoc).toContain('defineRoute("/docs/first-app"');
     expect(firstAppDoc).toContain("mkdir hello-litz");
     expect(firstAppDoc).toContain("bun add litzjs react react-dom");
-    expect(firstAppDoc).toContain("bun add -d typescript vite @vitejs/plugin-rsc");
+    expect(firstAppDoc).toContain("bun add -d typescript vite @types/react @types/react-dom");
     expect(firstAppDoc).toContain('import { litz } from "litzjs/vite";');
     expect(firstAppDoc).toContain(
       'Open <code className="text-sky-400">http://localhost:5173</code>.',
@@ -69,7 +69,7 @@ describe("docs package names", () => {
     expect(installationDoc).not.toMatch(/pnpm add litz(?!js)/);
   });
 
-  test("installation docs list the core peer dependency surface and optional Nitro adapter", () => {
+  test("installation docs list the minimal peer dependency surface and optional adapters", () => {
     const installationDoc = normalizeWhitespace(readDoc("www/src/routes/docs/installation.tsx"));
 
     expect(installationDoc).toContain("bun add react react-dom");
@@ -77,29 +77,50 @@ describe("docs package names", () => {
     expect(installationDoc).toContain("yarn add react react-dom");
     expect(installationDoc).toContain("pnpm add react react-dom");
 
-    expect(installationDoc).toContain("bun add -d typescript vite @vitejs/plugin-rsc");
+    expect(installationDoc).toContain("bun add -d vite typescript");
     expect(installationDoc).toContain("bun add -d nitro");
-    expect(installationDoc).toContain("npm install -D typescript vite @vitejs/plugin-rsc");
+    expect(installationDoc).toContain("npm install -D vite typescript");
     expect(installationDoc).toContain("npm install -D nitro");
-    expect(installationDoc).toContain("yarn add -D typescript vite @vitejs/plugin-rsc");
+    expect(installationDoc).toContain("yarn add -D vite typescript");
     expect(installationDoc).toContain("yarn add -D nitro");
-    expect(installationDoc).toContain("pnpm add -D typescript vite @vitejs/plugin-rsc");
+    expect(installationDoc).toContain("pnpm add -D vite typescript");
     expect(installationDoc).toContain("pnpm add -D nitro");
+    expect(installationDoc).not.toContain("bun add -d typescript vite @vitejs/plugin-rsc");
+    expect(installationDoc).not.toContain("npm install -D typescript vite @vitejs/plugin-rsc");
+    expect(installationDoc).not.toContain("yarn add -D typescript vite @vitejs/plugin-rsc");
+    expect(installationDoc).not.toContain("pnpm add -D typescript vite @vitejs/plugin-rsc");
 
     expect(installationDoc).toContain("Compatibility matrix");
     expect(installationDoc).toContain('packageName: "react"');
     expect(installationDoc).toContain('packageName: "react-dom"');
-    expect(installationDoc).toContain('packageName: "typescript"');
     expect(installationDoc).toContain('packageName: "vite"');
-    expect(installationDoc).toContain('packageName: "@vitejs/plugin-rsc"');
     expect(installationDoc).toContain('packageName: "nitro"');
     expect(installationDoc).toContain("^19");
-    expect(installationDoc).toContain("^6.0.2");
     expect(installationDoc).toContain("^8");
-    expect(installationDoc).toContain("^0.5.21");
     expect(installationDoc).toContain("^3");
+    expect(installationDoc).toContain("Optional capabilities");
+    expect(installationDoc).toContain("@vitejs/plugin-rsc");
+    expect(installationDoc).toContain("is bundled with");
     expect(installationDoc).toContain("Runtime compatibility notes");
     expect(installationDoc).toContain("does not publish a single runtime engine floor");
+  });
+
+  test("package metadata keeps implementation dependencies out of the default peer surface", () => {
+    const packageJson = JSON.parse(readDoc("package.json")) as {
+      readonly dependencies?: Record<string, string>;
+      readonly peerDependencies?: Record<string, string>;
+      readonly peerDependenciesMeta?: Record<string, { readonly optional?: boolean }>;
+    };
+
+    expect(packageJson.peerDependencies).toEqual({
+      nitro: "^3",
+      react: "^19",
+      "react-dom": "^19",
+      vite: "^8",
+    });
+    expect(packageJson.peerDependenciesMeta?.nitro?.optional).toBe(true);
+    expect(packageJson.dependencies?.["@vitejs/plugin-rsc"]).toBe("^0.5.21");
+    expect(packageJson.dependencies?.typescript).toBe("^6.0.2");
   });
 
   test("deployment and API reference docs use the published package name", () => {

--- a/www/src/routes/docs/first-app.tsx
+++ b/www/src/routes/docs/first-app.tsx
@@ -42,12 +42,14 @@ bun init -y`}
           2. Install Litz and the required packages
         </h2>
         <p className="text-neutral-400 mb-4">
-          Install the runtime packages first, then the TypeScript and Vite tooling:
+          Install the runtime packages first, then the TypeScript and Vite tooling. Litz bundles its
+          internal React Server Components plugin, so you do not need to install{" "}
+          <code className="text-sky-400">@vitejs/plugin-rsc</code> yourself.
         </p>
         <CodeBlock
           language="bash"
           code={`bun add litzjs react react-dom
-bun add -d typescript vite @vitejs/plugin-rsc @types/react @types/react-dom`}
+bun add -d typescript vite @types/react @types/react-dom`}
         />
         <p className="text-neutral-400 mt-4 mb-4">
           Install <code className="text-sky-400">nitro</code> only when you opt into the optional

--- a/www/src/routes/docs/installation.tsx
+++ b/www/src/routes/docs/installation.tsx
@@ -21,19 +21,9 @@ const compatibilityRows: readonly CompatibilityRow[] = [
     notes: "Required peer dependency for client mounting and server rendering.",
   },
   {
-    packageName: "typescript",
-    supportedVersion: "^6.0.2",
-    notes: "Required peer dependency for type-safe route definitions and the published types.",
-  },
-  {
     packageName: "vite",
     supportedVersion: "^8",
     notes: "Required peer dependency because Litz ships as a Vite-first framework plugin.",
-  },
-  {
-    packageName: "@vitejs/plugin-rsc",
-    supportedVersion: "^0.5.21",
-    notes: "Required peer dependency for the React Server Components pipeline.",
   },
   {
     packageName: "nitro",
@@ -75,7 +65,7 @@ function DocsInstallationPage() {
       <section className="mb-12">
         <h2 className="text-2xl font-semibold text-neutral-100 mb-4">Peer dependencies</h2>
         <p className="text-neutral-400 mb-4">
-          Litz expects your app to provide the core peer dependencies below. If your React + Vite
+          Litz keeps the default peer dependency surface close to a standard Vite React app. If your
           app already includes some of these packages, keep them within the supported ranges in the
           compatibility matrix.
         </p>
@@ -83,19 +73,19 @@ function DocsInstallationPage() {
           language="bash"
           code={`# With Bun
 bun add react react-dom
-bun add -d typescript vite @vitejs/plugin-rsc
+bun add -d vite typescript
 
 # With npm
 npm install react react-dom
-npm install -D typescript vite @vitejs/plugin-rsc
+npm install -D vite typescript
 
 # With Yarn
 yarn add react react-dom
-yarn add -D typescript vite @vitejs/plugin-rsc
+yarn add -D vite typescript
 
 # With pnpm
 pnpm add react react-dom
-pnpm add -D typescript vite @vitejs/plugin-rsc
+pnpm add -D vite typescript
 
 # Optional Nitro deployment adapter
 bun add -d nitro
@@ -109,13 +99,13 @@ pnpm add -D nitro`}
             <code className="text-sky-400">react-dom</code> as application dependencies.
           </li>
           <li>
-            Install <code className="text-sky-400">typescript</code>,{" "}
-            <code className="text-sky-400">vite</code>, and{" "}
-            <code className="text-sky-400">@vitejs/plugin-rsc</code> as development tooling.
+            Install <code className="text-sky-400">vite</code> and{" "}
+            <code className="text-sky-400">typescript</code> as development tooling.
           </li>
           <li>
-            Add <code className="text-sky-400">nitro</code> only when your Vite config uses{" "}
-            <code className="text-sky-400">litzNitro()</code>.
+            <code className="text-sky-400">@vitejs/plugin-rsc</code> is bundled with{" "}
+            <code className="text-sky-400">litzjs</code> for the core{" "}
+            <code className="text-sky-400">litz()</code> plugin.
           </li>
         </ul>
 
@@ -146,6 +136,15 @@ pnpm add -D nitro`}
             </tbody>
           </table>
         </div>
+
+        <h3 className="text-xl font-medium text-neutral-100 mb-3">Optional capabilities</h3>
+        <p className="text-neutral-400 mb-4">
+          The default <code className="text-sky-400">litz()</code> plugin includes the React Server
+          Components integration used by <code className="text-sky-400">view(...)</code>. Add{" "}
+          <code className="text-sky-400">nitro</code> only when your Vite config imports and uses{" "}
+          <code className="text-sky-400">litzNitro()</code> from{" "}
+          <code className="text-sky-400">"litzjs/vite/nitro"</code>.
+        </p>
 
         <h3 className="text-xl font-medium text-neutral-100 mb-3">Runtime compatibility notes</h3>
         <p className="text-neutral-400 mb-4">

--- a/www/src/routes/docs/installation.tsx
+++ b/www/src/routes/docs/installation.tsx
@@ -100,7 +100,9 @@ pnpm add -D nitro`}
           </li>
           <li>
             Install <code className="text-sky-400">vite</code> and{" "}
-            <code className="text-sky-400">typescript</code> as development tooling.
+            <code className="text-sky-400">typescript</code> as development tooling. Litz depends on
+            TypeScript internally, but your app still needs its own TypeScript install for editor
+            integration, <code className="text-sky-400">tsc</code>, and local type-check scripts.
           </li>
           <li>
             <code className="text-sky-400">@vitejs/plugin-rsc</code> is bundled with{" "}


### PR DESCRIPTION
Closes #113.

## Summary
- Move `@vitejs/plugin-rsc` and `typescript` out of the published peer dependency surface and into `dependencies`, since Litz imports them as implementation dependencies.
- Keep the core app-provided peers focused on `react`, `react-dom`, and `vite`, with `nitro` retained as an optional peer for `litzNitro()`.
- Update the README and installation/first-app docs so the minimal path is presented first and Nitro/RSC-related behavior is described as optional or bundled.
- Add regression coverage for the package metadata and installation docs.
- Add a patch changeset for the package metadata/docs change.

## Verification
- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`