### PR TITLE
[codex] Fix client routing under base paths

### DIFF
--- a/.changeset/client-base-routing.md
+++ b/.changeset/client-base-routing.md
@@ -1,0 +1,5 @@
+---
+"litzjs": patch
+---
+
+Fix client route matching and navigation when the app is served under a configured base path.

--- a/src/client/base-url.ts
+++ b/src/client/base-url.ts
@@ -1,6 +1,7 @@
-import { joinBasePath } from "../base-path";
+import { joinBasePath, resolveBasePathname, stripBasePath } from "../base-path";
 
 let configuredBaseUrl: string | undefined;
+const ABSOLUTE_URL_PATTERN = /^[a-zA-Z][a-zA-Z\d+.-]*:/;
 
 export function configureClientBaseUrl(baseUrl: string | undefined): void {
   configuredBaseUrl = baseUrl;
@@ -10,6 +11,32 @@ export function resolveClientTransportPath(pathname: string): string {
   return joinBasePath(resolveConfiguredBaseUrl(), pathname);
 }
 
-function resolveConfiguredBaseUrl(): string | undefined {
+export function resolveClientRoutePathname(pathname: string): string {
+  return resolveBasePathname(pathname, resolveConfiguredBaseUrl());
+}
+
+export function resolveClientHref(href: string): string {
+  if (
+    ABSOLUTE_URL_PATTERN.test(href) ||
+    href.startsWith("//") ||
+    href.startsWith("#") ||
+    href.startsWith("?")
+  ) {
+    return href;
+  }
+
+  const baseUrl = resolveConfiguredBaseUrl();
+  const pathnameEnd = href.search(/[?#]/);
+  const pathname = pathnameEnd === -1 ? href : href.slice(0, pathnameEnd);
+  const suffix = pathnameEnd === -1 ? "" : href.slice(pathnameEnd);
+
+  if (stripBasePath(pathname || "/", baseUrl) !== null) {
+    return href;
+  }
+
+  return `${joinBasePath(baseUrl, pathname)}${suffix}`;
+}
+
+export function resolveConfiguredBaseUrl(): string | undefined {
   return configuredBaseUrl;
 }

--- a/src/client/base-url.ts
+++ b/src/client/base-url.ts
@@ -25,6 +25,10 @@ export function resolveClientHref(href: string): string {
     return href;
   }
 
+  if (!href.startsWith("/")) {
+    return href;
+  }
+
   const baseUrl = resolveConfiguredBaseUrl();
   const pathnameEnd = href.search(/[?#]/);
   const pathname = pathnameEnd === -1 ? href : href.slice(0, pathnameEnd);

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -13,7 +13,7 @@ import {
 } from "../path-matching";
 import { createSearchParamRecord, type SearchParamRecord } from "../search-params";
 import { isAbortError } from "./abort-error";
-import { configureClientBaseUrl } from "./base-url";
+import { configureClientBaseUrl, resolveClientHref, resolveClientRoutePathname } from "./base-url";
 import { installClientBindings } from "./bindings";
 import { getLocationContext, getMatchesContext, getNavigationContext } from "./contexts";
 import {
@@ -476,6 +476,8 @@ function LitzApp(props: {
 
   const navigate = React.useCallback(
     (next: string, replace = false) => {
+      const href = resolveClientHref(next);
+
       if (props.navigationBehavior.scrollRestoration) {
         persistScrollPositionNow();
       }
@@ -490,7 +492,7 @@ function LitzApp(props: {
             ? withManagedNavigationState(window.history.state, getScrollPosition())
             : null,
           "",
-          next,
+          href,
         );
       } else {
         window.history.pushState(
@@ -501,7 +503,7 @@ function LitzApp(props: {
               })
             : null,
           "",
-          next,
+          href,
         );
       }
 
@@ -522,9 +524,11 @@ function LitzApp(props: {
   );
   const locationValue = React.useMemo(() => {
     const url = new URL(location);
+    const pathname = resolveClientRoutePathname(url.pathname);
+
     return {
       href: location,
-      pathname: url.pathname,
+      pathname,
       search: new URLSearchParams(url.search),
       hash: url.hash,
     };
@@ -579,18 +583,22 @@ function RouteHost(props: {
     [props.navigate],
   );
   const url = React.useMemo(() => new URL(props.location), [props.location]);
+  const routePathname = React.useMemo(
+    () => resolveClientRoutePathname(url.pathname),
+    [url.pathname],
+  );
   const search = React.useMemo(() => new URLSearchParams(url.search), [url.search]);
-  const matched = React.useMemo(() => findMatch(url.pathname), [url.pathname]);
+  const matched = React.useMemo(() => findMatch(routePathname), [routePathname]);
   const createBootstrapPageStateForLocation = React.useCallback(
-    (route: LoadedRoute) => createBootstrapPageState(route, url.pathname, search),
-    [search, url.pathname],
+    (route: LoadedRoute) => createBootstrapPageState(route, routePathname, search),
+    [routePathname, search],
   );
   const resolveRouteLoadFailureState = React.useCallback(
     (error: unknown) => {
       const failedRoute = createRouteLoadFailureRoute(
         matched?.entry ?? {
-          id: url.pathname,
-          path: url.pathname,
+          id: routePathname,
+          path: routePathname,
           load: async () => ({}),
         },
       );
@@ -598,10 +606,10 @@ function RouteHost(props: {
       return {
         displayLocation: props.location,
         renderedRoute: failedRoute,
-        pageState: createRouteLoadFailurePageState(failedRoute, url.pathname, search, error),
+        pageState: createRouteLoadFailurePageState(failedRoute, routePathname, search, error),
       };
     },
-    [matched, props.location, search, url.pathname],
+    [matched, props.location, routePathname, search],
   );
   const { displayLocation, renderedRoute, pageState, setPageState } = useResolvedRouteState<
     LoadedRoute,
@@ -617,6 +625,10 @@ function RouteHost(props: {
   });
 
   const displayedUrl = React.useMemo(() => new URL(displayLocation), [displayLocation]);
+  const displayedRoutePathname = React.useMemo(
+    () => resolveClientRoutePathname(displayedUrl.pathname),
+    [displayedUrl.pathname],
+  );
   const displayedSearch = React.useMemo(
     () => new URLSearchParams(displayedUrl.search),
     [displayedUrl.search],
@@ -626,17 +638,21 @@ function RouteHost(props: {
       return null;
     }
 
-    const activeMatches = buildActiveMatches(renderedRoute, displayedUrl.pathname, displayedSearch);
+    const activeMatches = buildActiveMatches(
+      renderedRoute,
+      displayedRoutePathname,
+      displayedSearch,
+    );
 
     return {
       activeMatches,
       loaderMatches: activeMatches.filter((entry) => Boolean(entry.options?.loader)),
       baseRequest: {
-        params: extractRouteParams(renderedRoute.path, displayedUrl.pathname) ?? {},
+        params: extractRouteParams(renderedRoute.path, displayedRoutePathname) ?? {},
         search: displayedSearch,
       },
     };
-  }, [displayedSearch, displayedUrl.pathname, renderedRoute]);
+  }, [displayedRoutePathname, displayedSearch, renderedRoute]);
 
   React.useEffect(() => {
     if (!renderedRoute || !activeRouteState || pageState.errorInfo) {
@@ -742,14 +758,14 @@ function RouteHost(props: {
       renderedRoute
         ? reloadCurrentRoute({
             route: renderedRoute,
-            pathname: displayedUrl.pathname,
+            pathname: displayedRoutePathname,
             search: displayedSearch,
             navigate,
             setPageState,
             mode,
           })
         : Promise.resolve(),
-    [displayedSearch, displayedUrl.pathname, navigate, renderedRoute, setPageState],
+    [displayedRoutePathname, displayedSearch, navigate, renderedRoute, setPageState],
   );
 
   const content = !matched
@@ -1868,6 +1884,7 @@ function prefetchRouteForHref(
 ): void {
   const currentUrl = new URL(window.location.href);
   const nextUrl = new URL(href, currentUrl);
+  const nextRoutePathname = resolveClientRoutePathname(nextUrl.pathname);
 
   if (
     !shouldPrefetchLink({
@@ -1880,7 +1897,7 @@ function prefetchRouteForHref(
     return;
   }
 
-  const matched = findMatch(nextUrl.pathname);
+  const matched = findMatch(nextRoutePathname);
 
   if (!matched) {
     return;
@@ -1891,7 +1908,7 @@ function prefetchRouteForHref(
     return;
   }
 
-  const dataPrefetchKey = createRouteDataPrefetchKey(nextUrl);
+  const dataPrefetchKey = createRouteDataPrefetchKey(nextRoutePathname, nextUrl.search);
   const inFlight = routeDataPrefetchCache.get(dataPrefetchKey);
 
   if (inFlight) {
@@ -1904,7 +1921,7 @@ function prefetchRouteForHref(
         return;
       }
 
-      await prefetchRouteLoaderData(route, nextUrl, options?.signal);
+      await prefetchRouteLoaderData(route, nextRoutePathname, nextUrl.search, options?.signal);
     })
     .finally(() => {
       routeDataPrefetchCache.delete(dataPrefetchKey);
@@ -1913,8 +1930,8 @@ function prefetchRouteForHref(
   routeDataPrefetchCache.set(dataPrefetchKey, prefetch);
 }
 
-function createRouteDataPrefetchKey(nextUrl: URL): string {
-  return `${nextUrl.pathname}${nextUrl.search}`;
+function createRouteDataPrefetchKey(pathname: string, search: string): string {
+  return `${pathname}${search}`;
 }
 
 function prefetchMatchedRouteModule(
@@ -1955,11 +1972,12 @@ function prefetchMatchedRouteModule(
 
 async function prefetchRouteLoaderData(
   route: LoadedRoute,
-  nextUrl: URL,
+  pathname: string,
+  searchString: string,
   signal?: AbortSignal,
 ): Promise<void> {
-  const search = new URLSearchParams(nextUrl.search);
-  const loaderMatches = buildActiveMatches(route, nextUrl.pathname, search).filter(
+  const search = new URLSearchParams(searchString);
+  const loaderMatches = buildActiveMatches(route, pathname, search).filter(
     (entry) => Boolean(entry.options?.loader) && !getCachedLoaderResult(entry.cacheKey),
   );
 
@@ -1970,7 +1988,7 @@ async function prefetchRouteLoaderData(
   const settled = await fetchRouteLoadersInParallel(loaderMatches, {
     routePath: route.path,
     baseRequest: {
-      params: extractRouteParams(route.path, nextUrl.pathname) ?? {},
+      params: extractRouteParams(route.path, pathname) ?? {},
       search,
     },
     signal,

--- a/src/client/link.tsx
+++ b/src/client/link.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import { resolveClientHref } from "./base-url";
 import { shouldInterceptLinkNavigation, toNavigationHref } from "./navigation";
 
 export type LinkPrefetchMode = "none" | "intent" | "render";
@@ -40,6 +41,7 @@ export function createLinkComponent(dependencies: {
       rel,
       ...rest
     } = props;
+    const browserHref = resolveClientHref(href);
 
     React.useEffect(() => {
       if (prefetch !== "render") {
@@ -48,7 +50,7 @@ export function createLinkComponent(dependencies: {
 
       const controller = new AbortController();
 
-      dependencies.prefetchRouteForHref(href, {
+      dependencies.prefetchRouteForHref(browserHref, {
         target,
         download,
         includeData: prefetchData,
@@ -58,11 +60,11 @@ export function createLinkComponent(dependencies: {
       return () => {
         controller.abort();
       };
-    }, [dependencies, download, href, prefetch, prefetchData, target]);
+    }, [browserHref, dependencies, download, prefetch, prefetchData, target]);
 
     return React.createElement("a", {
       ...rest,
-      href,
+      href: browserHref,
       target,
       download,
       rel,
@@ -77,7 +79,7 @@ export function createLinkComponent(dependencies: {
           return;
         }
 
-        dependencies.prefetchRouteForHref(href, {
+        dependencies.prefetchRouteForHref(browserHref, {
           target,
           download,
           includeData: prefetchData,
@@ -94,7 +96,7 @@ export function createLinkComponent(dependencies: {
           return;
         }
 
-        dependencies.prefetchRouteForHref(href, {
+        dependencies.prefetchRouteForHref(browserHref, {
           target,
           download,
           includeData: prefetchData,
@@ -111,7 +113,7 @@ export function createLinkComponent(dependencies: {
           return;
         }
 
-        dependencies.prefetchRouteForHref(href, {
+        dependencies.prefetchRouteForHref(browserHref, {
           target,
           download,
           includeData: prefetchData,
@@ -124,7 +126,7 @@ export function createLinkComponent(dependencies: {
           return;
         }
 
-        const nextUrl = new URL(href, window.location.href);
+        const nextUrl = new URL(browserHref, window.location.href);
         const currentUrl = new URL(window.location.href);
 
         if (

--- a/tests/client-base-url.test.ts
+++ b/tests/client-base-url.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  configureClientBaseUrl,
+  resolveClientHref,
+  resolveClientRoutePathname,
+  resolveClientTransportPath,
+} from "../src/client/base-url";
+
+describe("client base URL helpers", () => {
+  afterEach(() => {
+    configureClientBaseUrl(undefined);
+  });
+
+  test("strips the configured base path from browser route pathnames", () => {
+    configureClientBaseUrl("/app/");
+
+    expect(resolveClientRoutePathname("/app/projects/42")).toBe("/projects/42");
+    expect(resolveClientRoutePathname("/app")).toBe("/");
+    expect(resolveClientRoutePathname("/projects/42")).toBe("/projects/42");
+  });
+
+  test("prefixes root-relative app hrefs with the configured base path", () => {
+    configureClientBaseUrl("/app/");
+
+    expect(resolveClientHref("/projects/42?tab=activity#details")).toBe(
+      "/app/projects/42?tab=activity#details",
+    );
+    expect(resolveClientHref("/app/projects/42")).toBe("/app/projects/42");
+    expect(resolveClientTransportPath("/_litzjs/route")).toBe("/app/_litzjs/route");
+  });
+
+  test("preserves non-root-relative hrefs", () => {
+    configureClientBaseUrl("/app/");
+
+    expect(resolveClientHref("settings")).toBe("settings");
+    expect(resolveClientHref("../settings")).toBe("../settings");
+    expect(resolveClientHref("?tab=activity")).toBe("?tab=activity");
+    expect(resolveClientHref("#details")).toBe("#details");
+    expect(resolveClientHref("https://other.example.com/projects")).toBe(
+      "https://other.example.com/projects",
+    );
+    expect(resolveClientHref("//cdn.example.com/asset.js")).toBe("//cdn.example.com/asset.js");
+  });
+});

--- a/tests/client-wildcard-route-runtime.test.tsx
+++ b/tests/client-wildcard-route-runtime.test.tsx
@@ -217,6 +217,7 @@ describe("client wildcard route runtime", () => {
   });
 
   afterEach(() => {
+    clientModule?.configureClientRuntime({ baseUrl: undefined });
     globalThis.fetch = originalFetch;
     container?.remove();
     cleanupDom?.();
@@ -432,6 +433,84 @@ describe("client wildcard route runtime", () => {
     );
     expect(document.getElementById("status-state")?.getAttribute("data-value")).toBe("idle");
     expect(document.getElementById("pending-state")?.getAttribute("data-value")).toBe("false");
+  });
+
+  test("matches base-prefixed browser pathnames against route definitions", async () => {
+    window.history.replaceState(null, "", "/app/projects/42?tab=activity");
+
+    globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+      const inputUrl =
+        typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+
+      expect(inputUrl).toBe("/app/_litzjs/route");
+
+      if (typeof init?.body !== "string") {
+        throw new Error("Expected route loader request body to be a JSON string.");
+      }
+
+      const request = JSON.parse(init.body) as {
+        path: string;
+        request: {
+          params: Record<string, string>;
+          search: Record<string, string>;
+        };
+      };
+
+      expect(request.path).toBe("/projects/:id");
+      expect(request.request.params).toEqual({
+        id: "42",
+      });
+      expect(request.request.search).toEqual({
+        tab: "activity",
+      });
+
+      return Promise.resolve(
+        Response.json({
+          kind: "data",
+          data: { id: "42", tab: "activity", source: "base" },
+        }),
+      );
+    }) as typeof globalThis.fetch;
+
+    clientModule = await import("../src/client/index");
+    clientModule.configureClientRuntime({ baseUrl: "/app/" });
+
+    await act(async () => {
+      clientModule?.mountApp(container!);
+      await flushApp();
+    });
+
+    expect(window.location.pathname).toBe("/app/projects/42");
+    expect(document.getElementById("route-state")?.getAttribute("data-value")).toBe(
+      "project-route",
+    );
+    expect(document.getElementById("loader-data")?.getAttribute("data-value")).toBe(
+      JSON.stringify({ id: "42", tab: "activity", source: "base" }),
+    );
+  });
+
+  test("generates base-prefixed browser URLs for client navigation", async () => {
+    clientModule = await import("../src/client/index");
+    clientModule.configureClientRuntime({ baseUrl: "/app/" });
+
+    await act(async () => {
+      clientModule?.mountApp(container!);
+      await flushApp();
+    });
+
+    const link = container?.getElementsByTagName("a")[0] ?? null;
+
+    expect(link?.getAttribute("href")).toBe("/app/docs/getting-started/install");
+
+    await act(async () => {
+      link?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, button: 0 }));
+      await flushApp();
+    });
+
+    expect(window.location.pathname).toBe("/app/docs/getting-started/install");
+    expect(document.getElementById("route-state")?.getAttribute("data-value")).toBe(
+      "wildcard-route",
+    );
   });
 
   test("keeps overlapping route submits latest-only and aborts the older request", async () => {


### PR DESCRIPTION
## Summary

Fixes #132 by teaching the client runtime to distinguish between the browser URL pathname and the application route pathname when a Vite base path is configured.

## What changed

- Strip the configured client base path before route manifest matching, active match construction, route params, route loader requests, and route location context values.
- Generate base-prefixed browser hrefs for `Link` and imperative navigation while avoiding double-prefixing already-prefixed hrefs.
- Add regression coverage for initial page load under `/app/projects/42` and for base-prefixed client navigation URLs.
- Add the required patch changeset.

## Impact

Apps deployed below a base path such as `/app/` can now load and navigate client routes like `/projects/:id` from browser URLs like `/app/projects/42`, while internal route params remain based on `/projects/42` and browser-visible URLs keep the configured base.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun typecheck`
- `bun test tests/client-wildcard-route-runtime.test.tsx`
- `bun test`
