### PR TITLE
[codex] Refresh stale project guidance

### DIFF
--- a/.changeset/refresh-project-guidance.md
+++ b/.changeset/refresh-project-guidance.md
@@ -1,0 +1,5 @@
+---
+"litzjs": patch
+---
+
+Refresh stale repository guidance to describe Litz as a client-first React framework and use Bun-first `litzjs` installation commands.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-This is JavaScript library that exposes a simple, database agnostic Object Document Mapper (ODM) for NoSQL databases. The library is designed to be flexible and extensible, allowing developers to easily integrate it with various NoSQL (and SQL) databases.
+This is a JavaScript library that exposes Litz, a client-first React framework for Vite. The library provides explicit server boundaries, route loaders and actions, reusable server-backed resources, raw API routes, and React Server Components / Flight powered `view(...)` responses.
 This project uses Bun as the package manager. NEVER use `npm` or `yarn` to install dependencies or run scripts.
 
 For rules to follow when making Git operations, see [GIT.md](conventions/GIT.md)

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -92,7 +92,8 @@ surfaces by app authors.
 # Installation
 
 ```bash
-npm install litz
+bun add litzjs react react-dom
+bun add -d vite typescript
 ```
 
 ```ts

--- a/tests/docs-package-names.test.ts
+++ b/tests/docs-package-names.test.ts
@@ -55,6 +55,22 @@ describe("getting started docs flow", () => {
 });
 
 describe("docs package names", () => {
+  test("repo guidance matches the current framework and Bun package guidance", () => {
+    const agentsDoc = normalizeWhitespace(readDoc("AGENTS.md"));
+    const projectDoc = normalizeWhitespace(readDoc("PROJECT.md"));
+
+    expect(agentsDoc).toContain("client-first React framework for Vite");
+    expect(agentsDoc).toContain("route loaders and actions");
+    expect(agentsDoc).toContain("React Server Components / Flight");
+    expect(agentsDoc).toContain("This project uses Bun as the package manager.");
+    expect(agentsDoc).not.toContain("Object Document Mapper");
+    expect(agentsDoc).not.toContain("NoSQL");
+
+    expect(projectDoc).toContain("bun add litzjs react react-dom");
+    expect(projectDoc).toContain("bun add -d vite typescript");
+    expect(projectDoc).not.toMatch(/npm install litz(?!js)/);
+  });
+
   test("installation docs use the published package name in every install command", () => {
     const installationDoc = readDoc("www/src/routes/docs/installation.tsx");
 


### PR DESCRIPTION
## Summary

Fixes #142.

Updates stale repository guidance so contributors and automation see the current Litz project identity and install commands before inspecting package metadata.

## Changes

- Refresh `AGENTS.md` to describe Litz as a client-first React framework for Vite with explicit server boundaries, routes, resources, API routes, and RSC/Flight view responses.
- Replace `PROJECT.md`'s stale `npm install litz` example with Bun-first `litzjs` install guidance.
- Add a docs regression test covering the repo guidance files so stale ODM and wrong package-manager/package-name guidance does not recur.
- Add the required patch changeset.

## Validation

- `bun test tests/docs-package-names.test.ts`
- `bun fmt`
- `bun lint:fix`
- `bun typecheck`
- `bun test`
- `git diff --check`
