### PR TITLE
[codex] Add explicit app registration

### DIFF
--- a/.changeset/explicit-app-registration.md
+++ b/.changeset/explicit-app-registration.md
@@ -1,0 +1,10 @@
+---
+"litzjs": minor
+---
+
+Add explicit `defineApp(...)` registration for routes, resources, and API routes.
+
+Applications can now pass the same app definition to `mountApp(root, { app })` and
+`createServer({ app })`, and route/layout/resource definitions accept `clientLoading`
+metadata for client loading strategy selection. Duplicate route, resource, and API
+route registrations are rejected by path.

--- a/.changeset/explicit-app-registration.md
+++ b/.changeset/explicit-app-registration.md
@@ -8,3 +8,7 @@ Applications can now pass the same app definition to `mountApp(root, { app })` a
 `createServer({ app })`, and route/layout/resource definitions accept `clientLoading`
 metadata for client loading strategy selection. Duplicate route, resource, and API
 route registrations are rejected by path.
+
+The Vite plugin no longer auto-discovers `src/server.ts` or `src/server/index.ts`. Omit
+`server` for client-only builds, or pass `litz({ server: "..." })` to produce a server build from
+that explicit entry.

--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ does not ask applications to install or compose those Vite plugins directly.
 
 ## Quick Start
 
-Add the Litz Vite plugin. By default, Litz uses the browser entry at `src/main.tsx` and a custom
-server entry from `src/server.ts`, falling back to `src/server/index.ts`.
+Add the Litz Vite plugin. Without a server entry, Litz produces a client-only build.
 
 `vite.config.ts`
 
@@ -46,23 +45,23 @@ export default defineConfig({
 });
 ```
 
-You can point Litz at different browser or server entries when you need a different project layout:
+Pass `server` when your app uses route loaders, actions, resources, API routes, or `view(...)`
+responses:
 
 ```ts
 export default defineConfig({
   plugins: [
     litz({
-      clientEntry: "app/main.tsx",
-      server: "app/server/entry.ts",
+      server: "src/server.ts",
     }),
   ],
 });
 ```
 
-Litz does not infer the browser entry by scanning HTML module scripts. Keep standard Vite
-`index.html` behavior and point Litz at a different browser entry with `clientEntry` when your
-project does not use `src/main.tsx`. During development, Vite serves explicit HTML documents such as
-`/about.html`; Litz only falls back to `index.html` for extensionless app routes.
+Litz does not auto-discover a server entry. Keep standard Vite `index.html` behavior for the browser
+entry and point Litz at a different browser entry with `clientEntry` only when your project does not
+use `src/main.tsx`. During development, Vite serves explicit HTML documents such as `/about.html`;
+Litz only falls back to `index.html` for extensionless app routes when a server entry is configured.
 
 Register routes, resources, and API routes explicitly with `defineApp(...)`.
 
@@ -937,21 +936,21 @@ import { createServer } from "litzjs/server";
 export default createServer();
 ```
 
-The Vite plugin injects the discovered server manifest automatically into that entry.
+The Vite plugin injects the server manifest and configured base automatically into that entry.
 
 ### Production Output
 
 When you run `vite build`, Litz writes the browser assets to `dist/client`.
 
-Server output is always `dist/server/index.mjs`. The Vite plugin injects the discovered server
-manifest into `createServer(...)` automatically.
+When `litz({ server: "..." })` is configured, server output is `dist/server/index.mjs`. The Vite
+plugin injects the server manifest into `createServer(...)` automatically.
 
 Your host server or platform is responsible for serving `dist/client` (for example through
 `express.static`, a CDN, or a platform asset binding) while forwarding dynamic requests to
 `dist/server/index.mjs`.
 
-You can let Litz discover `src/server.ts` or `src/server/index.ts`, or configure a different path
-explicitly in `vite.config.ts`:
+If `server` is omitted, Litz only builds the client output and does not emit `dist/server`.
+Configure the server entry explicitly in `vite.config.ts` when you need one:
 
 ```ts
 import { defineConfig } from "vite";
@@ -1120,7 +1119,7 @@ Middleware receives:
 - Litz is SPA-first. The browser owns the document.
 - Server logic only exists at explicit framework boundaries.
 - `view(...)` uses RSC as a transport, not as the whole app architecture.
-- Routes, resources, and API routes are discovered from top-level glob options.
+- Routes, resources, and API routes are registered explicitly with `defineApp(...)`.
 - Paths are explicit and absolute.
 - `server(...)` is a declarative marker on a normal JavaScript function, not an isolation boundary
   or security boundary by itself.

--- a/README.md
+++ b/README.md
@@ -32,13 +32,8 @@ does not ask applications to install or compose those Vite plugins directly.
 
 ## Quick Start
 
-Add the Litz Vite plugin. By default, Litz discovers:
-
-- routes from `src/routes/**/*.{ts,tsx,js,jsx}`
-- API routes from `src/routes/api/**/*.{ts,tsx,js,jsx}`
-- resources from `src/routes/resources/**/*.{ts,tsx,js,jsx}`
-- the browser entry from `src/main.tsx`
-- a custom server entry from `src/server.ts`, falling back to `src/server/index.ts`
+Add the Litz Vite plugin. By default, Litz uses the browser entry at `src/main.tsx` and a custom
+server entry from `src/server.ts`, falling back to `src/server/index.ts`.
 
 `vite.config.ts`
 
@@ -51,16 +46,13 @@ export default defineConfig({
 });
 ```
 
-You can still override discovery explicitly when you need a different project layout:
+You can point Litz at different browser or server entries when you need a different project layout:
 
 ```ts
 export default defineConfig({
   plugins: [
     litz({
       clientEntry: "app/main.tsx",
-      routes: ["app/pages/**/*.{ts,tsx}"],
-      resources: ["app/resources/**/*.{ts,tsx}"],
-      api: ["app/api/**/*.{ts,tsx}"],
       server: "app/server/entry.ts",
     }),
   ],
@@ -72,6 +64,20 @@ Litz does not infer the browser entry by scanning HTML module scripts. Keep stan
 project does not use `src/main.tsx`. During development, Vite serves explicit HTML documents such as
 `/about.html`; Litz only falls back to `index.html` for extensionless app routes.
 
+Register routes, resources, and API routes explicitly with `defineApp(...)`.
+
+`src/app.ts`
+
+```ts
+import { defineApp } from "litzjs";
+
+import { route as homeRoute } from "./routes";
+
+export const app = defineApp({
+  routes: [homeRoute],
+});
+```
+
 Mount the Litz app from your browser entry.
 
 `src/main.tsx`
@@ -79,13 +85,15 @@ Mount the Litz app from your browser entry.
 ```tsx
 import { mountApp } from "litzjs/client";
 
+import { app } from "./app";
+
 const root = document.getElementById("app");
 
 if (!root) {
   throw new Error('Missing "#app" root element.');
 }
 
