### PR TITLE
[codex] add internal request validation hook

### DIFF
--- a/.changeset/internal-request-validation-hook.md
+++ b/.changeset/internal-request-validation-hook.md
@@ -1,0 +1,5 @@
+---
+"litzjs": minor
+---
+
+Add a `validateInternalRequest` server option for rejecting internal route and resource transport requests before middleware, input validation, or handlers run.

--- a/README.md
+++ b/README.md
@@ -1000,8 +1000,9 @@ export default createServer({
 ```
 
 The hook receives the internal request `kind`, `operation`, declared `path`, parsed transport
-`body`, and original `request`. Return nothing to continue, or return a `Response` to reject before
-route/resource middleware, input validation, or handlers run.
+`body`, original `request`, and `createContext` value when configured. Return nothing to continue,
+or return a `Response` to reject before route/resource middleware, input validation, or handlers
+run.
 
 Litz may serve `index.html` itself, but it also supports deployments where the document is served
 statically or by a custom server. Security decisions must not depend on the document coming from

--- a/README.md
+++ b/README.md
@@ -909,6 +909,11 @@ export default createServer({
       requestId: request.headers.get("x-request-id"),
     };
   },
+  validateInternalRequest({ operation, request }) {
+    if (operation === "action" && request.headers.get("origin") !== "https://app.example.com") {
+      return new Response("Forbidden", { status: 403 });
+    }
+  },
   notFound: "<!doctype html><html><body><h1>Not found</h1></body></html>",
   onError(error, context) {
     console.error("Litz server error", { error, context });
@@ -972,6 +977,31 @@ server endpoint:
 - validate params, search params, headers, and form/body input with `input` hooks or in middleware/handlers
 - apply CSRF protections when using cookie-backed auth for writes
 - do not assume a request came from Litz just because it arrived through `/_litzjs/*`
+
+For cookie-backed writes, use `validateInternalRequest` to apply a server-level CSRF or origin
+check before route and resource actions dispatch:
+
+```ts
+import { createServer } from "litzjs/server";
+
+export default createServer({
+  validateInternalRequest({ operation, request }) {
+    if (operation !== "action") {
+      return;
+    }
+
+    const origin = request.headers.get("origin");
+
+    if (origin !== "https://app.example.com") {
+      return new Response("Forbidden", { status: 403 });
+    }
+  },
+});
+```
+
+The hook receives the internal request `kind`, `operation`, declared `path`, parsed transport
+`body`, and original `request`. Return nothing to continue, or return a `Response` to reject before
+route/resource middleware, input validation, or handlers run.
 
 Litz may serve `index.html` itself, but it also supports deployments where the document is served
 statically or by a custom server. Security decisions must not depend on the document coming from

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -335,13 +335,14 @@ async function handleResourceRequest<TContext>(
     const body = await parseInternalRequestBody(request);
     const resourcePath = body.path;
     const operation = body.operation ?? "loader";
+    const context = await getContext();
     const validationResponse = await validateInternalRequest?.({
       request,
       kind: "resource",
       operation,
       path: resourcePath,
       body,
-      context: getLoadedContext?.(),
+      context,
     });
 
     if (validationResponse) {
@@ -373,7 +374,6 @@ async function handleResourceRequest<TContext>(
       body.payload,
     );
     const signal = request.signal;
-    const context = await getContext();
     const result = await runMiddlewareChain({
       middleware,
       request: normalizedRequest.request,
@@ -433,13 +433,14 @@ async function handleRouteRequest<TContext>(
     const requestPathname = resolveBasePathname(new URL(request.url).pathname, base);
     const operation =
       body.operation ?? (requestPathname === "/_litzjs/action" ? "action" : "loader");
+    const context = await getContext();
     const validationResponse = await validateInternalRequest?.({
       request,
       kind: "route",
       operation,
       path: routePath,
       body,
-      context: getLoadedContext?.(),
+      context,
     });
 
     if (validationResponse) {
@@ -461,7 +462,6 @@ async function handleRouteRequest<TContext>(
       body.payload,
     );
     const signal = request.signal;
-    const context = await getContext();
 
     if (operation === "loader" && targetIds && targetIds.length > 0) {
       const batchTargets: RouteMatchEntry[] = [];

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -24,6 +24,20 @@ type Awaitable<T> = T | Promise<T>;
 type DocumentResponseValue = Response | string | null | undefined;
 type DocumentResponseFactory = (request: Request) => Awaitable<DocumentResponseValue>;
 type DocumentResponseOption = Response | string | DocumentResponseFactory;
+export type InternalRequestKind = "route" | "resource";
+export type InternalRequestOperation = "loader" | "action";
+export type InternalRequestValidationContext<TContext = unknown> = {
+  request: Request;
+  kind: InternalRequestKind;
+  operation: InternalRequestOperation;
+  path: string | undefined;
+  body: InternalRequestBody;
+  context?: TContext | undefined;
+};
+export type InternalRequestValidationResult = Response | null | undefined | void;
+export type InternalRequestValidator<TContext = unknown> = (
+  context: InternalRequestValidationContext<TContext>,
+) => Awaitable<InternalRequestValidationResult>;
 type MiddlewareContextValue<TContext = unknown> = {
   request: Request;
   params: Record<string, string>;
@@ -137,6 +151,7 @@ let rscRendererPromise:
 
 export type CreateServerOptions<TContext = unknown> = {
   createContext?(request: Request): Promise<TContext> | TContext;
+  validateInternalRequest?: InternalRequestValidator<TContext>;
   onError?(error: unknown, context: TContext | undefined): void;
   manifest?: ServerManifest;
   base?: string;
@@ -177,6 +192,7 @@ export function createServer<TContext = unknown>(
           request,
           manifest.resources ?? [],
           getContext,
+          options.validateInternalRequest,
           (error, context) => options.onError?.(error, context),
           () => (contextLoaded ? contextValue : undefined),
         );
@@ -187,6 +203,7 @@ export function createServer<TContext = unknown>(
           request,
           manifest.routes ?? [],
           getContext,
+          options.validateInternalRequest,
           (error, context) => options.onError?.(error, context),
           () => (contextLoaded ? contextValue : undefined),
           basePath,
@@ -304,6 +321,7 @@ async function handleResourceRequest<TContext>(
   request: Request,
   resources: ResourceModule[],
   getContext: () => Promise<TContext | undefined>,
+  validateInternalRequest?: InternalRequestValidator<TContext>,
   reportError?: (error: unknown, context: TContext | undefined) => void,
   getLoadedContext?: () => TContext | undefined,
 ): Promise<Response> {
@@ -317,6 +335,19 @@ async function handleResourceRequest<TContext>(
     const body = await parseInternalRequestBody(request);
     const resourcePath = body.path;
     const operation = body.operation ?? "loader";
+    const validationResponse = await validateInternalRequest?.({
+      request,
+      kind: "resource",
+      operation,
+      path: resourcePath,
+      body,
+      context: getLoadedContext?.(),
+    });
+
+    if (validationResponse) {
+      return validationResponse;
+    }
+
     const entry = resources.find((resource) => resource.path === resourcePath);
 
     if (!resourcePath || !entry?.resource) {
@@ -383,6 +414,7 @@ async function handleRouteRequest<TContext>(
   request: Request,
   routes: RouteModule[],
   getContext: () => Promise<TContext | undefined>,
+  validateInternalRequest?: InternalRequestValidator<TContext>,
   reportError?: (error: unknown, context: TContext | undefined) => void,
   getLoadedContext?: () => TContext | undefined,
   base?: string,
@@ -401,6 +433,19 @@ async function handleRouteRequest<TContext>(
     const requestPathname = resolveBasePathname(new URL(request.url).pathname, base);
     const operation =
       body.operation ?? (requestPathname === "/_litzjs/action" ? "action" : "loader");
+    const validationResponse = await validateInternalRequest?.({
+      request,
+      kind: "route",
+      operation,
+      path: routePath,
+      body,
+      context: getLoadedContext?.(),
+    });
+
+    if (validationResponse) {
+      return validationResponse;
+    }
+
     const entry = routes.find((route) => route.path === routePath);
 
     if (!routePath || !entry?.route) {

--- a/tests/server-security.test.ts
+++ b/tests/server-security.test.ts
@@ -263,6 +263,92 @@ describe("server security", () => {
     expect(loaderCalls).toBe(1);
   });
 
+  test("passes createContext values to internal request validators", async () => {
+    const observedContexts: unknown[] = [];
+
+    const server = createServer({
+      createContext() {
+        return {
+          sessionId: "session-123",
+        };
+      },
+      validateInternalRequest({ context }) {
+        observedContexts.push(context);
+      },
+      manifest: {
+        routes: [
+          {
+            id: "projects.show",
+            path: "/projects/:id",
+            route: {
+              loader() {
+                return { kind: "data", data: { ok: true } };
+              },
+            },
+          },
+        ],
+        resources: [
+          {
+            path: "/resources/projects/:id",
+            resource: {
+              loader() {
+                return { kind: "data", data: { ok: true } };
+              },
+            },
+          },
+        ],
+      },
+    });
+    const routeRequest = createInternalActionRequestInit(
+      {
+        path: "/projects/:id",
+        target: "projects.show",
+        operation: "loader",
+        request: {
+          params: {
+            id: "42",
+          },
+        },
+      },
+      {
+        reload: true,
+      },
+    );
+    const resourceRequest = createInternalActionRequestInit(
+      {
+        path: "/resources/projects/:id",
+        operation: "loader",
+        request: {
+          params: {
+            id: "42",
+          },
+        },
+      },
+      {
+        reload: true,
+      },
+    );
+
+    const routeResponse = await server.fetch(
+      new Request("https://app.example.com/_litzjs/route", {
+        method: "POST",
+        headers: routeRequest.headers,
+        body: routeRequest.body,
+      }),
+    );
+    const resourceResponse = await server.fetch(
+      new Request("https://app.example.com/_litzjs/resource", {
+        method: "POST",
+        headers: resourceRequest.headers,
+        body: resourceRequest.body,
+      }),
+    );
+
+    expect(routeResponse.status).toBe(200);
+    expect(resourceResponse.status).toBe(200);
+    expect(observedContexts).toEqual([{ sessionId: "session-123" }, { sessionId: "session-123" }]);
+  });
+
   test("forwards cookies and origin to internal route actions without leaking transport headers", async () => {
     const server = createServer({
       manifest: {

--- a/tests/server-security.test.ts
+++ b/tests/server-security.test.ts
@@ -32,6 +32,237 @@ async function waitForCondition(condition: () => boolean): Promise<void> {
 }
 
 describe("server security", () => {
+  test("can reject internal route actions before the handler dispatches", async () => {
+    let actionCalls = 0;
+
+    const server = createServer({
+      validateInternalRequest({ kind, operation, request }) {
+        if (
+          kind === "route" &&
+          operation === "action" &&
+          request.headers.get("origin") !== "https://app.example.com"
+        ) {
+          return Response.json({ error: "Forbidden" }, { status: 403 });
+        }
+      },
+      manifest: {
+        routes: [
+          {
+            id: "projects.update",
+            path: "/projects/:id",
+            route: {
+              action() {
+                actionCalls += 1;
+
+                return { kind: "data", data: { ok: true } };
+              },
+            },
+          },
+        ],
+      },
+    });
+    const actionRequest = createInternalActionRequestInit(
+      {
+        path: "/projects/:id",
+        operation: "action",
+        request: {
+          params: {
+            id: "42",
+          },
+        },
+      },
+      {
+        name: "Litz",
+      },
+    );
+    const headers = new Headers(actionRequest.headers);
+
+    headers.set("origin", "https://attacker.example.com");
+
+    const response = await server.fetch(
+      new Request("https://app.example.com/_litzjs/action", {
+        method: "POST",
+        headers,
+        body: actionRequest.body,
+      }),
+    );
+    const body = (await response.json()) as { error: string };
+
+    expect(response.status).toBe(403);
+    expect(body.error).toBe("Forbidden");
+    expect(actionCalls).toBe(0);
+  });
+
+  test("can reject internal resource actions before the handler dispatches", async () => {
+    let actionCalls = 0;
+
+    const server = createServer({
+      validateInternalRequest({ kind, operation, request }) {
+        if (
+          kind === "resource" &&
+          operation === "action" &&
+          request.headers.get("x-csrf-token") !== "trusted"
+        ) {
+          return new Response("Forbidden", { status: 403 });
+        }
+      },
+      manifest: {
+        resources: [
+          {
+            path: "/resources/projects/:id",
+            resource: {
+              action() {
+                actionCalls += 1;
+
+                return { kind: "data", data: { ok: true } };
+              },
+            },
+          },
+        ],
+      },
+    });
+    const actionRequest = createInternalActionRequestInit(
+      {
+        path: "/resources/projects/:id",
+        operation: "action",
+        request: {
+          params: {
+            id: "42",
+          },
+        },
+      },
+      {
+        name: "Litz",
+      },
+    );
+
+    const response = await server.fetch(
+      new Request("https://app.example.com/_litzjs/resource", {
+        method: "POST",
+        headers: actionRequest.headers,
+        body: actionRequest.body,
+      }),
+    );
+    const body = await response.text();
+
+    expect(response.status).toBe(403);
+    expect(body).toBe("Forbidden");
+    expect(actionCalls).toBe(0);
+  });
+
+  test("allows internal writes when validateInternalRequest does not return a response", async () => {
+    let validatedPath: string | undefined;
+
+    const server = createServer({
+      validateInternalRequest({ kind, operation, path, request }) {
+        if (kind === "route" && operation === "action") {
+          validatedPath = path;
+          expect(request.headers.get("x-csrf-token")).toBe("trusted");
+        }
+      },
+      manifest: {
+        routes: [
+          {
+            id: "projects.update",
+            path: "/projects/:id",
+            route: {
+              action() {
+                return { kind: "data", data: { ok: true } };
+              },
+            },
+          },
+        ],
+      },
+    });
+    const actionRequest = createInternalActionRequestInit(
+      {
+        path: "/projects/:id",
+        operation: "action",
+        request: {
+          params: {
+            id: "42",
+          },
+        },
+      },
+      {
+        name: "Litz",
+      },
+    );
+    const headers = new Headers(actionRequest.headers);
+
+    headers.set("x-csrf-token", "trusted");
+
+    const response = await server.fetch(
+      new Request("https://app.example.com/_litzjs/action", {
+        method: "POST",
+        headers,
+        body: actionRequest.body,
+      }),
+    );
+    const body = (await response.json()) as {
+      kind: "data";
+      data: { ok: boolean };
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.kind).toBe("data");
+    expect(body.data.ok).toBe(true);
+    expect(validatedPath).toBe("/projects/:id");
+  });
+
+  test("can allow loader-only internal requests while rejecting writes", async () => {
+    let loaderCalls = 0;
+
+    const server = createServer({
+      validateInternalRequest({ operation, request }) {
+        if (operation === "action" && request.headers.get("origin") !== "https://app.example.com") {
+          return new Response("Forbidden", { status: 403 });
+        }
+      },
+      manifest: {
+        routes: [
+          {
+            id: "projects.show",
+            path: "/projects/:id",
+            route: {
+              loader() {
+                loaderCalls += 1;
+
+                return { kind: "data", data: { ok: true } };
+              },
+            },
+          },
+        ],
+      },
+    });
+    const loaderRequest = createInternalActionRequestInit(
+      {
+        path: "/projects/:id",
+        target: "projects.show",
+        operation: "loader",
+        request: {
+          params: {
+            id: "42",
+          },
+        },
+      },
+      {
+        reload: true,
+      },
+    );
+
+    const response = await server.fetch(
+      new Request("https://app.example.com/_litzjs/route", {
+        method: "POST",
+        headers: loaderRequest.headers,
+        body: loaderRequest.body,
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(loaderCalls).toBe(1);
+  });
+
   test("forwards cookies and origin to internal route actions without leaking transport headers", async () => {
     const server = createServer({
       manifest: {

--- a/www/src/routes/docs/server-configuration.tsx
+++ b/www/src/routes/docs/server-configuration.tsx
@@ -69,7 +69,8 @@ export default createServer();`}
         <p className="text-neutral-400 mb-4">
           Return nothing to continue, or return a <code className="text-sky-400">Response</code> to
           reject the request. This is the right place for origin or CSRF validation when actions use
-          cookie-backed authentication.
+          cookie-backed authentication. If <code className="text-sky-400">createContext</code> is
+          configured, its value is available as <code className="text-sky-400">context</code>.
         </p>
         <CodeBlock
           language="tsx"

--- a/www/src/routes/docs/server-configuration.tsx
+++ b/www/src/routes/docs/server-configuration.tsx
@@ -60,6 +60,36 @@ export default createServer();`}
       </section>
 
       <section className="mb-12">
+        <h2 className="text-2xl font-semibold text-neutral-100 mb-4">validateInternalRequest</h2>
+        <p className="text-neutral-400 mb-4">
+          Use <code className="text-sky-400">validateInternalRequest</code> for server-level checks
+          on the internal <code className="text-sky-400">/_litzjs/*</code> transport before route
+          and resource middleware, input validation, or handlers run.
+        </p>
+        <p className="text-neutral-400 mb-4">
+          Return nothing to continue, or return a <code className="text-sky-400">Response</code> to
+          reject the request. This is the right place for origin or CSRF validation when actions use
+          cookie-backed authentication.
+        </p>
+        <CodeBlock
+          language="tsx"
+          code={`export default createServer({
+  validateInternalRequest({ operation, request }) {
+    if (operation !== "action") {
+      return;
+    }
+
+    const origin = request.headers.get("origin");
+
+    if (origin !== "https://app.example.com") {
+      return new Response("Forbidden", { status: 403 });
+    }
+  },
+});`}
+        />
+      </section>
+
+      <section className="mb-12">
         <h2 className="text-2xl font-semibold text-neutral-100 mb-4">onError</h2>
         <p className="text-neutral-400 mb-4">
           <code className="text-sky-400">onError(error, context)</code> is called when an unhandled


### PR DESCRIPTION
## Summary

Closes #136.

Adds an opt-in `validateInternalRequest` option to `createServer(...)` so applications can reject internal route and resource transport requests before middleware, input validation, or handlers run. The hook receives the original request plus the parsed internal transport metadata (`kind`, `operation`, declared `path`, and body) and can return a `Response` to short-circuit dispatch.

## Why

The existing docs correctly warned that `/_litzjs/*` is not a trust boundary, but the framework only let apps enforce CSRF/origin checks inside route/resource middleware or handlers. That made it easy to miss protection on internal action/resource write surfaces. This change gives cookie-backed apps one central server-level hook for write validation while leaving loader requests opt-in based on app policy.

## Changes

- Adds exported internal request validation types and `CreateServerOptions.validateInternalRequest`.
- Runs the validator for internal route and resource requests after parsing transport metadata and before handler lookup/dispatch.
- Adds regression coverage for rejected route actions, rejected resource actions, accepted writes, and loader-only allowance.
- Documents the hook in the README security model and server configuration docs.
- Adds a changeset for the new public server option.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun typecheck`
- `bun test` (`320 pass, 0 fail`)
