### PR TITLE
[codex] Fix useMatches runtime guard

### DIFF
--- a/.changeset/fail-fast-use-matches.md
+++ b/.changeset/fail-fast-use-matches.md
@@ -1,0 +1,5 @@
+---
+"litzjs": patch
+---
+
+Make `useMatches()` throw a clear runtime error when it is used outside the Litz client runtime.

--- a/src/client/contexts.ts
+++ b/src/client/contexts.ts
@@ -14,14 +14,12 @@ let locationContext:
     } | null>
   | undefined;
 let matchesContext:
-  | React.Context<
-      Array<{
-        id: string;
-        path: string;
-        params: Record<string, string>;
-        search: URLSearchParams;
-      }>
-    >
+  | React.Context<Array<{
+      id: string;
+      path: string;
+      params: Record<string, string>;
+      search: URLSearchParams;
+    }> | null>
   | undefined;
 
 export function getNavigationContext(): React.Context<{
@@ -74,14 +72,12 @@ export function getLocationContext(): React.Context<{
   return locationContext;
 }
 
-export function getMatchesContext(): React.Context<
-  Array<{
-    id: string;
-    path: string;
-    params: Record<string, string>;
-    search: URLSearchParams;
-  }>
-> {
+export function getMatchesContext(): React.Context<Array<{
+  id: string;
+  path: string;
+  params: Record<string, string>;
+  search: URLSearchParams;
+}> | null> {
   if (!matchesContext) {
     const createContext = (
       React as typeof React & {
@@ -93,14 +89,12 @@ export function getMatchesContext(): React.Context<
       throw new Error("Litz client matches are not available in this environment.");
     }
 
-    matchesContext = createContext<
-      Array<{
-        id: string;
-        path: string;
-        params: Record<string, string>;
-        search: URLSearchParams;
-      }>
-    >([]);
+    matchesContext = createContext<Array<{
+      id: string;
+      path: string;
+      params: Record<string, string>;
+      search: URLSearchParams;
+    }> | null>(null);
   }
 
   return matchesContext;

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -314,7 +314,13 @@ export function useMatches(): Array<{
   params: Record<string, string>;
   search: URLSearchParams;
 }> {
-  return React.useContext(getMatchesContext());
+  const matches = React.useContext(getMatchesContext());
+
+  if (!matches) {
+    throw new Error("useMatches() must be used inside the Litz client runtime.");
+  }
+
+  return matches;
 }
 
 export function usePathname(): string {

--- a/tests/client-wildcard-route-runtime.test.tsx
+++ b/tests/client-wildcard-route-runtime.test.tsx
@@ -231,7 +231,7 @@ describe("client wildcard route runtime", () => {
     clientModule = await import("../src/client/index");
 
     function MatchesReader(): React.ReactElement {
-      clientModule?.useMatches();
+      clientModule!.useMatches();
 
       return <div />;
     }

--- a/tests/client-wildcard-route-runtime.test.tsx
+++ b/tests/client-wildcard-route-runtime.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import * as React from "react";
 import { act } from "react";
+import { renderToString } from "react-dom/server";
 
 import { data, defineRoute, server } from "../src/index";
 import { flushDom, installTestDom } from "./test-dom";
@@ -224,6 +225,20 @@ describe("client wildcard route runtime", () => {
     cleanupDom = null;
     container = null;
     clientModule = null;
+  });
+
+  test("useMatches() throws when rendered outside the Litz client runtime", async () => {
+    clientModule = await import("../src/client/index");
+
+    function MatchesReader(): React.ReactElement {
+      clientModule?.useMatches();
+
+      return <div />;
+    }
+
+    expect(() => {
+      renderToString(<MatchesReader />);
+    }).toThrow("useMatches() must be used inside the Litz client runtime.");
   });
 
   test("prefetches and navigates to wildcard routes through the client manifest", async () => {


### PR DESCRIPTION
## Summary

Fixes #139.

`useMatches()` now behaves consistently with neighboring client runtime hooks: when it is rendered without the Litz client runtime provider, it throws a clear runtime error instead of silently returning an empty match array.

## Root Cause

The matches context was initialized with `[]`, so missing providers were indistinguishable from a valid route state with no matches. That allowed route-dependent UI to render against incorrect default state outside `mountApp(...)`.

## Changes

- Changed the matches context default to `null` so missing providers can be detected.
- Updated `useMatches()` to throw `useMatches() must be used inside the Litz client runtime.` when the context is absent.
- Added a regression test for calling `useMatches()` outside the client runtime.
- Added a patch changeset.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`