-mountApp(root);
+mountApp(root, { app });
 ```
 
 You can optionally provide a wrapper component around the app root:

--- a/fixtures/rsc-smoke/src/app.ts
+++ b/fixtures/rsc-smoke/src/app.ts
@@ -1,0 +1,59 @@
+import { defineApp } from "litzjs";
+
+import { api as echoApi } from "./routes/api/echo";
+import { api as healthApi } from "./routes/api/health";
+import { route as actionViewRoute } from "./routes/features/action-view";
+import { route as apiRouteFeature } from "./routes/features/api-route";
+import { route as errorBoundaryRoute } from "./routes/features/error-boundary";
+import { route as errorDefaultRoute } from "./routes/features/error-default";
+import { route as inputValidationRoute } from "./routes/features/input-validation";
+import { route as layoutsRoute } from "./routes/features/layouts";
+import { route as loaderDataRoute } from "./routes/features/loader-data";
+import { route as loaderViewRoute } from "./routes/features/loader-view";
+import { route as middlewareRoute } from "./routes/features/middleware";
+import { route as navigationVariantsRoute } from "./routes/features/navigation-variants";
+import { route as offlineRoute } from "./routes/features/offline";
+import { route as redirectActionRoute } from "./routes/features/redirect-action";
+import { route as redirectLoaderRoute } from "./routes/features/redirect-loader";
+import { route as redirectTargetRoute } from "./routes/features/redirect-target";
+import { route as resourceActionsRoute } from "./routes/features/resource-actions";
+import { route as resourceDataRoute } from "./routes/features/resource-data";
+import { route as revalidateRoute } from "./routes/features/revalidate";
+import { route as searchParamsRoute } from "./routes/features/search-params";
+import { route as statusPendingRoute } from "./routes/features/status-pending";
+import { route as submitImperativeRoute } from "./routes/features/submit-imperative";
+import { route as useViewRoute } from "./routes/features/use-view";
+import { route as homeRoute } from "./routes/index";
+import { resource as accountMenuResource } from "./routes/resources/account-menu";
+import { resource as feedPanelResource } from "./routes/resources/feed-panel";
+import { resource as summaryCardResource } from "./routes/resources/summary-card";
+import { resource as validatedCardResource } from "./routes/resources/validated-card";
+
+export const app = defineApp({
+  routes: [
+    homeRoute,
+    actionViewRoute,
+    apiRouteFeature,
+    errorBoundaryRoute,
+    errorDefaultRoute,
+    inputValidationRoute,
+    layoutsRoute,
+    loaderDataRoute,
+    loaderViewRoute,
+    middlewareRoute,
+    navigationVariantsRoute,
+    offlineRoute,
+    redirectActionRoute,
+    redirectLoaderRoute,
+    redirectTargetRoute,
+    resourceActionsRoute,
+    resourceDataRoute,
+    revalidateRoute,
+    searchParamsRoute,
+    statusPendingRoute,
+    submitImperativeRoute,
+    useViewRoute,
+  ],
+  resources: [accountMenuResource, feedPanelResource, summaryCardResource, validatedCardResource],
+  apiRoutes: [echoApi, healthApi],
+});

--- a/fixtures/rsc-smoke/src/main.tsx
+++ b/fixtures/rsc-smoke/src/main.tsx
@@ -2,6 +2,7 @@ import type { PropsWithChildren } from "react";
 
 import { mountApp } from "litzjs/client";
 
+import { app } from "./app";
 import { AppShell } from "./components/app-shell";
 
 const root = document.getElementById("app");
@@ -28,6 +29,7 @@ function ClientNotFound() {
 }
 
 mountApp(root, {
+  app,
   component: AppShell,
   layout: {
     id: "fixture-client-layout",

--- a/fixtures/rsc-smoke/src/server.ts
+++ b/fixtures/rsc-smoke/src/server.ts
@@ -1,6 +1,9 @@
 import { createServer } from "litzjs/server";
 
+import { app } from "./app";
+
 export default createServer({
+  app,
   assets(request) {
     const url = new URL(request.url);
 

--- a/fixtures/rsc-smoke/vite.config.ts
+++ b/fixtures/rsc-smoke/vite.config.ts
@@ -8,7 +8,7 @@ const packageRoot = path.resolve(__dirname, "../..");
 
 export default defineConfig({
   root: rootDir,
-  plugins: [litz()],
+  plugins: [litz({ server: "src/server.ts" })],
   resolve: {
     alias: [
       {

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,7 +1,13 @@
 import * as React from "react";
 import { routeManifest } from "virtual:litzjs:route-manifest";
 
-import type { ActionHookResult, LayoutReference, LoaderHookResult, SubmitOptions } from "../index";
+import type {
+  ActionHookResult,
+  LayoutReference,
+  LitzApp as LitzAppDefinition,
+  LoaderHookResult,
+  SubmitOptions,
+} from "../index";
 import type { RouteRuntimeState } from "./runtime";
 
 import { createFormDataPayload } from "../form-data";
@@ -107,16 +113,17 @@ type ManifestEntry = {
   }>;
 };
 
-const manifest = sortByPathSpecificity(routeManifest as ManifestEntry[]);
-const routeModuleFiles = new Set(
+const defaultManifest = sortByPathSpecificity(routeManifest as ManifestEntry[]);
+let manifest = defaultManifest;
+let routeModuleFiles = new Set(
   manifest
     .map((entry) => entry.moduleFile)
     .filter((value): value is string => typeof value === "string"),
 );
-const exactManifestEntries = new Map<string, ManifestEntry>();
-const dynamicManifestEntries: ManifestEntry[] = [];
+let exactManifestEntries = new Map<string, ManifestEntry>();
+let dynamicManifestEntries: ManifestEntry[] = [];
 const ROUTE_CACHE_LIMIT = 200;
-const ROUTE_MODULE_CACHE_LIMIT = Math.max(manifest.length, 1);
+let routeModuleCacheLimit = Math.max(manifest.length, 1);
 const routeCache = new Map<string, LoaderHookResult>();
 const routeModuleCache = new Map<string, LoadedRoute>();
 const routeModulePrefetchCache = new Map<string, Promise<LoadedRoute | null>>();
@@ -147,6 +154,7 @@ interface ManagedNavigationBehavior {
 }
 
 export interface MountAppOptions {
+  readonly app?: LitzAppDefinition;
   readonly component?: React.JSXElementConstructor<{ children: React.ReactNode }>;
   readonly layout?: LayoutReference;
   readonly notFound?: React.ComponentType;
@@ -158,16 +166,11 @@ export function configureClientRuntime(options: { baseUrl?: string | undefined }
   configureClientBaseUrl(options.baseUrl);
 }
 
-for (const entry of manifest) {
-  if (hasPatternSegments(entry.path)) {
-    dynamicManifestEntries.push(entry);
-  } else {
-    exactManifestEntries.set(entry.path, entry);
-  }
-}
+configureActiveManifest(defaultManifest);
 
 export function mountApp(element: Element, options?: MountAppOptions): void {
   const resolvedOptions = normalizeMountAppOptions(options);
+  configureActiveManifest(createManifestFromApp(resolvedOptions?.app));
 
   void import("react-dom/client").then(({ createRoot }) => {
     const root = createRoot(element);
@@ -183,6 +186,40 @@ export function mountApp(element: Element, options?: MountAppOptions): void {
       }),
     );
   });
+}
+
+function createManifestFromApp(app: LitzAppDefinition | undefined): ManifestEntry[] {
+  if (!app) {
+    return defaultManifest;
+  }
+
+  return sortByPathSpecificity(
+    app.routes.map((route) => ({
+      id: route.id,
+      path: route.path,
+      load: async () => ({ route: route as LoadedRoute }),
+    })),
+  );
+}
+
+function configureActiveManifest(nextManifest: ManifestEntry[]): void {
+  manifest = nextManifest;
+  routeModuleFiles = new Set(
+    manifest
+      .map((entry) => entry.moduleFile)
+      .filter((value): value is string => typeof value === "string"),
+  );
+  exactManifestEntries = new Map();
+  dynamicManifestEntries = [];
+  routeModuleCacheLimit = Math.max(manifest.length, 1);
+
+  for (const entry of manifest) {
+    if (hasPatternSegments(entry.path)) {
+      dynamicManifestEntries.push(entry);
+    } else {
+      exactManifestEntries.set(entry.path, entry);
+    }
+  }
 }
 
 function clearClientHotUpdateCaches(): void {
@@ -1868,7 +1905,7 @@ function setCachedRouteModule(id: string, route: LoadedRoute): void {
 
   routeModuleCache.set(id, route);
 
-  while (routeModuleCache.size > ROUTE_MODULE_CACHE_LIMIT) {
+  while (routeModuleCache.size > routeModuleCacheLimit) {
     const oldestKey = routeModuleCache.keys().next().value;
 
     if (oldestKey === undefined) {

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -108,6 +108,7 @@ type ManifestEntry = {
   id: string;
   path: string;
   moduleFile?: string;
+  clientLoading?: "lazy" | "eager" | "preload";
   load: () => Promise<{
     route?: LoadedRoute;
   }>;
@@ -197,6 +198,7 @@ function createManifestFromApp(app: LitzAppDefinition | undefined): ManifestEntr
     app.routes.map((route) => ({
       id: route.id,
       path: route.path,
+      clientLoading: route.options?.clientLoading ?? app.clientLoading,
       load: async () => ({ route: route as LoadedRoute }),
     })),
   );
@@ -220,6 +222,41 @@ function configureActiveManifest(nextManifest: ManifestEntry[]): void {
       exactManifestEntries.set(entry.path, entry);
     }
   }
+
+  warmClientLoadedRoutes(manifest);
+}
+
+function warmClientLoadedRoutes(entries: readonly ManifestEntry[]): void {
+  const eagerEntries = entries.filter((entry) => entry.clientLoading === "eager");
+  const preloadEntries = entries.filter((entry) => entry.clientLoading === "preload");
+
+  for (const entry of eagerEntries) {
+    void prefetchMatchedRouteModule({ entry, params: {} });
+  }
+
+  if (preloadEntries.length === 0) {
+    return;
+  }
+
+  scheduleRoutePreload(() => {
+    for (const entry of preloadEntries) {
+      void prefetchMatchedRouteModule({ entry, params: {} });
+    }
+  });
+}
+
+function scheduleRoutePreload(callback: () => void): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  if ("requestIdleCallback" in window) {
+    const requestIdleCallback = window.requestIdleCallback as (handler: () => void) => number;
+    requestIdleCallback(callback);
+    return;
+  }
+
+  globalThis.setTimeout(callback, 0);
 }
 
 function clearClientHotUpdateCaches(): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -665,6 +665,7 @@ export type DefineRouteOptions<
 > = {
   component: React.ComponentType;
   layout?: LayoutReference;
+  clientLoading?: ClientLoadingMode;
   input?: TInput;
   loader?: RouteServerHandler<TContext, TLoaderResult, NoInferType<TPath>, TInput>;
   action?: RouteServerHandler<TContext, TActionResult, NoInferType<TPath>, TInput>;
@@ -723,6 +724,7 @@ export type DefineLayoutOptions<
 > = {
   component: React.JSXElementConstructor<{ children: React.ReactNode }>;
   layout?: LayoutReference;
+  clientLoading?: ClientLoadingMode;
   input?: TInput;
   loader?: RouteServerHandler<TContext, TLoaderResult, NoInferType<TPath>, TInput>;
   middleware?: MiddlewareRef<TContext, ServerResult>[];
@@ -769,6 +771,41 @@ export type LitzLayout<
     usePending(): boolean;
   } & ([TLoaderResult] extends [never] ? {} : LayoutLoaderClientHooks<TLoaderResult>)
 >;
+
+export type ClientLoadingMode = "lazy" | "eager" | "preload";
+
+type AppRouteRegistration = {
+  readonly id: string;
+  readonly path: string;
+};
+type AppResourceRegistration = {
+  readonly path: string;
+};
+type AppApiRouteRegistration = {
+  readonly path: string;
+};
+
+export interface DefineAppOptions<
+  TRoutes extends readonly AppRouteRegistration[] = readonly AppRouteRegistration[],
+  TResources extends readonly AppResourceRegistration[] = readonly AppResourceRegistration[],
+  TApiRoutes extends readonly AppApiRouteRegistration[] = readonly AppApiRouteRegistration[],
+> {
+  readonly clientLoading?: ClientLoadingMode;
+  readonly routes?: TRoutes;
+  readonly resources?: TResources;
+  readonly apiRoutes?: TApiRoutes;
+}
+
+export interface LitzApp<
+  TRoutes extends readonly AppRouteRegistration[] = readonly AppRouteRegistration[],
+  TResources extends readonly AppResourceRegistration[] = readonly AppResourceRegistration[],
+  TApiRoutes extends readonly AppApiRouteRegistration[] = readonly AppApiRouteRegistration[],
+> {
+  readonly clientLoading: ClientLoadingMode;
+  readonly routes: TRoutes;
+  readonly resources: TResources;
+  readonly apiRoutes: TApiRoutes;
+}
 
 export type LayoutReference = {
   id: string;
@@ -996,6 +1033,7 @@ type ResourceOptions<
 > = ResourceComponentOption<TPath, TComponent> &
   ResourceLoaderOption<TPath, TContext, TLoaderResult, TInput> &
   ResourceActionOption<TPath, TContext, TActionResult, TInput> & {
+    clientLoading?: ClientLoadingMode;
     input?: TInput;
     middleware?: MiddlewareRef<TContext, ServerResult>[];
   };
@@ -1243,6 +1281,40 @@ export function defineRoute(
       return React.createElement(FormComponent, props);
     },
   } as any;
+}
+
+export function defineApp<
+  const TRoutes extends readonly AppRouteRegistration[] = readonly AppRouteRegistration[],
+  const TResources extends readonly AppResourceRegistration[] = readonly AppResourceRegistration[],
+  const TApiRoutes extends readonly AppApiRouteRegistration[] = readonly AppApiRouteRegistration[],
+>(
+  options: DefineAppOptions<TRoutes, TResources, TApiRoutes>,
+): LitzApp<TRoutes, TResources, TApiRoutes> {
+  assertUniqueDefinitionPaths("route", options.routes ?? []);
+  assertUniqueDefinitionPaths("resource", options.resources ?? []);
+  assertUniqueDefinitionPaths("API route", options.apiRoutes ?? []);
+
+  return {
+    clientLoading: options.clientLoading ?? "lazy",
+    routes: options.routes ?? ([] as unknown as TRoutes),
+    resources: options.resources ?? ([] as unknown as TResources),
+    apiRoutes: options.apiRoutes ?? ([] as unknown as TApiRoutes),
+  };
+}
+
+function assertUniqueDefinitionPaths(
+  kind: string,
+  definitions: readonly { readonly path: string }[],
+): void {
+  const seen = new Set<string>();
+
+  for (const definition of definitions) {
+    if (seen.has(definition.path)) {
+      throw new Error(`[litzjs] Duplicate ${kind} registration for path "${definition.path}".`);
+    }
+
+    seen.add(definition.path);
+  }
 }
 
 export function defineLayout<

--- a/src/index.ts
+++ b/src/index.ts
@@ -777,6 +777,9 @@ export type ClientLoadingMode = "lazy" | "eager" | "preload";
 type AppRouteRegistration = {
   readonly id: string;
   readonly path: string;
+  readonly options?: {
+    readonly clientLoading?: ClientLoadingMode;
+  };
 };
 type AppResourceRegistration = {
   readonly path: string;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,4 +1,4 @@
-import type { ApiRouteMethod } from "../index";
+import type { ApiRouteMethod, LitzApp } from "../index";
 
 import { normalizeBasePath, resolveBasePathname } from "../base-path";
 import {
@@ -154,6 +154,7 @@ export type CreateServerOptions<TContext = unknown> = {
   createContext?(request: Request): Promise<TContext> | TContext;
   validateInternalRequest?: InternalRequestValidator<TContext>;
   onError?(error: unknown, context: TContext | undefined): void;
+  app?: LitzApp;
   manifest?: ServerManifest;
   base?: string;
   document?: DocumentResponseOption;
@@ -164,7 +165,7 @@ export type CreateServerOptions<TContext = unknown> = {
 export function createServer<TContext = unknown>(
   options: CreateServerOptions<TContext> = {},
 ): { fetch(request: Request): Promise<Response> } {
-  const manifest = normalizeServerManifest(options.manifest);
+  const manifest = normalizeServerManifest(options.manifest, options.app);
   const basePath = normalizeBasePath(options.base);
 
   async function handle(request: Request): Promise<Response> {
@@ -266,15 +267,40 @@ export function createServer<TContext = unknown>(
   return { fetch: handle };
 }
 
-function normalizeServerManifest(manifest: ServerManifest | undefined): ServerManifest {
-  if (!manifest) {
+function normalizeServerManifest(
+  manifest: ServerManifest | undefined,
+  app: LitzApp | undefined,
+): ServerManifest {
+  const appManifest: ServerManifest | undefined = app
+    ? {
+        routes: app.routes.map((route) => ({
+          id: route.id,
+          path: route.path,
+          route: route as RouteModule["route"],
+        })),
+        resources: app.resources.map((resource) => ({
+          path: resource.path,
+          resource: resource as ResourceModule["resource"],
+        })),
+        apiRoutes: app.apiRoutes.map((api) => ({
+          path: api.path,
+          api: api as ApiModule["api"],
+        })),
+      }
+    : undefined;
+
+  const resolvedManifest = appManifest ?? manifest;
+
+  if (!resolvedManifest) {
     return {};
   }
 
   return {
-    ...manifest,
-    routes: manifest.routes ? sortByPathSpecificity(manifest.routes) : undefined,
-    apiRoutes: manifest.apiRoutes ? sortByPathSpecificity(manifest.apiRoutes) : undefined,
+    ...resolvedManifest,
+    routes: resolvedManifest.routes ? sortByPathSpecificity(resolvedManifest.routes) : undefined,
+    apiRoutes: resolvedManifest.apiRoutes
+      ? sortByPathSpecificity(resolvedManifest.apiRoutes)
+      : undefined,
   };
 }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -271,6 +271,12 @@ function normalizeServerManifest(
   manifest: ServerManifest | undefined,
   app: LitzApp | undefined,
 ): ServerManifest {
+  if (app && manifest) {
+    throw new Error(
+      "[litzjs] Pass either createServer({ app }) or createServer({ manifest }), not both.",
+    );
+  }
+
   const appManifest: ServerManifest | undefined = app
     ? {
         routes: app.routes.map((route) => ({

--- a/src/vite-nitro.ts
+++ b/src/vite-nitro.ts
@@ -8,7 +8,6 @@ import path from "node:path";
 import type { LitzNitroPluginOptions } from "./vite/types";
 
 import { normalizeBasePath, resolveBasePathname } from "./base-path";
-import { discoverServerEntry } from "./vite/discovery";
 
 export type { LitzNitroPluginOptions };
 
@@ -91,14 +90,20 @@ export function litzNitro(options: LitzNitroPluginOptions = {}): PluginOption {
         ? path.resolve(root, options.output.publicDir)
         : path.resolve(finalNitroOutDir, "public");
 
-      const serverEntryPath = await discoverServerEntry(root, options.server);
-
-      if (serverEntryPath === null) {
+      if (!options.server) {
         throw new Error(
           [
-            "litzNitro() could not find a server entry for the Nitro renderer.",
-            'Create src/server.ts or src/server/index.ts, or pass the same custom server path to litzNitro({ server: "..." }) that you pass to litz({ server: "..." }).',
+            "litzNitro() requires an explicit server entry for the Nitro renderer.",
+            'Pass the same server path to litzNitro({ server: "..." }) that you pass to litz({ server: "..." }).',
           ].join(" "),
+        );
+      }
+
+      const serverEntryPath = path.resolve(root, options.server);
+
+      if (!existsSync(serverEntryPath)) {
+        throw new Error(
+          `[litzjs] Configured Nitro server entry "${options.server}" does not exist.`,
         );
       }
 
@@ -106,7 +111,7 @@ export function litzNitro(options: LitzNitroPluginOptions = {}): PluginOption {
       const isBuild = config.command === "build";
       const serverImportPath = isBuild
         ? path.resolve(root, rscOutDir, "index.js")
-        : path.resolve(root, serverEntryPath);
+        : serverEntryPath;
 
       writeNitroRendererSync(
         rendererRoot,
@@ -238,7 +243,7 @@ function writeNitroRendererSync(
     writeFileSync(
       rendererPath,
       [
-        "// Placeholder - replaced once the server entry is discovered.",
+        "// Placeholder - replaced once the explicit server entry is resolved.",
         'import { defineHandler } from "nitro/h3";',
         "",
         "export default defineHandler(() => new Response('Not ready', { status: 503 }));",

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -111,13 +111,13 @@ export function litz(options: LitzPluginOptions = {}): PluginOption {
   let resourceManifest: DiscoveredResource[] = [];
   let apiManifest: DiscoveredApiRoute[] = [];
   let clientProjectedFiles = new Set<string>();
-  const routePatterns = options.routes ?? [
+  const routePatterns = [
     "src/routes/**/*.{ts,tsx,js,jsx}",
     "!src/routes/api/**/*.{ts,tsx,js,jsx}",
     "!src/routes/resources/**/*.{ts,tsx,js,jsx}",
   ];
-  const resourcePatterns = options.resources ?? ["src/routes/resources/**/*.{ts,tsx,js,jsx}"];
-  const apiPatterns = options.api ?? ["src/routes/api/**/*.{ts,tsx,js,jsx}"];
+  const resourcePatterns = ["src/routes/resources/**/*.{ts,tsx,js,jsx}"];
+  const apiPatterns = ["src/routes/api/**/*.{ts,tsx,js,jsx}"];
   const rscPlugins = vitePluginRsc({
     ...options.rsc,
     entries: {

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -650,10 +650,13 @@ function injectServerRuntimeOptions(
         });
       } else if (node.arguments.length === 1 && ts.isObjectLiteralExpression(node.arguments[0]!)) {
         const optionsArgument = node.arguments[0]!;
+        const manifestInjection = hasObjectProperty(optionsArgument, "app")
+          ? ""
+          : " manifest: __litzjsServerManifest,";
         replacements.push({
           start: optionsArgument.getStart() + 1,
           end: optionsArgument.getStart() + 1,
-          text: " base: __litzjsBase, document: __litzjsCreateDocumentResponse, manifest: __litzjsServerManifest,",
+          text: ` base: __litzjsBase, document: __litzjsCreateDocumentResponse,${manifestInjection}`,
         });
       } else {
         throw new Error(
@@ -696,6 +699,26 @@ function injectServerRuntimeOptions(
     code: `${runtimeSource}${transformed}`,
     map: createLineOffsetSourceMap(id, code, countLines(runtimeSource)),
   };
+}
+
+function hasObjectProperty(objectLiteral: ts.ObjectLiteralExpression, name: string): boolean {
+  return objectLiteral.properties.some((property) => {
+    if (ts.isShorthandPropertyAssignment(property)) {
+      return property.name.text === name;
+    }
+
+    if (!ts.isPropertyAssignment(property)) {
+      return false;
+    }
+
+    const propertyName = property.name;
+
+    if (ts.isIdentifier(propertyName) || ts.isStringLiteral(propertyName)) {
+      return propertyName.text === name;
+    }
+
+    return false;
+  });
 }
 
 function getScriptKind(id: string): ts.ScriptKind {

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -38,7 +38,6 @@ import {
   discoverLayoutFromFile,
   discoverResourceFromFile,
   discoverRouteFromFile,
-  discoverServerEntry,
   isClientBoundaryModule,
   isRouteLikeModuleFile,
 } from "./vite/discovery";
@@ -75,7 +74,6 @@ export {
   discoverLayoutFromFile,
   discoverResourceFromFile,
   discoverRouteFromFile,
-  discoverServerEntry,
   handleLitzApiRequest,
   handleLitzDocumentRequest,
   handleLitzResourceRequest,
@@ -105,6 +103,7 @@ export function litz(options: LitzPluginOptions = {}): PluginOption {
   let configuredBase = "/";
   let baseOutDir = "dist";
   const browserEntryPath = options.clientEntry ?? "src/main.tsx";
+  const configuredServerEntryPath = options.server;
   let serverEntryPath: string | null = null;
   let routeManifest: DiscoveredRoute[] = [];
   let layoutManifest: DiscoveredLayout[] = [];
@@ -118,14 +117,16 @@ export function litz(options: LitzPluginOptions = {}): PluginOption {
   ];
   const resourcePatterns = ["src/routes/resources/**/*.{ts,tsx,js,jsx}"];
   const apiPatterns = ["src/routes/api/**/*.{ts,tsx,js,jsx}"];
-  const rscPlugins = vitePluginRsc({
-    ...options.rsc,
-    entries: {
-      client: LITZ_BROWSER_ENTRY_ID,
-      rsc: LITZ_RSC_ENTRY_ID,
-    },
-    serverHandler: false,
-  });
+  const rscPlugins = configuredServerEntryPath
+    ? vitePluginRsc({
+        ...options.rsc,
+        entries: {
+          client: LITZ_BROWSER_ENTRY_ID,
+          rsc: LITZ_RSC_ENTRY_ID,
+        },
+        serverHandler: false,
+      })
+    : [];
 
   const litzPlugin: Plugin = {
     name: "litzjs/vite",
@@ -139,19 +140,28 @@ export function litz(options: LitzPluginOptions = {}): PluginOption {
             build: {
               outDir: path.join(baseOutDir, "client"),
               manifest: true,
-            },
-          },
-          rsc: {
-            build: {
-              outDir: path.join(baseOutDir, "server"),
-              manifest: true,
               rollupOptions: {
-                output: {
-                  entryFileNames: "index.mjs",
+                input: {
+                  index: LITZ_BROWSER_ENTRY_ID,
                 },
               },
             },
           },
+          ...(configuredServerEntryPath
+            ? {
+                rsc: {
+                  build: {
+                    outDir: path.join(baseOutDir, "server"),
+                    manifest: true,
+                    rollupOptions: {
+                      output: {
+                        entryFileNames: "index.mjs",
+                      },
+                    },
+                  },
+                },
+              }
+            : {}),
         },
       };
     },
@@ -159,7 +169,7 @@ export function litz(options: LitzPluginOptions = {}): PluginOption {
     async configResolved(config) {
       root = config.root;
       configuredBase = normalizeBasePath(config.base);
-      serverEntryPath = await discoverServerEntry(root, options.server);
+      serverEntryPath = resolveConfiguredServerEntry(root, configuredServerEntryPath);
 
       ({ routeManifest, layoutManifest, resourceManifest, apiManifest } =
         await discoverAllManifests(root, routePatterns, resourcePatterns, apiPatterns));
@@ -175,7 +185,7 @@ export function litz(options: LitzPluginOptions = {}): PluginOption {
     resolveId(id) {
       if (id === ROUTE_MANIFEST_ID) return RESOLVED_ROUTE_MANIFEST_ID;
       if (id === RESOURCE_MANIFEST_ID) return RESOLVED_RESOURCE_MANIFEST_ID;
-      if (id === LITZ_RSC_ENTRY_ID) return RESOLVED_LITZ_RSC_ENTRY_ID;
+      if (configuredServerEntryPath && id === LITZ_RSC_ENTRY_ID) return RESOLVED_LITZ_RSC_ENTRY_ID;
       if (id === LITZ_BROWSER_ENTRY_ID) return RESOLVED_LITZ_BROWSER_ENTRY_ID;
       if (id === LITZ_RSC_RENDERER_ID) return RESOLVED_LITZ_RSC_RENDERER_ID;
       return null;
@@ -195,15 +205,12 @@ export function litz(options: LitzPluginOptions = {}): PluginOption {
         return createResourceManifestModule(resourceManifest);
       }
 
-      if (id === RESOLVED_LITZ_RSC_ENTRY_ID) {
-        return createGeneratedServerEntryModule(
-          root,
-          serverEntryPath,
-          configuredBase,
-          routeManifest,
-          resourceManifest,
-          apiManifest,
-        );
+      if (configuredServerEntryPath && id === RESOLVED_LITZ_RSC_ENTRY_ID) {
+        if (!serverEntryPath) {
+          throw new Error("[litzjs] Server entry was not resolved before loading the RSC entry.");
+        }
+
+        return createGeneratedServerEntryModule(serverEntryPath);
       }
 
       if (id === RESOLVED_LITZ_BROWSER_ENTRY_ID) {
@@ -249,7 +256,7 @@ export async function renderView(node, metadata = {}) {
     buildApp: {
       order: "post",
       async handler() {
-        finalizeFrameworkBuild(root, baseOutDir);
+        finalizeFrameworkBuild(root, baseOutDir, Boolean(configuredServerEntryPath));
       },
     },
 
@@ -539,30 +546,27 @@ export async function renderView(node, metadata = {}) {
   return [...rscPlugins, litzPlugin] as Plugin[];
 }
 
-function createGeneratedServerEntryModule(
+function createGeneratedServerEntryModule(serverEntryPath: string): string {
+  return `export { default } from ${JSON.stringify(toProjectImportSpecifier(serverEntryPath))};`;
+}
+
+function resolveConfiguredServerEntry(
   root: string,
-  serverEntryPath: string | null,
-  base: string,
-  routes: DiscoveredRoute[],
-  resources: DiscoveredResource[],
-  apiRoutes: DiscoveredApiRoute[],
-): string {
-  if (serverEntryPath) {
-    return `export { default } from ${JSON.stringify(toProjectImportSpecifier(serverEntryPath))};`;
+  configuredPath: string | undefined,
+): string | null {
+  if (!configuredPath) {
+    return null;
   }
 
-  return `${createInlineServerRuntime(root, base, createServerManifestModule(routes, resources, apiRoutes))}
-import { createServer } from "litzjs/server";
+  const absolutePath = path.resolve(root, configuredPath);
 
