### PR TITLE
fix: preserve route module on search updates

### DIFF
--- a/.changeset/search-route-runtime.md
+++ b/.changeset/search-route-runtime.md
@@ -1,0 +1,6 @@
+---
+"litzjs": patch
+---
+
+Keep the mounted route module active during same-route search parameter updates so dev runtime
+revalidation cannot replace the page with a missing route export fault.

--- a/e2e/rsc-smoke-loaders.e2e.ts
+++ b/e2e/rsc-smoke-loaders.e2e.ts
@@ -52,4 +52,20 @@ test.describe("smoke fixture loaders and views", () => {
     await expect(page.getByText("Hook term: litz")).toBeVisible();
     await expect(page.getByText("Hook tab: active")).toBeVisible();
   });
+
+  test("updates route search params in place without replacing the mounted route", async ({
+    page,
+  }) => {
+    await page.goto("/features/search-params?term=litz&tab=active");
+
+    await page.getByRole("button", { name: "Update search in-place" }).click();
+
+    await expect(page).toHaveURL("/features/search-params?term=bun&tab=recent");
+    await expect(page.getByRole("heading", { name: "Search Params" })).toBeVisible();
+    await expect(page.getByText("Loader term: bun")).toBeVisible();
+    await expect(page.getByText("Loader tab: recent")).toBeVisible();
+    await expect(page.getByText("Hook term: bun")).toBeVisible();
+    await expect(page.getByText("Hook tab: recent")).toBeVisible();
+    await expect(page.getByText("Route module did not export route.")).toBeHidden();
+  });
 });

