### PR TITLE
[codex] Sort direct server manifests by specificity

### DIFF
--- a/.changeset/sort-direct-api-manifests.md
+++ b/.changeset/sort-direct-api-manifests.md
@@ -1,0 +1,5 @@
+---
+"litzjs": patch
+---
+
+Sort direct server manifests by path specificity so static API routes are not shadowed by earlier dynamic routes.

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -14,6 +14,7 @@ import {
   hasMalformedPathnameEncoding,
   interpolatePath,
   matchPathname,
+  sortByPathSpecificity,
   trimPathSegments,
 } from "../path-matching";
 import { createSearchParams, type SearchParamRecord } from "../search-params";
@@ -163,7 +164,7 @@ export type CreateServerOptions<TContext = unknown> = {
 export function createServer<TContext = unknown>(
   options: CreateServerOptions<TContext> = {},
 ): { fetch(request: Request): Promise<Response> } {
-  const manifest = options.manifest ?? {};
+  const manifest = normalizeServerManifest(options.manifest);
   const basePath = normalizeBasePath(options.base);
 
   async function handle(request: Request): Promise<Response> {
@@ -263,6 +264,18 @@ export function createServer<TContext = unknown>(
   }
 
   return { fetch: handle };
+}
+
+function normalizeServerManifest(manifest: ServerManifest | undefined): ServerManifest {
+  if (!manifest) {
+    return {};
+  }
+
+  return {
+    ...manifest,
+    routes: manifest.routes ? sortByPathSpecificity(manifest.routes) : undefined,
+    apiRoutes: manifest.apiRoutes ? sortByPathSpecificity(manifest.apiRoutes) : undefined,
+  };
 }
 
 async function createDocumentResponse(

--- a/tests/server-api-route-order.test.ts
+++ b/tests/server-api-route-order.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+
+import { createServer } from "../src/server";
+
+describe("createServer API route ordering", () => {
+  test("matches more specific static API routes before dynamic routes in direct manifests", async () => {
+    const server = createServer({
+      manifest: {
+        apiRoutes: [
+          {
+            path: "/api/users/:id",
+            api: {
+              methods: {
+                GET({ params }) {
+                  return Response.json({ route: "dynamic", params });
+                },
+              },
+            },
+          },
+          {
+            path: "/api/users/me",
+            api: {
+              methods: {
+                GET() {
+                  return Response.json({ route: "static" });
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const response = await server.fetch(new Request("https://example.com/api/users/me"));
+    const body = (await response.json()) as { route: string };
+
+    expect(response.status).toBe(200);
+    expect(body.route).toBe("static");
+  });
+});

--- a/tests/server-api-route-order.test.ts
+++ b/tests/server-api-route-order.test.ts
@@ -3,6 +3,41 @@ import { describe, expect, test } from "bun:test";
 import { createServer } from "../src/server";
 
 describe("createServer API route ordering", () => {
+  test("checks more specific document routes before dynamic routes in direct manifests", async () => {
+    const pathAccesses: string[] = [];
+    const dynamicRoute = {
+      id: "/users/:id",
+      get path() {
+        pathAccesses.push("dynamic");
+        return "/users/:id";
+      },
+    };
+    const staticRoute = {
+      id: "/users/me",
+      get path() {
+        pathAccesses.push("static");
+        return "/users/me";
+      },
+    };
+    const server = createServer({
+      document: "Document",
+      manifest: {
+        routes: [dynamicRoute, staticRoute],
+      },
+    });
+
+    pathAccesses.length = 0;
+
+    const response = await server.fetch(
+      new Request("https://example.com/users/me", {
+        headers: { accept: "text/html" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(pathAccesses).toEqual(["static"]);
+  });
+
   test("matches more specific static API routes before dynamic routes in direct manifests", async () => {
     const server = createServer({
       manifest: {


### PR DESCRIPTION
## Summary

Fixes #138.

`createServer({ manifest })` now normalizes manually supplied route and API manifests with the shared path-specificity sorter before request handling. This makes direct manifest usage behave like Vite-discovered manifests and prevents a dynamic API route such as `/api/users/:id` from shadowing a more specific static route such as `/api/users/me` when the direct manifest is supplied in the wrong order.

## Root Cause

Vite discovery already sorted API manifests by path specificity, but `createServer` trusted direct manifest order. `handleApiRequest` selects the first matching API route, so direct manifests could accidentally match a less-specific dynamic route before a static route.

## Changes

- Added server manifest normalization at `createServer` construction.
- Sorted direct `routes` and `apiRoutes` by path specificity without mutating the caller's manifest arrays.
- Added a regression test covering a dynamic API route listed before a static API route.
- Added a patch changeset.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun run test`
- `bun typecheck`