### PR TITLE
[codex] Abort in-flight resource loaders

### DIFF
--- a/.changeset/abort-resource-loaders.md
+++ b/.changeset/abort-resource-loaders.md
@@ -1,0 +1,5 @@
+---
+"litzjs": patch
+---
+
+Abort in-flight resource loader requests when the final active subscriber unsubscribes.

--- a/src/client/resources.tsx
+++ b/src/client/resources.tsx
@@ -553,7 +553,7 @@ async function performPreparedResourceRequest(
       if (operation === "loader") {
         const loaderResult = await parseLoaderResponse(response);
 
-        if (entry.loaderSequence !== loaderSequence) {
+        if (shouldIgnoreResourceLoader(entry, loaderController, loaderSequence)) {
           return;
         }
 
@@ -877,6 +877,7 @@ function abortResourceLoader(entry: ResourceStoreEntry): void {
   entry.loaderInFlight = undefined;
   entry.loaderMode = undefined;
   syncEntryPendingState(entry);
+  notify(entry);
 }
 
 function pruneResourceStore(): void {

--- a/src/client/resources.tsx
+++ b/src/client/resources.tsx
@@ -78,6 +78,7 @@ type ResourceStoreEntry = {
   listeners: Set<() => void>;
   loaderInFlight?: Promise<LoaderHookResult | void>;
   loaderMode?: "loading" | "revalidating";
+  loaderController?: AbortController;
   loaderSequence: number;
   actionController?: AbortController;
   actionSequence: number;
@@ -338,6 +339,8 @@ export function invalidateResourceHotUpdateCaches(): void {
     entry.loaderSequence += 1;
     entry.actionController?.abort();
     entry.actionController = undefined;
+    entry.loaderController?.abort();
+    entry.loaderController = undefined;
     entry.loaderInFlight = undefined;
     entry.loaderMode = undefined;
     entry.snapshot = getInitialSnapshot();
@@ -492,6 +495,7 @@ async function performPreparedResourceRequest(
   const entry = getEntry(key);
   const loaderSequence = operation === "loader" ? entry.loaderSequence + 1 : undefined;
   const actionSequence = operation === "action" ? entry.actionSequence + 1 : undefined;
+  const loaderController = operation === "loader" ? new AbortController() : undefined;
   const actionController = operation === "action" ? new AbortController() : undefined;
 
   if (operation === "loader" && entry.loaderInFlight) {
@@ -500,6 +504,7 @@ async function performPreparedResourceRequest(
 
   if (operation === "loader") {
     entry.loaderSequence = loaderSequence!;
+    entry.loaderController = loaderController;
     entry.loaderMode = mode === "revalidating" ? "revalidating" : "loading";
   } else {
     entry.actionController?.abort();
@@ -542,6 +547,7 @@ async function performPreparedResourceRequest(
                   search: normalizedRequest.search,
                 },
               }),
+              signal: loaderController?.signal,
             });
 
       if (operation === "loader") {
@@ -609,6 +615,13 @@ async function performPreparedResourceRequest(
         return;
       }
 
+      if (
+        operation === "loader" &&
+        shouldIgnoreResourceLoader(entry, loaderController, loaderSequence, error)
+      ) {
+        return;
+      }
+
       if (isRedirectSignal(error)) {
         performClientRedirect(error.location, error.replace);
         entry.snapshot = {
@@ -630,6 +643,9 @@ async function performPreparedResourceRequest(
         if (entry.loaderInFlight === request) {
           entry.loaderInFlight = undefined;
           entry.loaderMode = undefined;
+        }
+        if (entry.loaderController === loaderController) {
+          entry.loaderController = undefined;
         }
       } else {
         if (entry.actionController === actionController) {
@@ -701,6 +717,7 @@ function subscribe(key: string, listener: () => void): () => void {
       entry.actionSequence += 1;
       entry.actionController?.abort();
       entry.actionController = undefined;
+      abortResourceLoader(entry);
     }
 
     deferredCleanupResourceEntry(key, entry);
@@ -749,7 +766,7 @@ function getActiveEntryStatus(entry: ResourceStoreEntry): RouteStatus | null {
     return "submitting";
   }
 
-  if (entry.loaderInFlight) {
+  if (entry.loaderController) {
     return entry.loaderMode ?? "loading";
   }
 
@@ -830,6 +847,36 @@ function shouldIgnoreResourceAction(
   }
 
   return isAbortError(error);
+}
+
+function shouldIgnoreResourceLoader(
+  entry: ResourceStoreEntry,
+  controller?: AbortController,
+  sequence?: number,
+  error?: unknown,
+): boolean {
+  if (!controller || sequence === undefined) {
+    return false;
+  }
+
+  if (controller.signal.aborted || entry.loaderSequence !== sequence) {
+    return true;
+  }
+
+  return isAbortError(error);
+}
+
+function abortResourceLoader(entry: ResourceStoreEntry): void {
+  if (!entry.loaderController) {
+    return;
+  }
+
+  entry.loaderSequence += 1;
+  entry.loaderController.abort();
+  entry.loaderController = undefined;
+  entry.loaderInFlight = undefined;
+  entry.loaderMode = undefined;
+  syncEntryPendingState(entry);
 }
 
 function pruneResourceStore(): void {

--- a/tests/resource-runtime.test.tsx
+++ b/tests/resource-runtime.test.tsx
@@ -1118,4 +1118,51 @@ describe("resource runtime", () => {
     expect(document.querySelector(".unmounted-resource")).not.toBeNull();
     expect(raceResourceEvents).toEqual([]);
   });
+
+  test("aborts an in-flight resource loader when the resource unmounts", async () => {
+    let loaderAborted = false;
+    let resolveLoaderFetch: ((response: Response) => void) | null = null;
+
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const signal = init?.signal;
+      expect(signal).toBeInstanceOf(AbortSignal);
+      (signal as AbortSignal).addEventListener(
+        "abort",
+        () => {
+          loaderAborted = true;
+        },
+        { once: true },
+      );
+
+      return await new Promise<Response>((resolve) => {
+        resolveLoaderFetch = resolve;
+      });
+    }) as typeof fetch;
+
+    await act(async () => {
+      root?.render(<raceResource.Component params={{ id: "user-009" }} />);
+      await flushDom();
+    });
+
+    expect(document.querySelector(".race-pending")?.getAttribute("data-value")).toBe("yes");
+
+    await act(async () => {
+      root?.render(<div className="unmounted-resource" />);
+      await flushDom();
+    });
+
+    expect(loaderAborted).toBe(true);
+
+    await act(async () => {
+      resolveLoaderFetch?.(
+        Response.json({
+          kind: "data",
+          data: { value: "stale" },
+        }),
+      );
+      await flushDom();
+    });
+
+    expect(document.querySelector(".unmounted-resource")).not.toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #137 by making resource loader requests abortable, matching the existing action cancellation behavior.

## Changes

- Add `AbortController` ownership for resource loader requests in the resource store.
- Abort pending loader fetches when the final subscriber unsubscribes or resource hot-update caches are invalidated.
- Ignore aborted or stale loader completions via loader request sequencing so stale responses cannot update resource state after unmounts or request-key changes.
- Add a regression test covering unmounting the only resource component while its loader is still pending.
- Add a patch changeset.

## Impact

Unmounted or replaced resource components no longer leave loader fetches running without active subscribers, reducing unnecessary server work and preventing stale completions from mutating resource store state.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`
- `bun run test:e2e`
