### PR TITLE
[codex] fix api fetch client base path

### DIFF
--- a/.changeset/client-base-routing.md
+++ b/.changeset/client-base-routing.md
@@ -2,4 +2,4 @@
 "litzjs": patch
 ---
 
-Fix client route matching and navigation when the app is served under a configured base path.
+Fix client route matching, navigation, and API fetch helpers when the app is served under a configured base path.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import * as React from "react";
 
 import type { SubmitPayload } from "./form-data";
 
+import { resolveClientHref } from "./client/base-url";
 import { getClientBindings } from "./client/bindings";
 import { interpolatePath } from "./path-matching";
 import {
@@ -1733,7 +1734,7 @@ function buildApiHref(
   const href = searchString ? `${pathname}?${searchString}` : pathname;
 
   if (!baseUrl) {
-    return href;
+    return resolveClientHref(href);
   }
 
   const resolvedBaseUrl = new URL(baseUrl);

--- a/tests/api-route-fetch.test.ts
+++ b/tests/api-route-fetch.test.ts
@@ -55,6 +55,26 @@ describe("defineApiRoute().fetch", () => {
     expect(capturedInput).toBe("/app/api/projects");
   });
 
+  test("prepends configured client base path and preserves query params", async () => {
+    let capturedInput: RequestInfo | URL | undefined;
+
+    configureClientBaseUrl("/app/");
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      capturedInput = input;
+      return new Response(null, { status: 204 });
+    }) as typeof fetch;
+
+    const api = defineApiRoute("/api/projects", {
+      GET() {
+        return new Response(null, { status: 204 });
+      },
+    });
+
+    await api.fetch({ search: { tag: "bun" } });
+
+    expect(capturedInput).toBe("/app/api/projects?tag=bun");
+  });
+
   test("supports an explicit baseUrl for server-side and test callers", async () => {
     let capturedInput: RequestInfo | URL | undefined;
 

--- a/tests/api-route-fetch.test.ts
+++ b/tests/api-route-fetch.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 
+import { configureClientBaseUrl } from "../src/client/base-url";
 import { defineApiRoute } from "../src/index";
 
 describe("defineApiRoute().fetch", () => {
@@ -7,6 +8,7 @@ describe("defineApiRoute().fetch", () => {
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
+    configureClientBaseUrl(undefined);
   });
 
   test("preserves repeated query params from object search input", async () => {
@@ -31,6 +33,26 @@ describe("defineApiRoute().fetch", () => {
     });
 
     expect(capturedInput).toBe("/api/projects?tag=framework&tag=bun&term=litz");
+  });
+
+  test("uses the configured client base path by default", async () => {
+    let capturedInput: RequestInfo | URL | undefined;
+
+    configureClientBaseUrl("/app/");
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      capturedInput = input;
+      return new Response(null, { status: 204 });
+    }) as typeof fetch;
+
+    const api = defineApiRoute("/api/projects", {
+      GET() {
+        return new Response(null, { status: 204 });
+      },
+    });
+
+    await api.fetch();
+
+    expect(capturedInput).toBe("/app/api/projects");
   });
 
   test("supports an explicit baseUrl for server-side and test callers", async () => {


### PR DESCRIPTION
## Summary

Fixes #133.

`defineApiRoute().fetch()` now uses the configured client base path when no explicit `baseUrl` is provided. This keeps browser-side API requests aligned with apps served below a Vite base such as `/app/`, while preserving the existing explicit `baseUrl` behavior for server-side and test callers.

## Root Cause

`buildApiHref(...)` returned the interpolated root-relative API href directly whenever `baseUrl` was absent. That bypassed the client base URL runtime used by navigation and internal Litz transport requests, so browser apps mounted under `/app/` requested `/api/...` instead of `/app/api/...`.

## Changes

- Route default API fetch hrefs through `resolveClientHref(...)` when `baseUrl` is omitted.
- Added a regression test for `configureClientBaseUrl('/app/')` with `defineApiRoute('/api/projects').fetch()`.
- Updated the patch changeset to cover API fetch helpers under configured base paths.

## Validation

- `bun test tests/api-route-fetch.test.ts`
- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`