-export default createServer({
-  base: __litzjsBase,
-  document: __litzjsCreateDocumentResponse,
-  manifest: __litzjsServerManifest,
-  createContext() {
-    return undefined;
-  },
-});
-`;
+  if (!existsSync(absolutePath)) {
+    throw new Error(
+      `[litzjs] Configured server entry "${configuredPath}" does not exist. Either create the file or omit litz({ server }) for a client-only build.`,
+    );
+  }
+
+  return normalizeRelativePath(root, absolutePath);
 }
 
 function injectServerRuntimeOptions(
@@ -794,7 +798,11 @@ function readDocumentTemplate(root: string): string {
   return readFileSync(templatePath, "utf8");
 }
 
-function finalizeFrameworkBuild(root: string, outDir: string): void {
+function finalizeFrameworkBuild(root: string, outDir: string, hasServerEntry: boolean): void {
+  if (!hasServerEntry) {
+    return;
+  }
+
   const distDir = path.resolve(root, outDir);
   const clientDir = path.join(distDir, "client");
   const ssrDir = path.join(distDir, "ssr");

--- a/src/vite/discovery.ts
+++ b/src/vite/discovery.ts
@@ -40,23 +40,6 @@ export async function discoverAllManifests(
   };
 }
 
-export async function discoverServerEntry(
-  root: string,
-  configuredPath?: string,
-): Promise<string | null> {
-  const candidates = configuredPath ? [configuredPath] : ["src/server.ts", "src/server/index.ts"];
-
-  for (const candidate of candidates) {
-    const absolutePath = path.resolve(root, candidate);
-
-    if (ts.sys.fileExists(absolutePath)) {
-      return normalizeRelativePath(root, absolutePath);
-    }
-  }
-
-  return null;
-}
-
 export function isClientBoundaryModule(file: string): boolean {
   return /\.client\.(ts|tsx|js|jsx)$/.test(file);
 }

--- a/src/vite/types.ts
+++ b/src/vite/types.ts
@@ -32,7 +32,7 @@ export interface LitzRouteRule {
 }
 
 export interface LitzNitroPluginOptions {
-  /** Path to a custom server entry file. Defaults to `src/server.ts` or `src/server/index.ts`. */
+  /** Path to the server entry file used by the Nitro renderer. */
   readonly server?: string;
   /**
    * Deployment preset. Determines the server output format and runtime
@@ -78,7 +78,7 @@ export interface LitzNitroPluginOptions {
 export interface LitzPluginOptions {
   /** Browser entry imported by Litz's generated client runtime module. */
   readonly clientEntry?: string;
-  /** Path to a custom server entry file. */
+  /** Path to a server entry file. Omit to skip the server build. */
   readonly server?: string;
   /** Options forwarded to `@vitejs/plugin-rsc`. */
   readonly rsc?: Omit<RscPluginOptions, "entries" | "serverHandler">;

--- a/src/vite/types.ts
+++ b/src/vite/types.ts
@@ -76,12 +76,6 @@ export interface LitzNitroPluginOptions {
 }
 
 export interface LitzPluginOptions {
-  /** Glob patterns for route files. */
-  readonly routes?: string[];
-  /** Glob patterns for API route files. */
-  readonly api?: string[];
-  /** Glob patterns for resource files. */
-  readonly resources?: string[];
   /** Browser entry imported by Litz's generated client runtime module. */
   readonly clientEntry?: string;
   /** Path to a custom server entry file. */

--- a/tests/client-wildcard-route-runtime.test.tsx
+++ b/tests/client-wildcard-route-runtime.test.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { act } from "react";
 import { renderToString } from "react-dom/server";
 
-import { data, defineRoute, server } from "../src/index";
+import { data, defineApp, defineRoute, server } from "../src/index";
 import { flushDom, installTestDom } from "./test-dom";
 
 type ClientModule = typeof import("../src/client/index");
@@ -857,5 +857,32 @@ describe("client wildcard route runtime", () => {
     expect(warnings).toEqual([
       "[litzjs] mountApp(root, Wrapper) is no longer supported. Pass mountApp(root, { component: Wrapper }) instead.",
     ]);
+  });
+
+  test("reads explicit app client loading metadata when mounting", async () => {
+    clientModule = await import("../src/client/index");
+    let optionReads = 0;
+    const eagerRoute = {
+      id: "explicit-eager",
+      path: "/",
+      component: HomeRoute,
+      get options() {
+        optionReads++;
+        return {
+          clientLoading: "eager" as const,
+        };
+      },
+    };
+    const app = defineApp({
+      clientLoading: "lazy",
+      routes: [eagerRoute],
+    });
+
+    await act(async () => {
+      clientModule?.mountApp(container!, { app });
+      await flushApp();
+    });
+
+    expect(optionReads).toBeGreaterThan(0);
   });
 });

--- a/tests/docs-package-names.test.ts
+++ b/tests/docs-package-names.test.ts
@@ -135,7 +135,7 @@ describe("docs package names", () => {
     expect(troubleshootingDoc).toContain("bun add -d typescript vite");
   });
 
-  test("configuration and API docs match current Vite defaults", () => {
+  test("configuration and API docs describe explicit app registration", () => {
     const readme = normalizeWhitespace(readDoc("README.md"));
     const configurationDoc = normalizeWhitespace(readDoc("www/src/routes/docs/configuration.tsx"));
     const apiReferenceDoc = normalizeWhitespace(readDoc("www/src/routes/docs/api-reference.tsx"));
@@ -143,13 +143,15 @@ describe("docs package names", () => {
       readDoc("www/src/routes/docs/troubleshooting.tsx"),
     );
 
-    for (const doc of [readme, configurationDoc, apiReferenceDoc, troubleshootingDoc]) {
-      expect(doc).toContain("src/routes/**/*.{ts,tsx,js,jsx}");
-    }
-
+    expect(readme).toContain("defineApp");
+    expect(configurationDoc).toContain("defineApp");
+    expect(configurationDoc).not.toContain("Glob patterns to discover route files");
     expect(configurationDoc).toContain("clientEntry");
+    expect(apiReferenceDoc).toContain("defineApp");
     expect(apiReferenceDoc).toContain("clientEntry?: string;");
+    expect(apiReferenceDoc).not.toContain("routes?: string[];");
     expect(apiReferenceDoc).toContain("rsc?: Omit<RscPluginOptions");
+    expect(troubleshootingDoc).toContain("defineApp");
     expect(troubleshootingDoc).toContain('import app from "./dist/server/index.mjs";');
     expect(troubleshootingDoc).toContain('const clientDir = path.resolve("dist/client");');
     expect(troubleshootingDoc).not.toContain("dist/public");

--- a/tests/explicit-app-registration.test.ts
+++ b/tests/explicit-app-registration.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+
+import { data, defineApiRoute, defineApp, defineResource, defineRoute, server } from "../src";
+import { createServer } from "../src/server";
+import { createInternalActionRequestInit } from "../src/server/internal-requests";
+
+describe("explicit app registration", () => {
+  test("createServer dispatches routes, resources, and API routes from a Litz app", async () => {
+    const route = defineRoute("/projects/:id", {
+      component() {
+        return null;
+      },
+      loader: server(({ params }) => data({ id: params.id })),
+    });
+    const resource = defineResource("/resources/account", {
+      component() {
+        return null;
+      },
+      loader: server(() => data({ name: "Ada" })),
+    });
+    const api = defineApiRoute("/api/health", {
+      GET() {
+        return Response.json({ ok: true });
+      },
+    });
+    const app = defineApp({
+      routes: [route],
+      resources: [resource],
+      apiRoutes: [api],
+    });
+    const litzServer = createServer({
+      app,
+      document: "Document",
+    });
+
+    const documentResponse = await litzServer.fetch(
+      new Request("https://example.com/projects/123", {
+        headers: { accept: "text/html" },
+      }),
+    );
+    const routeRequest = createInternalActionRequestInit({
+      path: "/projects/:id",
+      operation: "loader",
+      request: {
+        params: { id: "123" },
+      },
+    });
+    const routeResponse = await litzServer.fetch(
+      new Request("https://example.com/_litzjs/route", {
+        body: routeRequest.body,
+        headers: routeRequest.headers,
+        method: "POST",
+      }),
+    );
+    const resourceRequest = createInternalActionRequestInit({
+      path: "/resources/account",
+      operation: "loader",
+    });
+    const resourceResponse = await litzServer.fetch(
+      new Request("https://example.com/_litzjs/resource", {
+        body: resourceRequest.body,
+        headers: resourceRequest.headers,
+        method: "POST",
+      }),
+    );
+    const apiResponse = await litzServer.fetch(new Request("https://example.com/api/health"));
+
+    expect(documentResponse.status).toBe(200);
+    expect(await documentResponse.text()).toBe("Document");
+    expect(routeResponse.status).toBe(200);
+    expect(await routeResponse.json()).toMatchObject({
+      data: { id: "123" },
+      kind: "data",
+    });
+    expect(resourceResponse.status).toBe(200);
+    expect(await resourceResponse.json()).toMatchObject({
+      data: { name: "Ada" },
+      kind: "data",
+    });
+    expect(apiResponse.status).toBe(200);
+    expect(await apiResponse.json()).toEqual({ ok: true });
+  });
+
+  test("defineApp rejects duplicate registrations by path", () => {
+    const first = defineRoute("/duplicate", {
+      component() {
+        return null;
+      },
+    });
+    const second = defineRoute("/duplicate", {
+      component() {
+        return null;
+      },
+    });
+
+    expect(() => defineApp({ routes: [first, second] })).toThrow(
+      'Duplicate route registration for path "/duplicate"',
+    );
+  });
+});

--- a/tests/explicit-app-registration.test.ts
+++ b/tests/explicit-app-registration.test.ts
@@ -97,4 +97,22 @@ describe("explicit app registration", () => {
       'Duplicate route registration for path "/duplicate"',
     );
   });
+
+  test("createServer rejects mixed app and manifest inputs", () => {
+    const route = defineRoute("/", {
+      component() {
+        return null;
+      },
+    });
+    const app = defineApp({ routes: [route] });
+
+    expect(() =>
+      createServer({
+        app,
+        manifest: {
+          routes: [{ id: "legacy", path: "/", route: route as never }],
+        },
+      }),
+    ).toThrow("Pass either createServer({ app }) or createServer({ manifest }), not both.");
+  });
 });

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -25,7 +25,6 @@ import {
   discoverLayoutFromFile,
   discoverResourceFromFile,
   discoverRouteFromFile,
-  discoverServerEntry,
   handleLitzApiRequest,
   handleLitzDocumentRequest,
   handleLitzResourceRequest,
@@ -142,34 +141,6 @@ describe("vite production server helpers", () => {
     expect(buildOutput).not.toContain("Warning:");
   }, 65000);
 
-  test("prefers src/server.ts when auto-discovering a custom server entry", async () => {
-    const root = mkdtempSync(path.join(tmpdir(), "litz-server-entry-"));
-
-    try {
-      mkdirSync(path.join(root, "src"), { recursive: true });
-      mkdirSync(path.join(root, "src", "server"), { recursive: true });
-      writeFileSync(path.join(root, "src", "server.ts"), "export default null;\n", "utf8");
-      writeFileSync(path.join(root, "src", "server", "index.ts"), "export default null;\n", "utf8");
-
-      expect(discoverServerEntry(root)).resolves.toBe("src/server.ts");
-    } finally {
-      rmSync(root, { force: true, recursive: true });
-    }
-  });
-
-  test("falls back to src/server/index.ts when src/server.ts is absent", async () => {
-    const root = mkdtempSync(path.join(tmpdir(), "litz-server-entry-"));
-
-    try {
-      mkdirSync(path.join(root, "src", "server"), { recursive: true });
-      writeFileSync(path.join(root, "src", "server", "index.ts"), "export default null;\n", "utf8");
-
-      expect(discoverServerEntry(root)).resolves.toBe("src/server/index.ts");
-    } finally {
-      rmSync(root, { force: true, recursive: true });
-    }
-  });
-
   test("does not include Nitro in the default litz plugin path", () => {
     const plugins = litz() as Plugin[];
 
@@ -177,8 +148,44 @@ describe("vite production server helpers", () => {
     expect(plugins.some((plugin) => plugin.name === "litzjs/nitro")).toBe(false);
   });
 
-  test("routes the framework server entry to the RSC build output", async () => {
+  test("omits the RSC server build environment when no server entry is configured", async () => {
     const plugin = (litz() as Plugin[]).find((candidate) => candidate.name === "litzjs/vite");
+
+    if (!plugin?.config) {
+      throw new Error("Expected litzjs/vite config hook to be available.");
+    }
+
+    const config = typeof plugin.config === "function" ? plugin.config : plugin.config.handler;
+    const result = await config.call(
+      {} as never,
+      {
+        build: {
+          outDir: "build",
+        },
+      } as never,
+      {
+        command: "build",
+        mode: "production",
+      } as never,
+    );
+
+    expect(result).toMatchObject({
+      environments: {
+        client: {
+          build: {
+            outDir: path.join("build", "client"),
+            manifest: true,
+          },
+        },
+      },
+    });
+    expect(result).not.toHaveProperty("environments.rsc");
+  });
+
+  test("routes the configured server entry to the RSC build output", async () => {
+    const plugin = (litz({ server: "src/server.ts" }) as Plugin[]).find(
+      (candidate) => candidate.name === "litzjs/vite",
+    );
 
     if (!plugin?.config) {
       throw new Error("Expected litzjs/vite config hook to be available.");
@@ -265,6 +272,49 @@ describe("vite production server helpers", () => {
     }
   });
 
+  test("fails fast when a configured server entry does not exist", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "litz-missing-configured-server-"));
+
+    try {
+      const plugin = (litz({ server: "src/server.ts" }) as Plugin[]).find(
+        (candidate) => candidate.name === "litzjs/vite",
+      );
+
+      if (!plugin?.configResolved) {
+        throw new Error("Expected litzjs/vite configResolved hook to be available.");
+      }
+
+      const configResolved =
+        typeof plugin.configResolved === "function"
+          ? plugin.configResolved
+          : plugin.configResolved.handler;
+      let error: unknown;
+
+      try {
+        await configResolved.call(
+          {} as never,
+          {
+            root,
+            base: "/",
+            command: "build",
+            build: {
+              outDir: "dist",
+            },
+            environments: {},
+          } as never,
+        );
+      } catch (caughtError) {
+        error = caughtError;
+      }
+
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain('Configured server entry "src/server.ts"');
+      expect((error as Error).message).toContain("client-only build");
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   test("allows Nitro dev runtime dependencies outside the Vite root", () => {
     const plugin = (litzNitro() as Plugin[]).find((candidate) => candidate.name === "litzjs/nitro");
 
@@ -309,7 +359,7 @@ describe("vite production server helpers", () => {
       writeFileSync(path.join(projectRoot, "src", "server.ts"), "export default null;\n", "utf8");
       process.chdir(projectRoot);
 
-      const plugin = (litzNitro() as Plugin[]).find(
+      const plugin = (litzNitro({ server: "src/server.ts" }) as Plugin[]).find(
         (candidate) => candidate.name === "litzjs/nitro",
       );
 
@@ -381,7 +431,7 @@ describe("vite production server helpers", () => {
       );
       writeFileSync(path.join(root, "src", "server.ts"), "export default null;\n", "utf8");
 
-      const plugin = (litzNitro() as Plugin[]).find(
+      const plugin = (litzNitro({ server: "src/server.ts" }) as Plugin[]).find(
         (candidate) => candidate.name === "litzjs/nitro",
       );
 
@@ -431,7 +481,7 @@ describe("vite production server helpers", () => {
     }
   });
 
-  test("fails fast when litzNitro cannot discover a server entry", async () => {
+  test("fails fast when litzNitro has no explicit server entry", async () => {
     const root = mkdtempSync(path.join(tmpdir(), "litz-nitro-missing-server-"));
 
     try {
@@ -470,7 +520,7 @@ describe("vite production server helpers", () => {
       }
 
       expect(error).toBeInstanceOf(Error);
-      expect((error as Error).message).toContain("litzNitro() could not find a server entry");
+      expect((error as Error).message).toContain("litzNitro() requires an explicit server entry");
       expect((error as Error).message).toContain('litzNitro({ server: "..." })');
     } finally {
       rmSync(root, { force: true, recursive: true });
@@ -1663,7 +1713,9 @@ describe("dev server hot updates", () => {
         "utf8",
       );
 
-      const plugin = (litz() as Plugin[]).find((candidate) => candidate.name === "litzjs/vite");
+      const plugin = (litz({ server: "src/server.ts" }) as Plugin[]).find(
+        (candidate) => candidate.name === "litzjs/vite",
+      );
 
       if (!plugin?.configResolved || !plugin.transform) {
         throw new Error("Expected litzjs/vite transform hooks to be available.");
@@ -1745,7 +1797,9 @@ describe("dev server hot updates", () => {
         "utf8",
       );
 
-      const plugin = (litz() as Plugin[]).find((candidate) => candidate.name === "litzjs/vite");
+      const plugin = (litz({ server: "src/server.ts" }) as Plugin[]).find(
+        (candidate) => candidate.name === "litzjs/vite",
+      );
 
       if (!plugin?.configResolved || !plugin.transform) {
         throw new Error("Expected litzjs/vite transform hooks to be available.");
@@ -1827,7 +1881,9 @@ describe("dev server hot updates", () => {
         "utf8",
       );
 
-      const plugin = (litz() as Plugin[]).find((candidate) => candidate.name === "litzjs/vite");
+      const plugin = (litz({ server: "src/server.ts" }) as Plugin[]).find(
+        (candidate) => candidate.name === "litzjs/vite",
+      );
 
       if (!plugin?.configResolved || !plugin.transform) {
         throw new Error("Expected litzjs/vite transform hooks to be available.");
@@ -1898,7 +1954,9 @@ describe("dev server hot updates", () => {
         "utf8",
       );
 
-      const plugin = (litz() as Plugin[]).find((candidate) => candidate.name === "litzjs/vite");
+      const plugin = (litz({ server: "src/server.ts" }) as Plugin[]).find(
+        (candidate) => candidate.name === "litzjs/vite",
+      );
 
       if (!plugin?.configResolved || !plugin.transform) {
         throw new Error("Expected litzjs/vite transform hooks to be available.");
@@ -1972,7 +2030,9 @@ describe("dev server hot updates", () => {
         "utf8",
       );
 
-      const plugin = (litz() as Plugin[]).find((candidate) => candidate.name === "litzjs/vite");
+      const plugin = (litz({ server: "src/server.ts" }) as Plugin[]).find(
+        (candidate) => candidate.name === "litzjs/vite",
+      );
 
       if (!plugin?.configResolved || !plugin.transform) {
         throw new Error("Expected litzjs/vite transform hooks to be available.");
@@ -2043,7 +2103,9 @@ describe("dev server hot updates", () => {
         "utf8",
       );
 
-      const plugin = (litz() as Plugin[]).find((candidate) => candidate.name === "litzjs/vite");
+      const plugin = (litz({ server: "src/server.ts" }) as Plugin[]).find(
+        (candidate) => candidate.name === "litzjs/vite",
+      );
 
       if (!plugin?.configResolved || !plugin.transform) {
         throw new Error("Expected litzjs/vite transform hooks to be available.");

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -1785,6 +1785,83 @@ describe("dev server hot updates", () => {
     }
   });
 
+  test("does not inject a server manifest when the server entry already passes an app", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "litz-server-entry-app-"));
+
+    try {
+      mkdirSync(path.join(root, "src"), { recursive: true });
+      writeFileSync(path.join(root, "src", "main.tsx"), "export {};\n", "utf8");
+      writeFileSync(
+        path.join(root, "src", "server.ts"),
+        'import { createServer } from "litzjs/server";\nimport { app } from "./app";\n\nexport default createServer({ app });\n',
+        "utf8",
+      );
+
+      const plugin = (litz({ server: "src/server.ts" }) as Plugin[]).find(
+        (candidate) => candidate.name === "litzjs/vite",
+      );
+
+      if (!plugin?.configResolved || !plugin.transform) {
+        throw new Error("Expected litzjs/vite transform hooks to be available.");
+      }
+
+      const configResolved =
+        typeof plugin.configResolved === "function"
+          ? plugin.configResolved
+          : plugin.configResolved.handler;
+      const transform =
+        typeof plugin.transform === "function" ? plugin.transform : plugin.transform.handler;
+      const pluginContext = {
+        environment: {
+          name: "nitro",
+        },
+      } as never;
+
+      await configResolved.call(
+        {} as never,
+        {
+          root,
+          base: "/app/",
+          command: "serve",
+          build: {
+            outDir: "dist",
+          },
+          environments: {
+            client: {
+              build: {
+                outDir: path.join("dist", "client"),
+              },
+            },
+            rsc: {
+              build: {
+                outDir: path.join("dist", "server"),
+                rollupOptions: {
+                  output: {
+                    codeSplitting: false,
+                  },
+                },
+              },
+            },
+          },
+        } as never,
+      );
+
+      const result = await transform.call(
+        pluginContext,
+        'import { createServer } from "litzjs/server";\nimport { app } from "./app";\n\nexport default createServer({ app });\n',
+        path.join(root, "src", "server.ts"),
+      );
+      const code = typeof result === "string" ? result : result?.code?.toString();
+
+      expect(code).toContain(
+        "export default createServer({ base: __litzjsBase, document: __litzjsCreateDocumentResponse, app });",
+      );
+      expect(code).not.toContain("manifest: __litzjsServerManifest, app");
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   test("injects runtime options into empty custom server entries", async () => {
     const root = mkdtempSync(path.join(tmpdir(), "litz-server-entry-empty-"));
 

--- a/www/src/app.ts
+++ b/www/src/app.ts
@@ -1,0 +1,59 @@
+import { defineApp } from "litzjs";
+
+import { route as apiReferenceRoute } from "./routes/docs/api-reference";
+import { route as apiRoutesRoute } from "./routes/docs/api-routes";
+import { route as authenticationRoute } from "./routes/docs/authentication";
+import { route as bunRoute } from "./routes/docs/bun";
+import { route as cloudflareWorkersRoute } from "./routes/docs/cloudflare-workers";
+import { route as configurationRoute } from "./routes/docs/configuration";
+import { route as denoDeployRoute } from "./routes/docs/deno-deploy";
+import { route as errorHandlingRoute } from "./routes/docs/error-handling";
+import { route as firstAppRoute } from "./routes/docs/first-app";
+import { route as formsRoute } from "./routes/docs/forms";
+import { route as installationRoute } from "./routes/docs/installation";
+import { route as introductionRoute } from "./routes/docs/introduction";
+import { route as layoutsRoute } from "./routes/docs/layouts";
+import { route as loadersAndActionsRoute } from "./routes/docs/loaders-and-actions";
+import { route as middlewareRoute } from "./routes/docs/middleware";
+import { route as navigationRoute } from "./routes/docs/navigation";
+import { route as nodeRoute } from "./routes/docs/node";
+import { route as quickStartRoute } from "./routes/docs/quick-start";
+import { route as resourcesRoute } from "./routes/docs/resources";
+import { route as routingRoute } from "./routes/docs/routing";
+import { route as serverConfigurationRoute } from "./routes/docs/server-configuration";
+import { route as testingRoute } from "./routes/docs/testing";
+import { route as troubleshootingRoute } from "./routes/docs/troubleshooting";
+import { route as typescriptRoute } from "./routes/docs/typescript";
+import { route as viewResponsesRoute } from "./routes/docs/view-responses";
+import { route as homeRoute } from "./routes/index";
+
+export const app = defineApp({
+  routes: [
+    homeRoute,
+    apiReferenceRoute,
+    apiRoutesRoute,
+    authenticationRoute,
+    bunRoute,
+    cloudflareWorkersRoute,
+    configurationRoute,
+    denoDeployRoute,
+    errorHandlingRoute,
+    firstAppRoute,
+    formsRoute,
+    installationRoute,
+    introductionRoute,
+    layoutsRoute,
+    loadersAndActionsRoute,
+    middlewareRoute,
+    navigationRoute,
+    nodeRoute,
+    quickStartRoute,
+    resourcesRoute,
+    routingRoute,
+    serverConfigurationRoute,
+    testingRoute,
+    troubleshootingRoute,
+    typescriptRoute,
+    viewResponsesRoute,
+  ],
+});

--- a/www/src/main.tsx
+++ b/www/src/main.tsx
@@ -1,6 +1,7 @@
 import { mountApp } from "litzjs/client";
 import { registerSW } from "virtual:pwa-register";
 
+import { app } from "./app";
 import { layout } from "./routes/_layouts/root";
 import "./index.css";
 
@@ -10,5 +11,5 @@ if (!root) {
   throw new Error('Missing "#app" root element.');
 }
 
-mountApp(root, { layout });
+mountApp(root, { app, layout });
 registerSW();

--- a/www/src/routes/docs/api-reference.tsx
+++ b/www/src/routes/docs/api-reference.tsx
@@ -1051,13 +1051,17 @@ const viteGroups: readonly ReferenceGroupSpec[] = [
   server?: string;
   rsc?: Omit<RscPluginOptions, "entries" | "serverHandler">;
 };`,
