### PR TITLE
[codex] Suppress expected sensitive dev middleware test logs

### DIFF
--- a/.changeset/suppress-sensitive-test-logs.md
+++ b/.changeset/suppress-sensitive-test-logs.md
@@ -1,0 +1,5 @@
+---
+"litzjs": patch
+---
+
+Suppress expected sensitive dev middleware errors during regression tests.

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -102,6 +102,26 @@ async function waitForProcessExit(serverProcess: ChildProcessWithoutNullStreams)
   });
 }
 
+async function captureExpectedConsoleErrors<T>(
+  callback: () => Promise<T>,
+): Promise<{ result: T; errorLogCount: number }> {
+  const originalConsoleError = console.error;
+  let errorLogCount = 0;
+
+  console.error = (..._args: unknown[]) => {
+    errorLogCount += 1;
+  };
+
+  try {
+    return {
+      result: await callback(),
+      errorLogCount,
+    };
+  } finally {
+    console.error = originalConsoleError;
+  }
+}
+
 describe("vite production server helpers", () => {
   test("build completes without warnings", () => {
     const repoRoot = process.cwd();
@@ -2913,22 +2933,25 @@ describe("dev server error masking", () => {
     const response = createMockResponse();
     const next = mock(() => {});
 
-    await handleLitzResourceRequest(
-      server,
-      [
-        {
-          path: "/resources/config",
-          modulePath: "src/resources/config.ts",
-          hasLoader: true,
-          hasAction: false,
-          hasComponent: false,
-        },
-      ],
-      request,
-      response,
-      next,
+    const { errorLogCount } = await captureExpectedConsoleErrors(() =>
+      handleLitzResourceRequest(
+        server,
+        [
+          {
+            path: "/resources/config",
+            modulePath: "src/resources/config.ts",
+            hasLoader: true,
+            hasAction: false,
+            hasComponent: false,
+          },
+        ],
+        request,
+        response,
+        next,
+      ),
     );
 
+    expect(errorLogCount).toBe(1);
     expect(response.statusCode).toBe(500);
     expect(response.getBody()).not.toContain(sensitiveMessage);
     expect(response.getBody()).not.toContain("hunter2");
@@ -2957,14 +2980,17 @@ describe("dev server error masking", () => {
     const response = createMockResponse();
     const next = mock(() => {});
 
-    await handleLitzRouteRequest(
-      server,
-      [{ id: "secrets.show", path: "/secrets/:id", modulePath: "src/routes/secrets.ts" }],
-      request,
-      response,
-      next,
+    const { errorLogCount } = await captureExpectedConsoleErrors(() =>
+      handleLitzRouteRequest(
+        server,
+        [{ id: "secrets.show", path: "/secrets/:id", modulePath: "src/routes/secrets.ts" }],
+        request,
+        response,
+        next,
+      ),
     );
 
+    expect(errorLogCount).toBe(1);
     expect(response.statusCode).toBe(500);
     expect(response.getBody()).not.toContain(sensitiveMessage);
     expect(response.getBody()).not.toContain("xyz789");
@@ -2983,14 +3009,17 @@ describe("dev server error masking", () => {
     const response = createMockResponse();
     const next = mock(() => {});
 
-    await handleLitzApiRequest(
-      server,
-      [{ path: "/api/private", modulePath: "src/api/private.ts" }],
-      request,
-      response,
-      next,
+    const { errorLogCount } = await captureExpectedConsoleErrors(() =>
+      handleLitzApiRequest(
+        server,
+        [{ path: "/api/private", modulePath: "src/api/private.ts" }],
+        request,
+        response,
+        next,
+      ),
     );
 
+    expect(errorLogCount).toBe(1);
     expect(response.statusCode).toBe(500);
     expect(response.getBody()).not.toContain(sensitiveMessage);
     expect(response.getBody()).not.toContain("s3cret");


### PR DESCRIPTION
## Summary

Closes #140.

This updates the dev middleware error-masking regression tests so expected handler failures are captured instead of written to stderr. The affected resource, route, and API route tests still verify that middleware error logging occurs, while continuing to assert that raw sensitive-looking messages are masked from HTTP responses.

A patch changeset is included for the release notes.

## Root Cause

The tests intentionally throw errors containing fake secrets to validate response masking, but the dev middleware also logs caught handler errors with `console.error(error)`. Because the tests did not capture that expected log path, `bun test` printed the fake secrets into local and CI output even though the response assertions passed.

## Validation

- `bun test tests/vite.test.ts`
- Verified the targeted test output does not contain `hunter2`, `xyz789`, `s3cret`, `password=`, `admin_token`, or `redis://`
- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`
