### PR TITLE
[codex] Fix batched route loader concurrency

### DIFF
--- a/.changeset/concurrent-route-loader-batches.md
+++ b/.changeset/concurrent-route-loader-batches.md
@@ -1,0 +1,5 @@
+---
+"litzjs": patch
+---
+
+Execute batched route loader targets concurrently on the server while preserving response ordering.

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -405,6 +405,7 @@ async function handleRouteRequest<TContext>(
       return createLitzJsonResponse(404, { kind: "fault", message: "Route not found." });
     }
 
+    const route = entry.route;
     const chain = getRouteMatchChain(entry);
     const normalizedRequest = normalizeInternalRequest(
       request,
@@ -416,7 +417,7 @@ async function handleRouteRequest<TContext>(
     const context = await getContext();
 
     if (operation === "loader" && targetIds && targetIds.length > 0) {
-      const results: BatchedLoaderResponseEntry[] = [];
+      const batchTargets: RouteMatchEntry[] = [];
 
       for (const batchTargetId of targetIds) {
         const batchTarget = findTargetRouteMatch(chain, batchTargetId);
@@ -425,15 +426,25 @@ async function handleRouteRequest<TContext>(
           return createLitzJsonResponse(404, { kind: "fault", message: "Route target not found." });
         }
 
-        const batchResult = await executeRouteTarget({
-          route: entry.route,
-          operation,
-          chain,
-          target: batchTarget,
-          normalizedRequest,
-          signal,
-          context,
-        });
+        batchTargets.push(batchTarget);
+      }
+
+      const batchResults = await Promise.all(
+        batchTargets.map((batchTarget) =>
+          executeRouteTarget({
+            route,
+            operation,
+            chain,
+            target: batchTarget,
+            normalizedRequest,
+            signal,
+            context,
+          }),
+        ),
+      );
+      const results: BatchedLoaderResponseEntry[] = [];
+
+      for (const batchResult of batchResults) {
         const serializedResult = createBatchedLoaderResponseEntry(batchResult);
 
         if (!serializedResult) {
@@ -463,7 +474,7 @@ async function handleRouteRequest<TContext>(
 
     viewId = `${target.id}#${operation}`;
     const result = await executeRouteTarget({
-      route: entry.route,
+      route,
       operation,
       chain,
       target,

--- a/src/vite/dev-middleware.ts
+++ b/src/vite/dev-middleware.ts
@@ -324,7 +324,7 @@ export async function handleLitzRouteRequest(
     const signal = controller.signal;
 
     if (operation === "loader" && targetIds && targetIds.length > 0) {
-      const results: BatchedLoaderResponseEntry[] = [];
+      const batchTargets: DevRouteMatchEntry[] = [];
 
       for (const batchTargetId of targetIds) {
         const batchTarget = findDevTargetRouteMatch(chain, batchTargetId);
@@ -334,14 +334,24 @@ export async function handleLitzRouteRequest(
           return;
         }
 
-        const batchResult = await executeDevRouteTarget({
-          route,
-          operation,
-          chain,
-          target: batchTarget,
-          normalizedRequest,
-          signal,
-        });
+        batchTargets.push(batchTarget);
+      }
+
+      const batchResults = await Promise.all(
+        batchTargets.map((batchTarget) =>
+          executeDevRouteTarget({
+            route,
+            operation,
+            chain,
+            target: batchTarget,
+            normalizedRequest,
+            signal,
+          }),
+        ),
+      );
+      const results: BatchedLoaderResponseEntry[] = [];
+
+      for (const batchResult of batchResults) {
         const serializedResult = createDevBatchedLoaderResponseEntry(batchResult);
 
         if (!serializedResult) {

--- a/tests/server-security.test.ts
+++ b/tests/server-security.test.ts
@@ -27,6 +27,8 @@ async function waitForCondition(condition: () => boolean): Promise<void> {
 
     await new Promise((resolve) => setTimeout(resolve, 0));
   }
+
+  throw new Error("waitForCondition: condition was not met within the allotted attempts");
 }
 
 describe("server security", () => {

--- a/tests/server-security.test.ts
+++ b/tests/server-security.test.ts
@@ -3,6 +3,32 @@ import { describe, expect, test } from "bun:test";
 import { createServer } from "../src/server";
 import { createInternalActionRequestInit } from "../src/server/internal-requests";
 
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  resolve(value: T): void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+
+  return {
+    promise: new Promise<T>((nextResolve) => {
+      resolve = nextResolve;
+    }),
+    resolve,
+  };
+}
+
+async function waitForCondition(condition: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    if (condition()) {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
 describe("server security", () => {
   test("forwards cookies and origin to internal route actions without leaking transport headers", async () => {
     const server = createServer({
@@ -394,6 +420,93 @@ describe("server security", () => {
         revalidate: [],
       },
     });
+  });
+
+  test("executes batched internal route loader requests concurrently", async () => {
+    const startedTargets: string[] = [];
+    const routeDeferred = createDeferred<string>();
+    const layoutDeferred = createDeferred<string>();
+
+    const server = createServer({
+      manifest: {
+        routes: [
+          {
+            id: "projects.show",
+            path: "/projects/:id",
+            route: {
+              async loader() {
+                startedTargets.push("route");
+
+                return {
+                  kind: "data",
+                  data: {
+                    source: await routeDeferred.promise,
+                  },
+                };
+              },
+              options: {
+                layout: {
+                  id: "projects.layout",
+                  path: "/projects",
+                  options: {
+                    async loader() {
+                      startedTargets.push("layout");
+
+                      return {
+                        kind: "data",
+                        data: {
+                          source: await layoutDeferred.promise,
+                        },
+                      };
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const responsePromise = server.fetch(
+      new Request("https://app.example.com/_litzjs/route", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          path: "/projects/:id",
+          targets: ["projects.show", "projects.layout"],
+          operation: "loader",
+          request: {
+            params: { id: "42" },
+          },
+        }),
+      }),
+    );
+
+    await waitForCondition(() => startedTargets.length === 2);
+
+    expect(startedTargets).toEqual(["route", "layout"]);
+
+    layoutDeferred.resolve("layout");
+    routeDeferred.resolve("route");
+
+    const response = await responsePromise;
+    const body = (await response.json()) as {
+      kind: "batch";
+      results: Array<{
+        body: {
+          kind: "data";
+          data: {
+            source: string;
+          };
+        };
+      }>;
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.results.map((result) => result.body.data.source)).toEqual(["route", "layout"]);
   });
 
   test("does not expose unhandled server error messages from api routes", async () => {


### PR DESCRIPTION
## Summary

Fixes #134 by changing batched internal route loader handling to resolve all requested route targets first, then execute the target loaders concurrently with `Promise.all`. The serialized response is still built from the settled results in the original requested target order.

The same change is applied to the production server and Vite dev middleware so behavior stays consistent across dev and built server execution.

## Root Cause

The client already batches multiple matched route loaders into a single internal transport request, but the server-side batch handler iterated through `targets` with a `for` loop and awaited each loader before starting the next one. That preserved order, but it made independent layout and route loaders run sequentially.

## Changes

- Resolve and validate all batch target IDs before starting loader execution.
- Execute batch targets concurrently in both `src/server/index.ts` and `src/vite/dev-middleware.ts`.
- Preserve deterministic result ordering by serializing the `Promise.all` result array in request order.
- Add a regression test that asserts both batched loaders start before either deferred result resolves, then verifies response order after resolving them out of order.
- Add a patch changeset.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun typecheck`
- `bun test`