-        summary: "Options accepted by the main Vite plugin factory.",
+        summary:
+          "Options accepted by the main Vite plugin factory. Omit `server` for a client-only build.",
       },
       {
         name: "litz",
         signature: `litz(options?: LitzPluginOptions): PluginOption`,
         summary:
           "Creates the Litz Vite plugin stack, including `@vitejs/plugin-rsc` and the framework server build.",
+        details: [
+          "`server` is optional. If it is omitted, Litz only produces the client build and does not emit `dist/server`.",
+        ],
         example: {
           language: "ts",
           code: `import { defineConfig } from "vite";

--- a/www/src/routes/docs/api-reference.tsx
+++ b/www/src/routes/docs/api-reference.tsx
@@ -33,6 +33,30 @@ const litzCoreGroups: readonly ReferenceGroupSpec[] = [
       "These are the main entrypoints for declaring application structure and server behavior from `litzjs`.",
     entries: [
       {
+        name: "defineApp",
+        signature: `defineApp({ routes, resources, apiRoutes, clientLoading }): LitzApp`,
+        summary:
+          "Registers the routes, resources, and API routes that participate in the application.",
+        details: [
+          "Registration is explicit: importing a file does not enroll it unless the exported definition is included in `defineApp(...)`.",
+          '`clientLoading` defaults to `"lazy"` and can be overridden on route, layout, and resource definitions.',
+        ],
+        example: {
+          language: "ts",
+          code: `import { defineApp } from "litzjs";
+
+import { api as healthApi } from "./api/health";
+import { resource as accountResource } from "./resources/account";
+import { route as homeRoute } from "./routes/home";
+
+export const app = defineApp({
+  routes: [homeRoute],
+  resources: [accountResource],
+  apiRoutes: [healthApi],
+});`,
+        },
+      },
+      {
         name: "defineRoute",
         signature: `defineRoute(path, options): LitzRoute<TPath, TContext, TLoaderResult, TActionResult, TInput>`,
         summary:
@@ -979,6 +1003,7 @@ const serverGroups: readonly ReferenceGroupSpec[] = [
         signature: `type CreateServerOptions<TContext = unknown> = {
   createContext?(request: Request): Promise<TContext> | TContext;
   onError?(error: unknown, context: TContext | undefined): void;
+  app?: LitzApp;
   manifest?: ServerManifest;
   base?: string;
   document?: Response | string | ((request: Request) => Promise<Response | string | null | undefined> | Response | string | null | undefined);
@@ -1022,9 +1047,6 @@ const viteGroups: readonly ReferenceGroupSpec[] = [
       {
         name: "LitzPluginOptions",
         signature: `type LitzPluginOptions = {
-  routes?: string[];
-  api?: string[];
-  resources?: string[];
   clientEntry?: string;
   server?: string;
   rsc?: Omit<RscPluginOptions, "entries" | "serverHandler">;
@@ -1035,7 +1057,7 @@ const viteGroups: readonly ReferenceGroupSpec[] = [
         name: "litz",
         signature: `litz(options?: LitzPluginOptions): PluginOption`,
         summary:
-          "Creates the Litz Vite plugin stack, including route/resource/API discovery, `@vitejs/plugin-rsc`, and the framework server build.",
+          "Creates the Litz Vite plugin stack, including `@vitejs/plugin-rsc` and the framework server build.",
         example: {
           language: "ts",
           code: `import { defineConfig } from "vite";
@@ -1044,7 +1066,6 @@ import { litz } from "litzjs/vite";
 export default defineConfig({
   plugins: [
     litz({
-      routes: ["src/routes/**/*.{ts,tsx,js,jsx}"],
       clientEntry: "src/main.tsx",
       server: "src/server.ts",
     }),

--- a/www/src/routes/docs/configuration.tsx
+++ b/www/src/routes/docs/configuration.tsx
@@ -13,7 +13,7 @@ function DocsConfigurationPage() {
       <title>Configuration | Litz</title>
       <h1 className="text-3xl font-bold text-neutral-50 mb-4">Configuration</h1>
       <p className="text-xl text-neutral-300 mb-8">
-        Configure the Litz Vite plugin to customize routing, discovery, and server behavior.
+        Configure the Litz Vite plugin and register your app explicitly in TypeScript.
       </p>
 
       <section className="mb-12">
@@ -35,7 +35,7 @@ export default defineConfig({
       <section className="mb-12">
         <h2 className="text-2xl font-semibold text-neutral-100 mb-4">Options</h2>
         <p className="text-neutral-400 mb-4">
-          The <code className="text-sky-400">litz()</code> function accepts an options object:
+          The <code className="text-sky-400">litz()</code> function accepts build entry options:
         </p>
         <CodeBlock
           language="ts"
@@ -45,9 +45,6 @@ import { litz } from "litzjs/vite";
 export default defineConfig({
   plugins: [
     litz({
-      routes: ["src/routes/**/*.{ts,tsx,js,jsx}"],
-      api: ["src/routes/api/**/*.{ts,tsx,js,jsx}"],
-      resources: ["src/routes/resources/**/*.{ts,tsx,js,jsx}"],
       clientEntry: "src/main.tsx",
       server: "src/server.ts",
     }),
@@ -57,66 +54,27 @@ export default defineConfig({
       </section>
 
       <section className="mb-12">
-        <h3 className="text-xl font-medium text-neutral-100 mb-3">routes</h3>
+        <h3 className="text-xl font-medium text-neutral-100 mb-3">App registration</h3>
         <p className="text-neutral-400 mb-4">
-          <strong>Type:</strong> <code className="text-sky-400">string[]</code>
-        </p>
-        <p className="text-neutral-400 mb-4">
-          Glob patterns to discover route files. Routes define pages with{" "}
-          <code className="text-sky-400">defineRoute()</code>.
-        </p>
-        <p className="text-neutral-400 mb-4">
-          <strong>Default:</strong> All .ts, .tsx, .js, and .jsx files in src/routes, excluding api
-          and resources subdirectories
+          Routes, resources, and API routes are registered with{" "}
+          <code className="text-sky-400">defineApp()</code>. File placement does not register
+          anything by itself.
         </p>
         <CodeBlock
           language="ts"
-          code={`// Example: custom route directory
-litz({
-  routes: ["app/pages/**/*.{ts,tsx}"],
-})`}
-        />
-      </section>
+          code={`// src/app.ts
+import { defineApp } from "litzjs";
 
-      <section className="mb-12">
-        <h3 className="text-xl font-medium text-neutral-100 mb-3">api</h3>
-        <p className="text-neutral-400 mb-4">
-          <strong>Type:</strong> <code className="text-sky-400">string[]</code>
-        </p>
-        <p className="text-neutral-400 mb-4">
-          Glob patterns to discover API route files. API routes define HTTP endpoints with{" "}
-          <code className="text-sky-400">defineApiRoute()</code>.
-        </p>
-        <p className="text-neutral-400 mb-4">
-          <strong>Default:</strong> All .ts, .tsx, .js, and .jsx files in src/routes/api
-        </p>
-        <CodeBlock
-          language="ts"
-          code={`// Example: custom API directory
-litz({
-  api: ["app/api/**/*.{ts,tsx}"],
-})`}
-        />
-      </section>
+import { api as healthApi } from "./api/health";
+import { resource as accountResource } from "./resources/account";
+import { route as homeRoute } from "./routes/home";
 
-      <section className="mb-12">
-        <h3 className="text-xl font-medium text-neutral-100 mb-3">resources</h3>
-        <p className="text-neutral-400 mb-4">
-          <strong>Type:</strong> <code className="text-sky-400">string[]</code>
-        </p>
-        <p className="text-neutral-400 mb-4">
-          Glob patterns to discover resource files. Resources define reusable server-backed UI with{" "}
-          <code className="text-sky-400">defineResource()</code>.
-        </p>
-        <p className="text-neutral-400 mb-4">
-          <strong>Default:</strong> All .ts, .tsx, .js, and .jsx files in src/routes/resources
-        </p>
-        <CodeBlock
-          language="ts"
-          code={`// Example: custom resources directory
-litz({
-  resources: ["app/components/**/*.{ts,tsx}"],
-})`}
+export const app = defineApp({
+  clientLoading: "lazy",
+  routes: [homeRoute],
+  resources: [accountResource],
+  apiRoutes: [healthApi],
+});`}
         />
       </section>
 
@@ -133,10 +91,12 @@ litz({
         </p>
         <CodeBlock
           language="ts"
-          code={`// Example: custom browser entry
-litz({
-  clientEntry: "app/browser.tsx",
-})`}
+          code={`// app/browser.tsx
+import { mountApp } from "litzjs/client";
+
+import { app } from "./app";
+
+mountApp(document.getElementById("app")!, { app });`}
         />
       </section>
 
@@ -156,16 +116,18 @@ litz({
         </p>
         <CodeBlock
           language="ts"
-          code={`// Example: custom server entry
-litz({
-  server: "app/server.ts",
-})`}
+          code={`// app/server.ts
+import { createServer } from "litzjs/server";
+
+import { app } from "./app";
+
+export default createServer({ app });`}
         />
       </section>
 
       <section className="mb-12">
         <h2 className="text-2xl font-semibold text-neutral-100 mb-4">Complete example</h2>
-        <p className="text-neutral-400 mb-4">A full configuration with all options:</p>
+        <p className="text-neutral-400 mb-4">A full Vite plugin configuration:</p>
         <CodeBlock
           language="ts"
           code={`import { defineConfig } from "vite";
@@ -174,19 +136,6 @@ import { litz } from "litzjs/vite";
 export default defineConfig({
   plugins: [
     litz({
-      // Route files (pages)
-      routes: [
-        "src/routes/**/*.{ts,tsx,js,jsx}",
-        "!src/routes/api/**/*.{ts,tsx,js,jsx}",
-        "!src/routes/resources/**/*.{ts,tsx,js,jsx}",
-      ],
-
-      // API route files
-      api: ["src/routes/api/**/*.{ts,tsx,js,jsx}"],
-
-      // Resource files (reusable server-backed UI)
-      resources: ["src/routes/resources/**/*.{ts,tsx,js,jsx}"],
-
       // Browser entry (optional)
       clientEntry: "src/main.tsx",
 

--- a/www/src/routes/docs/configuration.tsx
+++ b/www/src/routes/docs/configuration.tsx
@@ -35,7 +35,8 @@ export default defineConfig({
       <section className="mb-12">
         <h2 className="text-2xl font-semibold text-neutral-100 mb-4">Options</h2>
         <p className="text-neutral-400 mb-4">
-          The <code className="text-sky-400">litz()</code> function accepts build entry options:
+          The <code className="text-sky-400">litz()</code> function accepts optional build entry
+          options. Omit <code className="text-sky-400">server</code> for a client-only build:
         </p>
         <CodeBlock
           language="ts"
@@ -111,8 +112,7 @@ mountApp(document.getElementById("app")!, { app });`}
           <code className="text-sky-400">litzjs/server</code>.
         </p>
         <p className="text-neutral-400 mb-4">
-          <strong>Default:</strong> <code className="text-sky-400">"src/server.ts"</code> or{" "}
-          <code className="text-sky-400">"src/server/index.ts"</code> (auto-discovered)
+          <strong>Default:</strong> omitted. When omitted, Litz does not produce a server build.
         </p>
         <CodeBlock
           language="ts"
@@ -139,7 +139,7 @@ export default defineConfig({
       // Browser entry (optional)
       clientEntry: "src/main.tsx",
 
-      // Custom server entry (optional)
+      // Server entry (optional; omitted means client-only)
       server: "src/server.ts",
     }),
   ],

--- a/www/src/routes/docs/first-app.tsx
+++ b/www/src/routes/docs/first-app.tsx
@@ -129,13 +129,15 @@ export default defineConfig({
           language="tsx"
           code={`import { mountApp } from "litzjs/client";
 
+import { app } from "./app";
+
 const root = document.getElementById("app");
 
 if (!root) {
   throw new Error('Missing "#app" root element.');
 }
 
-mountApp(root);`}
+mountApp(root, { app });`}
         />
       </section>
 
@@ -164,7 +166,24 @@ function HomePage() {
       </section>
 
       <section className="mb-12">
-        <h2 className="text-2xl font-semibold text-neutral-100 mb-4">7. Start the dev server</h2>
+        <h2 className="text-2xl font-semibold text-neutral-100 mb-4">7. Register the app</h2>
+        <p className="text-neutral-400 mb-4">
+          Create <code className="text-sky-400">src/app.ts</code> and include the route explicitly:
+        </p>
+        <CodeBlock
+          language="ts"
+          code={`import { defineApp } from "litzjs";
+
+import { route as homeRoute } from "./routes";
+
+export const app = defineApp({
+  routes: [homeRoute],
+});`}
+        />
+      </section>
+
+      <section className="mb-12">
+        <h2 className="text-2xl font-semibold text-neutral-100 mb-4">8. Start the dev server</h2>
         <p className="text-neutral-400 mb-4">Run Vite directly from Bun in the same directory:</p>
         <CodeBlock language="bash" code={`bunx vite`} />
         <p className="text-neutral-400 mt-4 mb-4">

--- a/www/src/routes/docs/installation.tsx
+++ b/www/src/routes/docs/installation.tsx
@@ -130,10 +130,10 @@ pnpm add -D vite typescript`}
 
         <h3 className="text-xl font-medium text-neutral-100 mb-3">Included capabilities</h3>
         <p className="text-neutral-400 mb-4">
-          The default <code className="text-sky-400">litz()</code> plugin includes the React Server
-          Components integration used by <code className="text-sky-400">view(...)</code> and the
-          framework build pipeline used for production builds. Most apps only need{" "}
-          <code className="text-sky-400">plugins: [litz()]</code>.
+          The <code className="text-sky-400">litz()</code> plugin can build client-only apps. Add{" "}
+          <code className="text-sky-400">server: "src/server.ts"</code> when you need the React
+          Server Components integration used by <code className="text-sky-400">view(...)</code>,
+          route loaders and actions, resources, or API routes.
         </p>
 
         <h3 className="text-xl font-medium text-neutral-100 mb-3">Runtime compatibility notes</h3>
@@ -195,8 +195,8 @@ export default defineConfig({
           <Link href="/docs/first-app" className="text-sky-400 hover:text-sky-300">
             First App
           </Link>{" "}
-          for the empty-directory walkthrough before you fine-tune route discovery patterns and
-          server entry options in Quick Start and Configuration.
+          for the empty-directory walkthrough before you fine-tune app registration and server entry
+          options in Quick Start and Configuration.
         </p>
       </section>
 

--- a/www/src/routes/docs/quick-start.tsx
+++ b/www/src/routes/docs/quick-start.tsx
@@ -26,6 +26,24 @@ function DocsQuickStartPage() {
       </p>
 
       <section className="mb-12">
+        <h2 className="text-2xl font-semibold text-neutral-100 mb-4">Define the app</h2>
+        <p className="text-neutral-400 mb-4">
+          Create <code className="text-sky-400">src/app.ts</code> and explicitly register your
+          route:
+        </p>
+        <CodeBlock
+          language="ts"
+          code={`import { defineApp } from "litzjs";
+
+import { route as homeRoute } from "./routes";
+
+export const app = defineApp({
+  routes: [homeRoute],
+});`}
+        />
+      </section>
+
+      <section className="mb-12">
         <h2 className="text-2xl font-semibold text-neutral-100 mb-4">Mount the app</h2>
         <p className="text-neutral-400 mb-4">
           Create <code className="text-sky-400">src/main.tsx</code>:
@@ -34,13 +52,15 @@ function DocsQuickStartPage() {
           language="tsx"
           code={`import { mountApp } from "litzjs/client";
 
+import { app } from "./app";
+
 const root = document.getElementById("app");
 
 if (!root) {
   throw new Error('Missing "#app" root element.');
 }
 
-mountApp(root);`}
+mountApp(root, { app });`}
         />
 
         <h3 className="text-xl font-medium text-neutral-100 mb-3 mt-6">Optional wrapper</h3>

--- a/www/src/routes/docs/routing.tsx
+++ b/www/src/routes/docs/routing.tsx
@@ -164,55 +164,36 @@ function SettingsPage() {
       </section>
 
       <section className="mb-12">
-        <h2 className="text-2xl font-semibold text-neutral-100 mb-4">Route discovery</h2>
+        <h2 className="text-2xl font-semibold text-neutral-100 mb-4">Route registration</h2>
         <p className="text-neutral-400 mb-4">
-          The Litz Vite plugin scans your project for files that export a{" "}
-          <code className="text-sky-400">route</code> binding created by{" "}
-          <code className="text-sky-400">defineRoute</code>. It collects these at build time so the
-          client router knows every path.
+          Define routes in ordinary TypeScript, then include them in{" "}
+          <code className="text-sky-400">defineApp({`{ routes: [...] }`})</code>. File placement
+          alone does not register a route.
         </p>
         <p className="text-neutral-400 mb-4">
           Because routes are path-based rather than filesystem-based, you can organise route files
-          however you like. The plugin only cares about the exported{" "}
-          <code className="text-sky-400">route</code> binding, not the directory structure.
-        </p>
-        <p className="text-neutral-400 mb-4">
-          Discovery is intentionally static. The supported declaration forms are:
+          however you like. The app definition controls which route objects participate.
         </p>
         <CodeBlock
           language="tsx"
-          code={`export const route = defineRoute("/dashboard", {
-  component: DashboardPage,
-});
-
-const dashboardRoute = defineRoute("/dashboard", {
-  component: DashboardPage,
-});
-
-export { dashboardRoute as route };`}
-        />
-        <p className="text-neutral-400 mt-4 mb-4">
-          The path must be a string literal or no-substitution template literal in the{" "}
-          <code className="text-sky-400">defineRoute</code> call. Local aliases and simple wrappers
-          are supported only when they resolve back to that static call.
-        </p>
-        <p className="text-neutral-400 mb-4">
-          These forms are not discovered and will warn during dev or build when the file imports{" "}
-          <code className="text-sky-400">defineRoute</code> from{" "}
-          <code className="text-sky-400">"litzjs"</code>:
-        </p>
-        <CodeBlock
-          language="tsx"
-          code={`const path = "/dashboard";
-
-export const route = defineRoute(path, {
-  component: DashboardPage,
-});
-
+          code={`// routes/dashboard.tsx
 export const dashboardRoute = defineRoute("/dashboard", {
   component: DashboardPage,
+});
+
+// app.ts
+import { defineApp } from "litzjs";
+
+import { dashboardRoute } from "./routes/dashboard";
+
+export const app = defineApp({
+  routes: [dashboardRoute],
 });`}
         />
+        <p className="text-neutral-400 mt-4 mb-4">
+          Route paths still come from <code className="text-sky-400">defineRoute</code>, so the URL
+          remains explicit at the definition site.
+        </p>
       </section>
 
       <div className="flex justify-between pt-8 border-t border-neutral-800">

--- a/www/src/routes/docs/server-configuration.tsx
+++ b/www/src/routes/docs/server-configuration.tsx
@@ -26,7 +26,7 @@ function ServerConfiguration() {
           request handler: <code className="text-sky-400">Request → Response</code>.
         </p>
         <p className="text-neutral-400 mb-4">
-          The Vite plugin injects the discovered routes and configured base, so custom server
+          The Vite plugin injects the registered app manifest and configured base, so custom server
           entries only need to describe request-specific behavior:
         </p>
         <CodeBlock
@@ -160,16 +160,17 @@ export default createServer();`}
       </section>
 
       <section className="mb-12">
-        <h2 className="text-2xl font-semibold text-neutral-100 mb-4">Discovery</h2>
+        <h2 className="text-2xl font-semibold text-neutral-100 mb-4">Registration</h2>
         <p className="text-neutral-400 mb-4">
-          The Vite plugin discovers routes, resources, API routes, and the configured base path,
-          then wires them into <code className="text-sky-400">createServer</code> during the build.
-          Custom server entries can stay focused on context, error handling, assets, and document
-          behavior.
+          Register routes, resources, and API routes with{" "}
+          <code className="text-sky-400">defineApp(...)</code>, then pass that app to{" "}
+          <code className="text-sky-400">createServer({`{ app }`})</code>. During builds, the Vite
+          plugin also injects the configured base path.
         </p>
         <p className="text-neutral-400 mb-4">
-          Discovery paths are configured in <code className="text-sky-400">vite.config.ts</code>{" "}
-          through the <code className="text-sky-400">litz()</code> plugin options.
+          Configure <code className="text-sky-400">litz({`{ server: "src/server.ts" }`})</code> when
+          you want Litz to produce a server build. Omit <code className="text-sky-400">server</code>{" "}
+          for client-only apps.
         </p>
       </section>
 

--- a/www/src/routes/docs/troubleshooting.tsx
+++ b/www/src/routes/docs/troubleshooting.tsx
@@ -77,57 +77,40 @@ import { litz } from "litzjs/vite";`}
         </p>
         <ul className="text-neutral-400 space-y-2 list-disc list-inside mb-4">
           <li>
-            Export <code className="text-sky-400">route</code> from the module and define the URL in{" "}
+            Export the route definition from its module and define the URL in{" "}
             <code className="text-sky-400">defineRoute("/path", ...)</code>.
           </li>
           <li>
-            Keep the route path static. Discovery reads string literals in{" "}
-            <code className="text-sky-400">defineRoute</code>,{" "}
-            <code className="text-sky-400">defineLayout</code>,{" "}
-            <code className="text-sky-400">defineResource</code>, and{" "}
-            <code className="text-sky-400">defineApiRoute</code> calls; paths stored in variables
-            are ignored.
+            Import that route from your app module and include it in{" "}
+            <code className="text-sky-400">defineApp({`{ routes: [...] }`})</code>. File placement
+            alone does not register routes.
           </li>
           <li>
-            Treat <code className="text-sky-400">[litzjs]</code> discovery warnings as registration
-            failures. They mean a matched file imports a Litz route factory but does not export the
-            required binding name, or the exported binding does not resolve to a static factory
-            call.
-          </li>
-          <li>
-            Keep page routes inside the configured route globs. The default is{" "}
-            <code className="text-sky-400">{"src/routes/**/*.{ts,tsx,js,jsx}"}</code>, excluding the{" "}
-            <code className="text-sky-400">api</code> and{" "}
-            <code className="text-sky-400">resources</code> subdirectories.
-          </li>
-          <li>
-            If you moved routes into a custom folder, update the Vite plugin{" "}
-            <code className="text-sky-400">routes</code> option so discovery can see them.
+            Pass the same app object to{" "}
+            <code className="text-sky-400">mountApp(root, {`{ app }`})</code> and{" "}
+            <code className="text-sky-400">createServer({`{ app }`})</code>.
           </li>
         </ul>
         <CodeBlock
           language="ts"
-          code={`// vite.config.ts
-import { defineConfig } from "vite";
-import { litz } from "litzjs/vite";
-
-export default defineConfig({
-  plugins: [
-    litz({
-      routes: ["app/pages/**/*.{ts,tsx}"],
-    }),
-  ],
-});
-
-// app/pages/dashboard.tsx
+          code={`// app/pages/dashboard.tsx
 import { defineRoute } from "litzjs";
 
 export const route = defineRoute("/dashboard", {
   component: DashboardPage,
+});
+
+// app/app.ts
+import { defineApp } from "litzjs";
+
+import { route as dashboardRoute } from "./pages/dashboard";
+
+export const app = defineApp({
+  routes: [dashboardRoute],
 });`}
         />
         <p className="text-neutral-400 mt-4">
-          For route shape and discovery rules, see{" "}
+          For route shape and app registration rules, see{" "}
           <Link href="/docs/routing" className="text-sky-400 hover:text-sky-300">
             Routing
           </Link>{" "}

--- a/www/src/server.ts
+++ b/www/src/server.ts
@@ -1,6 +1,9 @@
 import { createServer } from "litzjs/server";
 
+import { app } from "./app";
+
 export default createServer({
+  app,
   onError: (error) => {
     console.error("An error occurred:", error);
   },

--- a/www/vite.config.ts
+++ b/www/vite.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
   },
   plugins: [
     tailwindcss(),
-    litz(),
+    litz({ server: "src/server.ts" }),
     ...pwaPlugins,
     cloudflare({
       viteEnvironment: {


### PR DESCRIPTION
## Summary

Closes #166.

This PR introduces explicit app registration through `defineApp(...)` so applications can intentionally register routes, resources, and API routes in ordinary TypeScript. The app definition can now be passed to both `mountApp(root, { app })` and `createServer({ app })`, making the client and server runtimes share the same visible app graph.

It also removes implicit server entry discovery. If `litz({ server })` is omitted, Litz produces a client-only build and does not emit `dist/server`. If a server entry is needed, the user must point to it explicitly.

## What changed

- Added `defineApp(...)`, `LitzApp`, `DefineAppOptions`, and `ClientLoadingMode` to the public `litzjs` API.
- Added `clientLoading` metadata support on route, layout, and resource definitions.
- Updated `mountApp(...)` to accept an explicit app and derive the active client route manifest from it.
- Updated `createServer(...)` to accept an explicit app and normalize it into the existing server manifest shape, with app registration taking precedence when both `app` and injected manifests are present.
- Rejects duplicate route, resource, and API route registrations by path at `defineApp(...)` time.
- Removed public `routes`, `resources`, and `api` glob options from `LitzPluginOptions`.
- Removed `src/server.ts` / `src/server/index.ts` auto-discovery. `server` is now optional, but when omitted the build is client-only.
- Updated Nitro integration to require the same explicit server entry.
- Added explicit `src/app.ts` files for the smoke fixture and docs site, and passed those app definitions to client and server entries.
- Updated README, docs, and API reference content to explain explicit registration and server opt-in behavior.
- Added a changeset for the new app registration and server-entry behavior.

## Impact

This moves user-facing registration away from implicit file enrollment and toward explicit imports. Existing internal route/resource/API discovery helpers are still present for the current Vite manifest pipeline and tests, but the public configuration surface no longer exposes route/resource/API glob options or implicit server-entry conventions.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun lint`
- `bun typecheck`
- `bun test`
