### PR TITLE
[codex] Fix body-forbidden result statuses

### DIFF
--- a/.changeset/body-forbidden-result-statuses.md
+++ b/.changeset/body-forbidden-result-statuses.md
@@ -1,0 +1,5 @@
+---
+"litzjs": patch
+---
+
+Return bodyless responses for result helpers that use HTTP statuses which forbid response bodies.

--- a/src/input-validation.ts
+++ b/src/input-validation.ts
@@ -167,6 +167,10 @@ function createJsonResponse(
   body: Record<string, unknown>,
   headers: Headers,
 ): Response {
+  if (isBodyForbiddenStatus(status)) {
+    return createBodylessResponse(status, headers);
+  }
+
   if (!headers.has("content-type")) {
     headers.set("content-type", "application/json; charset=utf-8");
   }
@@ -175,6 +179,20 @@ function createJsonResponse(
     status,
     headers,
   });
+}
+
+export function createBodylessResponse(status: number, headers?: Headers): Response {
+  const responseHeaders = new Headers(headers);
+  responseHeaders.delete("content-type");
+
+  return new Response(null, {
+    status,
+    headers: responseHeaders,
+  });
+}
+
+export function isBodyForbiddenStatus(status: number): boolean {
+  return status === 204 || status === 205 || status === 304;
 }
 
 async function resolveValidatedBody<TContext>(

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2,7 +2,9 @@ import type { ApiRouteMethod } from "../index";
 
 import { normalizeBasePath, resolveBasePathname } from "../base-path";
 import {
+  createBodylessResponse,
   createApiResponseFromResult,
+  isBodyForbiddenStatus,
   isServerResultLike,
   resolveValidatedInput,
   type RuntimeInputValidation,
@@ -912,6 +914,11 @@ function createLitzJsonResponse(
   headers?: Headers,
 ): Response {
   const responseHeaders = new Headers(headers);
+
+  if (isBodyForbiddenStatus(status)) {
+    return createBodylessResponse(status, responseHeaders);
+  }
+
   responseHeaders.set("content-type", "application/vnd.litzjs.result+json");
   return new Response(JSON.stringify(body), {
     status,

--- a/src/vite/dev-middleware.ts
+++ b/src/vite/dev-middleware.ts
@@ -11,6 +11,7 @@ import type { DiscoveredApiRoute, DiscoveredResource, DiscoveredRoute } from "./
 import { resolveBasePathname } from "../base-path";
 import {
   createApiResponseFromResult,
+  isBodyForbiddenStatus,
   isServerResultLike,
   resolveValidatedInput,
   type RuntimeInputValidation,
@@ -840,6 +841,13 @@ function sendLitzJson(
   body: Record<string, unknown>,
 ): void {
   response.statusCode = status;
+
+  if (isBodyForbiddenStatus(status)) {
+    response.removeHeader("content-type");
+    response.end();
+    return;
+  }
+
   response.setHeader("content-type", "application/vnd.litzjs.result+json");
   response.end(JSON.stringify(body));
 }

--- a/tests/input-validation.test.ts
+++ b/tests/input-validation.test.ts
@@ -225,6 +225,57 @@ describe("input validation hooks", () => {
     });
   });
 
+  test.each([204, 205, 304])(
+    "route result helpers with status %p return bodyless responses",
+    async (status) => {
+      const route = defineRoute("/projects/:id", {
+        component() {
+          return null;
+        },
+        action() {
+          return data(null, {
+            status,
+            headers: {
+              "x-result": "saved",
+            },
+          });
+        },
+      });
+      const app = createServer({
+        manifest: {
+          routes: [{ id: route.id, path: route.path, route: route as any }],
+        },
+      });
+      const actionRequest = createInternalActionRequestInit(
+        {
+          path: route.path,
+          operation: "action",
+          request: {
+            params: {
+              id: "42",
+            },
+          },
+        },
+        {
+          name: "Litz",
+        },
+      );
+
+      const response = await app.fetch(
+        new Request("https://app.example.com/_litzjs/action", {
+          method: "POST",
+          headers: actionRequest.headers,
+          body: actionRequest.body,
+        }),
+      );
+
+      expect(response.status).toBe(status);
+      expect(response.headers.get("content-type")).toBeNull();
+      expect(response.headers.get("x-result")).toBe("saved");
+      expect(await response.text()).toBe("");
+    },
+  );
+
   test("resource actions can short-circuit with invalid results from input body parsing", async () => {
     let actionCalls = 0;
 
@@ -387,6 +438,49 @@ describe("input validation hooks", () => {
       data: undefined,
     });
   });
+
+  test.each([204, 205, 304])(
+    "api result helpers with status %p return bodyless responses",
+    async (status) => {
+      const api = defineApiRoute("/api/projects/:id", {
+        input: {
+          body() {
+            throw data(null, {
+              status,
+              headers: {
+                "x-result": "created",
+              },
+            });
+          },
+        } as any,
+        POST() {
+          return Response.json({ ok: true });
+        },
+      });
+      const app = createServer({
+        manifest: {
+          apiRoutes: [{ path: api.path, api: api as any }],
+        },
+      });
+
+      const response = await app.fetch(
+        new Request("https://app.example.com/api/projects/7", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            name: "Litz",
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(status);
+      expect(response.headers.get("content-type")).toBeNull();
+      expect(response.headers.get("x-result")).toBe("created");
+      expect(await response.text()).toBe("");
+    },
+  );
 
   test("api validation fallback preserves explicit status for unsupported view results", async () => {
     const api = defineApiRoute("/api/projects/:id", {

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -2132,7 +2132,10 @@ function createMockRequest(options: {
   return stream as unknown as IncomingMessage;
 }
 
-function createMockResponse(): ServerResponse & { getBody(): string } {
+function createMockResponse(): ServerResponse & {
+  getBody(): string;
+  getHeaderValue(key: string): string | undefined;
+} {
   let body = "";
   let statusCode = 200;
   const headers: Record<string, string> = {};
@@ -2145,7 +2148,10 @@ function createMockResponse(): ServerResponse & { getBody(): string } {
       statusCode = code;
     },
     setHeader(key: string, value: string) {
-      headers[key] = value;
+      headers[key.toLowerCase()] = value;
+    },
+    removeHeader(key: string) {
+      delete headers[key.toLowerCase()];
     },
     write(data?: string | Buffer) {
       if (data) {
@@ -2160,7 +2166,13 @@ function createMockResponse(): ServerResponse & { getBody(): string } {
     getBody() {
       return body;
     },
-  } as unknown as ServerResponse & { getBody(): string };
+    getHeaderValue(key: string) {
+      return headers[key.toLowerCase()];
+    },
+  } as unknown as ServerResponse & {
+    getBody(): string;
+    getHeaderValue(key: string): string | undefined;
+  };
 }
 
 describe("document entry resolution", () => {
@@ -2756,6 +2768,57 @@ describe("dev server error masking", () => {
         },
       ],
     });
+  });
+
+  test.each([204, 205, 304])("returns bodyless dev route results for status %p", async (status) => {
+    const server = createMockViteDevServer(async () => ({
+      route: {
+        action() {
+          return {
+            kind: "data",
+            status,
+            headers: {
+              "content-type": "application/json",
+              "x-result": "saved",
+            },
+            data: null,
+          };
+        },
+      },
+    }));
+    const internalMetadata = JSON.stringify({
+      path: "/projects/:id",
+      target: "projects.show",
+      operation: "action",
+      request: {
+        params: {
+          id: "42",
+        },
+      },
+    });
+    const request = createMockRequest({
+      url: "/_litzjs/action",
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: internalMetadata,
+    });
+    const response = createMockResponse();
+    const next = mock(() => {});
+
+    await handleLitzRouteRequest(
+      server,
+      [{ id: "projects.show", path: "/projects/:id", modulePath: "src/routes/projects.ts" }],
+      request,
+      response,
+      next,
+    );
+
+    expect(response.statusCode).toBe(status);
+    expect(response.getHeaderValue("content-type")).toBeUndefined();
+    expect(response.getHeaderValue("x-result")).toBe("saved");
+    expect(response.getBody()).toBe("");
   });
 
   test("treats missing internal route targets as faults", async () => {


### PR DESCRIPTION
## Summary

Fixes #135.

Result helper serialization now treats HTTP statuses that forbid response bodies (`204`, `205`, and `304`) as bodyless responses instead of attempting to construct JSON `Response` bodies with those statuses.

## Root Cause

 `createApiResponseFromResult(...)` and `createServerResultResponse(...)` both serialized result helper payloads through JSON response constructors while preserving caller-provided statuses. When callers used a status such as `204`, Fetch-compatible `Response` constructors rejected the body/status combination, which could mask the intended response as a framework/server error.

## Changes

- Added shared body-forbidden status handling for JSON result responses.
- Preserved caller headers on bodyless responses while removing `content-type` because no body is sent.
- Added regression coverage for API validation fallback results and internal route action results using `data(null, { status: 204 })`.
- Added the required patch changeset.

## Validation

- `bun test tests/input-validation.test.ts`
- `bun fmt`
- `bun lint:fix`
- `bun run test`
- `bun typecheck`
- `bun lint`