--- a/src/client/route-host-state.tsx
+++ b/src/client/route-host-state.tsx
@@ -48,6 +48,7 @@ export function useResolvedRouteState<TRoute, TPageState>(options: {
   const [renderedRoute, setRenderedRoute] = React.useState<TRoute | null>(null);
   const [pageState, setPageState] = React.useState<TPageState>(() => createEmptyPageState());
   const renderedRouteRef = React.useRef<TRoute | null>(null);
+  const renderedEntryIdRef = React.useRef<string | null>(null);
 
   React.useEffect(() => {
     renderedRouteRef.current = renderedRoute;
@@ -59,7 +60,11 @@ export function useResolvedRouteState<TRoute, TPageState>(options: {
     async function loadRouteModule(): Promise<void> {
       const routeState = resolveRouteModuleLoadState({
         matched: Boolean(options.matched),
-        cachedRoute: options.matched ? getCachedRoute(options.matched.entry.id) : null,
+        cachedRoute: options.matched
+          ? renderedEntryIdRef.current === options.matched.entry.id
+            ? renderedRouteRef.current
+            : getCachedRoute(options.matched.entry.id)
+          : null,
         previousRoute: renderedRouteRef.current,
         nextLocation: options.location,
         createEmptyPageState: () => createEmptyPageState(),
@@ -67,6 +72,7 @@ export function useResolvedRouteState<TRoute, TPageState>(options: {
       });
 
       if (routeState.kind === "not-found") {
+        renderedEntryIdRef.current = null;
         setRenderedRoute(routeState.loadedRoute);
         setDisplayLocation(routeState.displayLocation);
         setPageState(routeState.pageState);
@@ -74,6 +80,7 @@ export function useResolvedRouteState<TRoute, TPageState>(options: {
       }
 
       if (routeState.kind === "cached") {
+        renderedEntryIdRef.current = options.matched?.entry.id ?? null;
         setPageState(routeState.pageState);
         setRenderedRoute(routeState.loadedRoute);
         setDisplayLocation(routeState.displayLocation);
@@ -81,6 +88,7 @@ export function useResolvedRouteState<TRoute, TPageState>(options: {
       }
 
       if (routeState.kind === "reset-before-load") {
+        renderedEntryIdRef.current = null;
         setRenderedRoute(routeState.loadedRoute);
         setDisplayLocation(routeState.displayLocation);
         setPageState(routeState.pageState);
@@ -104,6 +112,7 @@ export function useResolvedRouteState<TRoute, TPageState>(options: {
         }
 
         setCachedRoute(matchedEntry.id, loaded.route);
+        renderedEntryIdRef.current = matchedEntry.id;
         const loadedRouteState = resolveLoadedRouteState({
           loadedRoute: loaded.route,
           nextLocation: options.location,
@@ -118,6 +127,7 @@ export function useResolvedRouteState<TRoute, TPageState>(options: {
         }
 
         const failedRouteState = resolveRouteLoadFailureState(error, renderedRouteRef.current);
+        renderedEntryIdRef.current = null;
         setRenderedRoute(failedRouteState.renderedRoute);
         setDisplayLocation(failedRouteState.displayLocation);
         setPageState(failedRouteState.pageState);

--- a/src/client/route-host-state.tsx
+++ b/src/client/route-host-state.tsx
@@ -21,6 +21,11 @@ export type RouteLoadFailureState<TRoute, TPageState> = {
   pageState: TPageState;
 };
 
+interface RenderedRouteSnapshot<TRoute> {
+  readonly entryId: string | null;
+  readonly route: TRoute | null;
+}
+
 export function useResolvedRouteState<TRoute, TPageState>(options: {
   matched: MatchedManifestEntry<TRoute>;
   location: string;
@@ -47,32 +52,41 @@ export function useResolvedRouteState<TRoute, TPageState>(options: {
   const [displayLocation, setDisplayLocation] = React.useState(() => options.location);
   const [renderedRoute, setRenderedRoute] = React.useState<TRoute | null>(null);
   const [pageState, setPageState] = React.useState<TPageState>(() => createEmptyPageState());
-  const renderedRouteRef = React.useRef<TRoute | null>(null);
-  const renderedEntryIdRef = React.useRef<string | null>(null);
+  const renderedRouteSnapshotRef = React.useRef<RenderedRouteSnapshot<TRoute>>({
+    entryId: null,
+    route: null,
+  });
 
   React.useEffect(() => {
-    renderedRouteRef.current = renderedRoute;
+    renderedRouteSnapshotRef.current = {
+      entryId: renderedRouteSnapshotRef.current.entryId,
+      route: renderedRoute,
+    };
   }, [renderedRoute]);
 
   React.useLayoutEffect(() => {
     let cancelled = false;
 
     async function loadRouteModule(): Promise<void> {
+      const renderedRouteSnapshot = renderedRouteSnapshotRef.current;
       const routeState = resolveRouteModuleLoadState({
         matched: Boolean(options.matched),
         cachedRoute: options.matched
-          ? renderedEntryIdRef.current === options.matched.entry.id
-            ? renderedRouteRef.current
+          ? renderedRouteSnapshot.entryId === options.matched.entry.id
+            ? renderedRouteSnapshot.route
             : getCachedRoute(options.matched.entry.id)
           : null,
-        previousRoute: renderedRouteRef.current,
+        previousRoute: renderedRouteSnapshot.route,
         nextLocation: options.location,
         createEmptyPageState: () => createEmptyPageState(),
         createBootstrapPageState: (route) => createBootstrapPageState(route),
       });
 
       if (routeState.kind === "not-found") {
-        renderedEntryIdRef.current = null;
+        renderedRouteSnapshotRef.current = {
+          entryId: null,
+          route: routeState.loadedRoute,
+        };
         setRenderedRoute(routeState.loadedRoute);
         setDisplayLocation(routeState.displayLocation);
         setPageState(routeState.pageState);
@@ -80,7 +94,10 @@ export function useResolvedRouteState<TRoute, TPageState>(options: {
       }
 
       if (routeState.kind === "cached") {
-        renderedEntryIdRef.current = options.matched?.entry.id ?? null;
+        renderedRouteSnapshotRef.current = {
+          entryId: options.matched?.entry.id ?? null,
+          route: routeState.loadedRoute,
+        };
         setPageState(routeState.pageState);
         setRenderedRoute(routeState.loadedRoute);
         setDisplayLocation(routeState.displayLocation);
@@ -88,7 +105,10 @@ export function useResolvedRouteState<TRoute, TPageState>(options: {
       }
 
       if (routeState.kind === "reset-before-load") {
-        renderedEntryIdRef.current = null;
+        renderedRouteSnapshotRef.current = {
+          entryId: null,
+          route: routeState.loadedRoute,
+        };
         setRenderedRoute(routeState.loadedRoute);
         setDisplayLocation(routeState.displayLocation);
         setPageState(routeState.pageState);
@@ -112,12 +132,15 @@ export function useResolvedRouteState<TRoute, TPageState>(options: {
         }
 
         setCachedRoute(matchedEntry.id, loaded.route);
-        renderedEntryIdRef.current = matchedEntry.id;
         const loadedRouteState = resolveLoadedRouteState({
           loadedRoute: loaded.route,
           nextLocation: options.location,
           createBootstrapPageState: (route) => createBootstrapPageState(route),
         });
+        renderedRouteSnapshotRef.current = {
+          entryId: matchedEntry.id,
+          route: loadedRouteState.loadedRoute,
+        };
         setPageState(loadedRouteState.pageState);
         setRenderedRoute(loadedRouteState.loadedRoute);
         setDisplayLocation(loadedRouteState.displayLocation);
@@ -126,8 +149,14 @@ export function useResolvedRouteState<TRoute, TPageState>(options: {
           throw error;
         }
 
-        const failedRouteState = resolveRouteLoadFailureState(error, renderedRouteRef.current);
-        renderedEntryIdRef.current = null;
+        const failedRouteState = resolveRouteLoadFailureState(
+          error,
+          renderedRouteSnapshotRef.current.route,
+        );
+        renderedRouteSnapshotRef.current = {
+          entryId: null,
+          route: failedRouteState.renderedRoute,
+        };
         setRenderedRoute(failedRouteState.renderedRoute);
         setDisplayLocation(failedRouteState.displayLocation);
         setPageState(failedRouteState.pageState);

--- a/tests/route-host-state.test.tsx
+++ b/tests/route-host-state.test.tsx
@@ -226,6 +226,92 @@ describe("route host state", () => {
     expect(mountEvents).toEqual(["mount"]);
   });
 
+  test("reuses the current route module when only the current entry location changes", async () => {
+    const cache = new Map<string, TestRoute>();
+    const loadCalls: string[] = [];
+
+    const currentRoute: TestRoute = {
+      id: "search-route",
+      component() {
+        return <div id="route-state" data-value="search-route" />;
+      },
+    };
+
+    const matchedEntry = {
+      entry: {
+        id: "search-route",
+        load: async () => {
+          loadCalls.push("load");
+          return { route: currentRoute };
+        },
+      } satisfies RouteManifestEntry<TestRoute>,
+    } satisfies MatchedManifestEntry<TestRoute>;
+
+    function TestHarness(props: { location: string }) {
+      const createEmptyPageState = React.useCallback(
+        () => ({
+          routeId: null,
+          status: "loading" as const,
+          errorMessage: null,
+        }),
+        [],
+      );
+      const createBootstrapPageState = React.useCallback(
+        (route: TestRoute) => ({
+          routeId: route.id,
+          status: "idle" as const,
+          errorMessage: null,
+        }),
+        [],
+      );
+      const getCachedRoute = React.useCallback((id: string) => cache.get(id) ?? null, []);
+      const setCachedRoute = React.useCallback((id: string, route: TestRoute) => {
+        cache.set(id, route);
+      }, []);
+      const state = useResolvedRouteState<TestRoute, TestPageState>({
+        matched: matchedEntry,
+        location: props.location,
+        createEmptyPageState,
+        createBootstrapPageState,
+        getCachedRoute,
+        setCachedRoute,
+      });
+
+      return (
+        <div>
+          <div id="display-location" data-value={state.displayLocation} />
+          <div id="page-state" data-value={state.pageState.routeId ?? "none"} />
+          {state.renderedRoute ? renderTestRoute(state.renderedRoute) : null}
+        </div>
+      );
+    }
+
+    await act(async () => {
+      root?.render(<TestHarness location="https://example.com/search?term=litz" />);
+      await flushDom();
+    });
+
+    expect(loadCalls).toEqual(["load"]);
+    expect(document.getElementById("route-state")?.getAttribute("data-value")).toBe("search-route");
+    expect(document.getElementById("display-location")?.getAttribute("data-value")).toBe(
+      "https://example.com/search?term=litz",
+    );
+
+    cache.clear();
+
+    await act(async () => {
+      root?.render(<TestHarness location="https://example.com/search?term=bun&tab=recent" />);
+      await flushDom();
+    });
+
+    expect(loadCalls).toEqual(["load"]);
+    expect(document.getElementById("route-state")?.getAttribute("data-value")).toBe("search-route");
+    expect(document.getElementById("display-location")?.getAttribute("data-value")).toBe(
+      "https://example.com/search?term=bun&tab=recent",
+    );
+    expect(document.getElementById("page-state")?.getAttribute("data-value")).toBe("search-route");
+  });
+
   test("routes rejected route module loads through the failure state callback", async () => {
     const loadError = new Error("Chunk 404");
     const fallbackRoute: TestRoute = {

--- a/tests/route-host-state.test.tsx
+++ b/tests/route-host-state.test.tsx
@@ -312,6 +312,82 @@ describe("route host state", () => {
     expect(document.getElementById("page-state")?.getAttribute("data-value")).toBe("search-route");
   });
 
+  test("reuses the loaded route for same-entry navigation before route ref effects flush", async () => {
+    const cache = new Map<string, TestRoute>();
+    const loadCalls: string[] = [];
+
+    const currentRoute: TestRoute = {
+      id: "search-route",
+      component() {
+        return <div id="route-state" data-value="search-route" />;
+      },
+    };
+
+    const matchedEntry = {
+      entry: {
+        id: "search-route",
+        load: async () => {
+          loadCalls.push("load");
+          return { route: currentRoute };
+        },
+      } satisfies RouteManifestEntry<TestRoute>,
+    } satisfies MatchedManifestEntry<TestRoute>;
+
+    function TestHarness(props: { location: string }) {
+      const createEmptyPageState = React.useCallback(
+        () => ({
+          routeId: null,
+          status: "loading" as const,
+          errorMessage: null,
+        }),
+        [],
+      );
+      const createBootstrapPageState = React.useCallback(
+        (route: TestRoute) => ({
+          routeId: route.id,
+          status: "idle" as const,
+          errorMessage: null,
+        }),
+        [],
+      );
+      const getCachedRoute = React.useCallback((id: string) => cache.get(id) ?? null, []);
+      const setCachedRoute = React.useCallback((id: string, route: TestRoute) => {
+        cache.set(id, route);
+      }, []);
+      const state = useResolvedRouteState<TestRoute, TestPageState>({
+        matched: matchedEntry,
+        location: props.location,
+        createEmptyPageState,
+        createBootstrapPageState,
+        getCachedRoute,
+        setCachedRoute,
+      });
+
+      return (
+        <div>
+          <div id="display-location" data-value={state.displayLocation} />
+          <div id="page-state" data-value={state.pageState.routeId ?? "none"} />
+          {state.renderedRoute ? renderTestRoute(state.renderedRoute) : null}
+        </div>
+      );
+    }
+
+    await act(async () => {
+      root?.render(<TestHarness location="https://example.com/search?term=litz" />);
+      await Promise.resolve();
+      cache.clear();
+      root?.render(<TestHarness location="https://example.com/search?term=bun&tab=recent" />);
+      await flushDom();
+    });
+
+    expect(loadCalls).toEqual(["load"]);
+    expect(document.getElementById("route-state")?.getAttribute("data-value")).toBe("search-route");
+    expect(document.getElementById("display-location")?.getAttribute("data-value")).toBe(
+      "https://example.com/search?term=bun&tab=recent",
+    );
+    expect(document.getElementById("page-state")?.getAttribute("data-value")).toBe("search-route");
+  });
+
   test("routes rejected route module loads through the failure state callback", async () => {
     const loadError = new Error("Chunk 404");
     const fallbackRoute: TestRoute = {


### PR DESCRIPTION
## Summary

Fixes #127.

This updates the client route host state so navigations that stay on the same manifest entry reuse the currently mounted route module instead of requiring a fresh module load or an LRU cache hit. That keeps `route.useSearch()` setter navigation on the active route during dev runtime revalidation and avoids replacing the page with the missing route export fault UI.

## Changes

- Track the currently rendered manifest entry in `useResolvedRouteState` and treat it as the cached route for same-entry URL changes.
- Add unit regression coverage proving same-entry location changes do not reload the route module when the external route cache is cold.
- Add Playwright smoke coverage for the `/features/search-params` `Update search in-place` flow.
- Add a patch changeset for the runtime bug fix.

## Verification

- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`
- `bunx playwright test e2e/rsc-smoke-loaders.e2e.ts --grep "updates route search params"`
