### PR TITLE
[codex] Support custom data serializers

### DIFF
--- a/.changeset/custom-data-serializers.md
+++ b/.changeset/custom-data-serializers.md
@@ -1,0 +1,6 @@
+---
+"litzjs": minor
+---
+
+Add app-level custom data serializers for `data(...)` result transport across route loaders, route actions, resources, and batched loader responses.
+

--- a/README.md
+++ b/README.md
@@ -1066,6 +1066,42 @@ Behavior summary:
 - explicit action `error(...)` is available through `useActionError()` and `useError()`
 - route faults go through route error boundaries
 
+### Custom Data Serializers
+
+By default, Litz encodes `data(...)`, `invalid(...)`, and `error(...)` payload data with
+`JSON.stringify(...)` and decodes them with `JSON.parse(...)`. Configure `dataSerializer` on your
+app when loader, action, or resource data needs to round-trip richer values such as `BigInt`:
+
+```tsx
+import { defineApp } from "litzjs";
+
+export const app = defineApp({
+  dataSerializer: {
+    stringify(value) {
+      return JSON.stringify(value, (_key, nestedValue) =>
+        typeof nestedValue === "bigint" ? { $bigint: nestedValue.toString() } : nestedValue,
+      );
+    },
+    parse(text) {
+      return JSON.parse(text, (_key, nestedValue) =>
+        nestedValue &&
+        typeof nestedValue === "object" &&
+        "$bigint" in nestedValue &&
+        typeof nestedValue.$bigint === "string"
+          ? BigInt(nestedValue.$bigint)
+          : nestedValue,
+      );
+    },
+  },
+  routes: [route],
+  resources: [resource],
+});
+```
+
+Pass the same app to `createServer({ app })` and `mountApp(..., { app })`. The serializer applies to
+route loaders, route actions, resource loaders/actions, and batched loader responses. It does not
+apply to `view(...)` responses, which use the React Flight transport.
+
 ## Middleware
 
 Routes, resources, and API routes can declare a `middleware` array. Middleware runs in order and can continue with `next()`, short-circuit with a result, or explicitly replace `context` with `next({ context })`.

--- a/README.md
+++ b/README.md
@@ -1101,6 +1101,8 @@ export const app = defineApp({
 Pass the same app to `createServer({ app })` and `mountApp(..., { app })`. The serializer applies to
 route loaders, route actions, resource loaders/actions, and batched loader responses. It does not
 apply to `view(...)` responses, which use the React Flight transport.
+Use `jsonDataSerializer` when a custom serializer needs to delegate back to Litz's default JSON
+implementation.
 
 ## Middleware
 

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -52,7 +52,7 @@ import {
   useRequiredRouteStatus,
 } from "./runtime";
 import { sortRecord } from "./sort-record";
-import { getRevalidateTargets } from "./transport";
+import { configureDataSerializer, getRevalidateTargets } from "./transport";
 
 installClientBindings({
   usePathname,
@@ -163,8 +163,15 @@ export interface MountAppOptions {
   readonly focusManagement?: boolean;
 }
 
-export function configureClientRuntime(options: { baseUrl?: string | undefined }): void {
+export function configureClientRuntime(options: {
+  baseUrl?: string | undefined;
+  dataSerializer?: LitzAppDefinition["dataSerializer"];
+}): void {
   configureClientBaseUrl(options.baseUrl);
+
+  if (Object.prototype.hasOwnProperty.call(options, "dataSerializer")) {
+    configureDataSerializer(options.dataSerializer);
+  }
 }
 
 configureActiveManifest(defaultManifest);
@@ -172,6 +179,7 @@ configureActiveManifest(defaultManifest);
 export function mountApp(element: Element, options?: MountAppOptions): void {
   const resolvedOptions = normalizeMountAppOptions(options);
   configureActiveManifest(createManifestFromApp(resolvedOptions?.app));
+  configureDataSerializer(resolvedOptions?.app?.dataSerializer);
 
   void import("react-dom/client").then(({ createRoot }) => {
     const root = createRoot(element);

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -179,7 +179,13 @@ configureActiveManifest(defaultManifest);
 export function mountApp(element: Element, options?: MountAppOptions): void {
   const resolvedOptions = normalizeMountAppOptions(options);
   configureActiveManifest(createManifestFromApp(resolvedOptions?.app));
-  configureDataSerializer(resolvedOptions?.app?.dataSerializer);
+
+  if (
+    resolvedOptions?.app &&
+    Object.prototype.hasOwnProperty.call(resolvedOptions.app, "dataSerializer")
+  ) {
+    configureDataSerializer(resolvedOptions.app.dataSerializer);
+  }
 
   void import("react-dom/client").then(({ createRoot }) => {
     const root = createRoot(element);

--- a/src/client/transport.tsx
+++ b/src/client/transport.tsx
@@ -1,5 +1,6 @@
 import type { ActionHookResult, LoaderHookResult } from "../index";
 
+import { jsonDataSerializer, type DataSerializer } from "../data-serializer";
 import { createPublicResultHeaders } from "./result-headers";
 
 export type LitzJsonBody =
@@ -43,6 +44,12 @@ type BatchedLoaderBody = {
   kind: "batch";
   results: BatchedLoaderEntry[];
 };
+
+let dataSerializer: DataSerializer = jsonDataSerializer;
+
+export function configureDataSerializer(serializer?: DataSerializer): void {
+  dataSerializer = serializer ?? jsonDataSerializer;
+}
 
 export async function parseLoaderResponse(response: Response): Promise<LoaderHookResult> {
   const contentType = response.headers.get("content-type") ?? "";
@@ -111,7 +118,7 @@ export async function parseLoaderBatchResponse(
   }
 
   try {
-    const parsedBody = JSON.parse(bodyText) as unknown;
+    const parsedBody = dataSerializer.parse(bodyText);
 
     if (isBatchedLoaderBody(parsedBody)) {
       return parsedBody.results.map((entry) => {
@@ -331,7 +338,7 @@ async function parseLitzJsonResponse<const TAllowedKinds extends readonly LitzJs
   }
 
   try {
-    const parsedBody = JSON.parse(bodyText) as unknown;
+    const parsedBody = dataSerializer.parse(bodyText);
 
     if (isLitzJsonBody(parsedBody) && allowedKinds.includes(parsedBody.kind)) {
       return parsedBody as Extract<LitzJsonBody, { kind: TAllowedKinds[number] | "fault" }>;

--- a/src/data-serializer.ts
+++ b/src/data-serializer.ts
@@ -1,0 +1,13 @@
+export type DataSerializer = {
+  stringify(value: unknown): string;
+  parse(text: string): unknown;
+};
+
+export const jsonDataSerializer: DataSerializer = {
+  stringify(value) {
+    return JSON.stringify(value);
+  },
+  parse(text) {
+    return JSON.parse(text) as unknown;
+  },
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import type { DataSerializer } from "./data-serializer";
 import type { SubmitPayload } from "./form-data";
 
 import { resolveClientHref } from "./client/base-url";
@@ -15,6 +16,7 @@ export {
   type SubmitPayload,
 } from "./form-data";
 export type { SearchParamRecord, SearchParamValue } from "./search-params";
+export type { DataSerializer } from "./data-serializer";
 
 export type MiddlewareOverrides<TContext = unknown> = {
   context?: TContext;
@@ -794,6 +796,7 @@ export interface DefineAppOptions<
   TApiRoutes extends readonly AppApiRouteRegistration[] = readonly AppApiRouteRegistration[],
 > {
   readonly clientLoading?: ClientLoadingMode;
+  readonly dataSerializer?: DataSerializer;
   readonly routes?: TRoutes;
   readonly resources?: TResources;
   readonly apiRoutes?: TApiRoutes;
@@ -805,6 +808,7 @@ export interface LitzApp<
   TApiRoutes extends readonly AppApiRouteRegistration[] = readonly AppApiRouteRegistration[],
 > {
   readonly clientLoading: ClientLoadingMode;
+  readonly dataSerializer?: DataSerializer;
   readonly routes: TRoutes;
   readonly resources: TResources;
   readonly apiRoutes: TApiRoutes;
@@ -1299,6 +1303,7 @@ export function defineApp<
 
   return {
     clientLoading: options.clientLoading ?? "lazy",
+    dataSerializer: options.dataSerializer,
     routes: options.routes ?? ([] as unknown as TRoutes),
     resources: options.resources ?? ([] as unknown as TResources),
     apiRoutes: options.apiRoutes ?? ([] as unknown as TApiRoutes),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1304,7 +1304,9 @@ export function defineApp<
 
   return {
     clientLoading: options.clientLoading ?? "lazy",
-    dataSerializer: options.dataSerializer,
+    ...(Object.prototype.hasOwnProperty.call(options, "dataSerializer")
+      ? { dataSerializer: options.dataSerializer }
+      : {}),
     routes: options.routes ?? ([] as unknown as TRoutes),
     resources: options.resources ?? ([] as unknown as TResources),
     apiRoutes: options.apiRoutes ?? ([] as unknown as TApiRoutes),

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export {
   type FormJsonValue,
   type SubmitPayload,
 } from "./form-data";
+export { jsonDataSerializer } from "./data-serializer";
 export type { SearchParamRecord, SearchParamValue } from "./search-params";
 export type { DataSerializer } from "./data-serializer";
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,6 +1,7 @@
 import type { ApiRouteMethod, LitzApp } from "../index";
 
 import { normalizeBasePath, resolveBasePathname } from "../base-path";
+import { jsonDataSerializer, type DataSerializer } from "../data-serializer";
 import {
   createBodylessResponse,
   createApiResponseFromResult,
@@ -165,6 +166,7 @@ export type CreateServerOptions<TContext = unknown> = {
   document?: DocumentResponseOption;
   notFound?: DocumentResponseOption;
   assets?: (request: Request) => Promise<Response | null | undefined> | Response | null | undefined;
+  dataSerializer?: DataSerializer;
 };
 
 export function createServer<TContext = unknown>(
@@ -172,6 +174,8 @@ export function createServer<TContext = unknown>(
 ): LitzRuntimeServer<TContext> {
   const manifest = normalizeServerManifest(options.manifest, options.app);
   const basePath = normalizeBasePath(options.base);
+  const dataSerializer =
+    options.app?.dataSerializer ?? options.dataSerializer ?? jsonDataSerializer;
 
   async function handle(request: Request): Promise<Response> {
     const url = new URL(request.url);
@@ -202,6 +206,7 @@ export function createServer<TContext = unknown>(
           options.validateInternalRequest,
           (error, context) => options.onError?.(error, context),
           () => (contextLoaded ? contextValue : undefined),
+          dataSerializer,
         );
       }
 
@@ -214,6 +219,7 @@ export function createServer<TContext = unknown>(
           (error, context) => options.onError?.(error, context),
           () => (contextLoaded ? contextValue : undefined),
           basePath,
+          dataSerializer,
         );
       }
 
@@ -397,6 +403,7 @@ async function handleResourceRequest<TContext>(
   validateInternalRequest?: InternalRequestValidator<TContext>,
   reportError?: (error: unknown, context: TContext | undefined) => void,
   getLoadedContext?: () => TContext | undefined,
+  dataSerializer = jsonDataSerializer,
 ): Promise<Response> {
   let viewId = "litzjs#view";
 
@@ -425,7 +432,12 @@ async function handleResourceRequest<TContext>(
     const entry = resources.find((resource) => resource.path === resourcePath);
 
     if (!resourcePath || !entry?.resource) {
-      return createLitzJsonResponse(404, { kind: "fault", message: "Resource not found." });
+      return createLitzJsonResponse(
+        404,
+        { kind: "fault", message: "Resource not found." },
+        undefined,
+        dataSerializer,
+      );
     }
 
     const resource = entry.resource;
@@ -434,10 +446,15 @@ async function handleResourceRequest<TContext>(
     viewId = `${entry.path}#${operation}`;
 
     if (!handler) {
-      return createLitzJsonResponse(405, {
-        kind: "fault",
-        message: `Resource does not define a ${operation}.`,
-      });
+      return createLitzJsonResponse(
+        405,
+        {
+          kind: "fault",
+          message: `Resource does not define a ${operation}.`,
+        },
+        undefined,
+        dataSerializer,
+      );
     }
 
     const normalizedRequest = normalizeInternalRequest(
@@ -472,14 +489,14 @@ async function handleResourceRequest<TContext>(
       },
     });
 
-    return createServerResultResponse(result, viewId);
+    return createServerResultResponse(result, viewId, dataSerializer);
   } catch (error) {
     if (isServerResultLike(error)) {
-      return createServerResultResponse(error, viewId);
+      return createServerResultResponse(error, viewId, dataSerializer);
     }
 
     reportError?.(error, getLoadedContext?.());
-    return createUnhandledFaultResponse();
+    return createUnhandledFaultResponse(dataSerializer);
   }
 }
 
@@ -491,6 +508,7 @@ async function handleRouteRequest<TContext>(
   reportError?: (error: unknown, context: TContext | undefined) => void,
   getLoadedContext?: () => TContext | undefined,
   base?: string,
+  dataSerializer = jsonDataSerializer,
 ): Promise<Response> {
   let viewId = "litzjs#view";
 
@@ -523,7 +541,12 @@ async function handleRouteRequest<TContext>(
     const entry = routes.find((route) => route.path === routePath);
 
     if (!routePath || !entry?.route) {
-      return createLitzJsonResponse(404, { kind: "fault", message: "Route not found." });
+      return createLitzJsonResponse(
+        404,
+        { kind: "fault", message: "Route not found." },
+        undefined,
+        dataSerializer,
+      );
     }
 
     const route = entry.route;
@@ -543,7 +566,12 @@ async function handleRouteRequest<TContext>(
         const batchTarget = findTargetRouteMatch(chain, batchTargetId);
 
         if (!batchTarget) {
-          return createLitzJsonResponse(404, { kind: "fault", message: "Route target not found." });
+          return createLitzJsonResponse(
+            404,
+            { kind: "fault", message: "Route target not found." },
+            undefined,
+            dataSerializer,
+          );
         }
 
         batchTargets.push(batchTarget);
@@ -568,19 +596,29 @@ async function handleRouteRequest<TContext>(
         const serializedResult = createBatchedLoaderResponseEntry(batchResult);
 
         if (!serializedResult) {
-          return createLitzJsonResponse(409, {
-            kind: "fault",
-            message: "Batched route loaders do not support view results.",
-          });
+          return createLitzJsonResponse(
+            409,
+            {
+              kind: "fault",
+              message: "Batched route loaders do not support view results.",
+            },
+            undefined,
+            dataSerializer,
+          );
         }
 
         results.push(serializedResult);
       }
 
-      return createLitzJsonResponse(200, {
-        kind: "batch",
-        results,
-      });
+      return createLitzJsonResponse(
+        200,
+        {
+          kind: "batch",
+          results,
+        },
+        undefined,
+        dataSerializer,
+      );
     }
 
     const target =
@@ -589,7 +627,12 @@ async function handleRouteRequest<TContext>(
         : findTargetRouteMatch(chain, targetId ?? routePath);
 
     if (!target) {
-      return createLitzJsonResponse(404, { kind: "fault", message: "Route target not found." });
+      return createLitzJsonResponse(
+        404,
+        { kind: "fault", message: "Route target not found." },
+        undefined,
+        dataSerializer,
+      );
     }
 
     viewId = `${target.id}#${operation}`;
@@ -603,14 +646,14 @@ async function handleRouteRequest<TContext>(
       context,
     });
 
-    return createServerResultResponse(result, viewId);
+    return createServerResultResponse(result, viewId, dataSerializer);
   } catch (error) {
     if (isServerResultLike(error)) {
-      return createServerResultResponse(error, viewId);
+      return createServerResultResponse(error, viewId, dataSerializer);
     }
 
     reportError?.(error, getLoadedContext?.());
-    return createUnhandledFaultResponse();
+    return createUnhandledFaultResponse(dataSerializer);
   }
 }
 
@@ -918,12 +961,18 @@ function createBatchedLoaderResponseEntry(result: unknown): BatchedLoaderRespons
 async function createServerResultResponse(
   result: unknown,
   viewId = "litzjs#view",
+  dataSerializer = jsonDataSerializer,
 ): Promise<Response> {
   if (!result || typeof result !== "object" || !("kind" in result)) {
-    return createLitzJsonResponse(500, {
-      kind: "fault",
-      message: "Handler returned an unknown result.",
-    });
+    return createLitzJsonResponse(
+      500,
+      {
+        kind: "fault",
+        message: "Handler returned an unknown result.",
+      },
+      undefined,
+      dataSerializer,
+    );
   }
 
   const serverResult = result as {
@@ -955,6 +1004,7 @@ async function createServerResultResponse(
           revalidate: serverResult.revalidate ?? [],
         },
         headers,
+        dataSerializer,
       );
     case "invalid":
       return createLitzJsonResponse(
@@ -966,6 +1016,7 @@ async function createServerResultResponse(
           data: serverResult.data,
         },
         headers,
+        dataSerializer,
       );
     case "redirect":
       return createLitzJsonResponse(
@@ -977,6 +1028,7 @@ async function createServerResultResponse(
           revalidate: serverResult.revalidate ?? [],
         },
         headers,
+        dataSerializer,
       );
     case "error":
       return createLitzJsonResponse(
@@ -988,6 +1040,7 @@ async function createServerResultResponse(
           data: serverResult.data,
         },
         headers,
+        dataSerializer,
       );
     case "fault":
       return createLitzJsonResponse(
@@ -998,6 +1051,7 @@ async function createServerResultResponse(
           digest: serverResult.digest,
         },
         headers,
+        dataSerializer,
       );
     case "view": {
       headers.set("content-type", "text/x-component");
@@ -1012,10 +1066,15 @@ async function createServerResultResponse(
       });
     }
     default:
-      return createLitzJsonResponse(500, {
-        kind: "fault",
-        message: `Unsupported result kind "${serverResult.kind}".`,
-      });
+      return createLitzJsonResponse(
+        500,
+        {
+          kind: "fault",
+          message: `Unsupported result kind "${serverResult.kind}".`,
+        },
+        undefined,
+        dataSerializer,
+      );
   }
 }
 
@@ -1030,6 +1089,7 @@ function createLitzJsonResponse(
   status: number,
   body: Record<string, unknown>,
   headers?: Headers,
+  dataSerializer = jsonDataSerializer,
 ): Response {
   const responseHeaders = new Headers(headers);
 
@@ -1038,17 +1098,22 @@ function createLitzJsonResponse(
   }
 
   responseHeaders.set("content-type", "application/vnd.litzjs.result+json");
-  return new Response(JSON.stringify(body), {
+  return new Response(dataSerializer.stringify(body), {
     status,
     headers: responseHeaders,
   });
 }
 
-function createUnhandledFaultResponse(): Response {
-  return createLitzJsonResponse(500, {
-    kind: "fault",
-    message: "Internal server error.",
-  });
+function createUnhandledFaultResponse(dataSerializer = jsonDataSerializer): Response {
+  return createLitzJsonResponse(
+    500,
+    {
+      kind: "fault",
+      message: "Internal server error.",
+    },
+    undefined,
+    dataSerializer,
+  );
 }
 
 function createBadRequestResponse(): Response {

--- a/tests/client-wildcard-route-runtime.test.tsx
+++ b/tests/client-wildcard-route-runtime.test.tsx
@@ -332,6 +332,44 @@ describe("client wildcard route runtime", () => {
     expect(result.data).toEqual({ count: 9007199254740993n });
   });
 
+  test("mountApp with an app that has no serializer preserves a serializer configured by configureClientRuntime", async () => {
+    clientModule = await import("../src/client/index");
+    const { parseLoaderResponse } = await import("../src/client/transport");
+    const app = defineApp({
+      routes: [projectRoute],
+    });
+
+    clientModule.configureClientRuntime({ dataSerializer: bigintSerializer });
+
+    await act(async () => {
+      clientModule?.mountApp(container!, { app });
+      await flushApp();
+    });
+
+    const result = await parseLoaderResponse(
+      new Response(
+        bigintSerializer.stringify({
+          kind: "data",
+          data: { count: 9007199254740995n },
+        }),
+        {
+          headers: {
+            "content-type": "application/vnd.litzjs.result+json",
+          },
+        },
+      ),
+    );
+
+    expect(Object.prototype.hasOwnProperty.call(app, "dataSerializer")).toBe(false);
+    expect(result.kind).toBe("data");
+
+    if (result.kind !== "data") {
+      throw new Error("Expected data result.");
+    }
+
+    expect(result.data).toEqual({ count: 9007199254740995n });
+  });
+
   test("renders a managed route fault when a lazy route module rejects during navigation", async () => {
     loadBrokenRoute.mockImplementationOnce(async () => Promise.reject(new Error("Chunk 404")));
     clientModule = await import("../src/client/index");

--- a/tests/client-wildcard-route-runtime.test.tsx
+++ b/tests/client-wildcard-route-runtime.test.tsx
@@ -50,6 +50,29 @@ const submitRoute = defineRoute("/submit/:id", {
 const loadSubmitRoute = mock(async () => ({
   route: submitRoute,
 }));
+const bigintSerializer = {
+  stringify(value: unknown): string {
+    return JSON.stringify(value, (_key, nestedValue) =>
+      typeof nestedValue === "bigint"
+        ? { __litzjsTestBigInt: nestedValue.toString() }
+        : nestedValue,
+    );
+  },
+  parse(text: string): unknown {
+    return JSON.parse(text, (_key, nestedValue) => {
+      if (
+        nestedValue &&
+        typeof nestedValue === "object" &&
+        "__litzjsTestBigInt" in nestedValue &&
+        typeof nestedValue.__litzjsTestBigInt === "string"
+      ) {
+        return BigInt(nestedValue.__litzjsTestBigInt);
+      }
+
+      return nestedValue;
+    }) as unknown;
+  },
+};
 
 function HomeRoute(): React.ReactElement {
   if (!clientModule) {
@@ -218,7 +241,7 @@ describe("client wildcard route runtime", () => {
   });
 
   afterEach(() => {
-    clientModule?.configureClientRuntime({ baseUrl: undefined });
+    clientModule?.configureClientRuntime({ baseUrl: undefined, dataSerializer: undefined });
     globalThis.fetch = originalFetch;
     container?.remove();
     cleanupDom?.();
@@ -273,6 +296,40 @@ describe("client wildcard route runtime", () => {
       "wildcard-route",
     );
     expect(loadDocsRoute).toHaveBeenCalledTimes(1);
+  });
+
+  test("mountApp without an app preserves a serializer configured by configureClientRuntime", async () => {
+    clientModule = await import("../src/client/index");
+    const { parseLoaderResponse } = await import("../src/client/transport");
+
+    clientModule.configureClientRuntime({ dataSerializer: bigintSerializer });
+
+    await act(async () => {
+      clientModule?.mountApp(container!);
+      await flushApp();
+    });
+
+    const result = await parseLoaderResponse(
+      new Response(
+        bigintSerializer.stringify({
+          kind: "data",
+          data: { count: 9007199254740993n },
+        }),
+        {
+          headers: {
+            "content-type": "application/vnd.litzjs.result+json",
+          },
+        },
+      ),
+    );
+
+    expect(result.kind).toBe("data");
+
+    if (result.kind !== "data") {
+      throw new Error("Expected data result.");
+    }
+
+    expect(result.data).toEqual({ count: 9007199254740993n });
   });
 
   test("renders a managed route fault when a lazy route module rejects during navigation", async () => {

--- a/tests/docs-package-names.test.ts
+++ b/tests/docs-package-names.test.ts
@@ -303,6 +303,7 @@ describe("docs package names", () => {
       "fault",
       "formJson",
       "invalid",
+      "jsonDataSerializer",
       "redirect",
       "server",
       "useLocation",

--- a/tests/explicit-app-registration.test.ts
+++ b/tests/explicit-app-registration.test.ts
@@ -4,6 +4,30 @@ import { data, defineApiRoute, defineApp, defineResource, defineRoute, server } 
 import { __withLitzRuntimeOptions, createServer } from "../src/server";
 import { createInternalActionRequestInit } from "../src/server/internal-requests";
 
+const bigintSerializer = {
+  stringify(value: unknown): string {
+    return JSON.stringify(value, (_key, nestedValue) =>
+      typeof nestedValue === "bigint"
+        ? { __litzjsTestBigInt: nestedValue.toString() }
+        : nestedValue,
+    );
+  },
+  parse(text: string): unknown {
+    return JSON.parse(text, (_key, nestedValue) => {
+      if (
+        nestedValue &&
+        typeof nestedValue === "object" &&
+        "__litzjsTestBigInt" in nestedValue &&
+        typeof nestedValue.__litzjsTestBigInt === "string"
+      ) {
+        return BigInt(nestedValue.__litzjsTestBigInt);
+      }
+
+      return nestedValue;
+    }) as unknown;
+  },
+};
+
 describe("explicit app registration", () => {
   test("createServer dispatches routes, resources, and API routes from a Litz app", async () => {
     const route = defineRoute("/projects/:id", {
@@ -79,6 +103,164 @@ describe("explicit app registration", () => {
     });
     expect(apiResponse.status).toBe(200);
     expect(await apiResponse.json()).toEqual({ ok: true });
+  });
+
+  test("custom data serializer round-trips route loader and action data", async () => {
+    const route = defineRoute("/counter", {
+      component() {
+        return null;
+      },
+      loader: server(() => data({ count: 9007199254740993n })),
+      action: server(() => data({ count: 9007199254740995n })),
+    });
+    const app = defineApp({
+      dataSerializer: bigintSerializer,
+      routes: [route],
+    });
+    const litzServer = createServer({ app });
+
+    const loaderRequest = createInternalActionRequestInit({
+      path: "/counter",
+      operation: "loader",
+    });
+    const loaderResponse = await litzServer.fetch(
+      new Request("https://example.com/_litzjs/route", {
+        body: loaderRequest.body,
+        headers: loaderRequest.headers,
+        method: "POST",
+      }),
+    );
+    const actionRequest = createInternalActionRequestInit({
+      path: "/counter",
+      operation: "action",
+    });
+    const actionResponse = await litzServer.fetch(
+      new Request("https://example.com/_litzjs/action", {
+        body: actionRequest.body,
+        headers: actionRequest.headers,
+        method: "POST",
+      }),
+    );
+
+    expect(bigintSerializer.parse(await loaderResponse.text())).toEqual({
+      kind: "data",
+      data: { count: 9007199254740993n },
+      revalidate: [],
+    });
+    expect(bigintSerializer.parse(await actionResponse.text())).toEqual({
+      kind: "data",
+      data: { count: 9007199254740995n },
+      revalidate: [],
+    });
+  });
+
+  test("custom data serializer round-trips resource loader and action data", async () => {
+    const resource = defineResource("/resources/counter", {
+      component() {
+        return null;
+      },
+      loader: server(() => data({ count: 9007199254740997n })),
+      action: server(() => data({ count: 9007199254740999n })),
+    });
+    const app = defineApp({
+      dataSerializer: bigintSerializer,
+      resources: [resource],
+    });
+    const litzServer = createServer({ app });
+
+    const loaderRequest = createInternalActionRequestInit({
+      path: "/resources/counter",
+      operation: "loader",
+    });
+    const loaderResponse = await litzServer.fetch(
+      new Request("https://example.com/_litzjs/resource", {
+        body: loaderRequest.body,
+        headers: loaderRequest.headers,
+        method: "POST",
+      }),
+    );
+    const actionRequest = createInternalActionRequestInit({
+      path: "/resources/counter",
+      operation: "action",
+    });
+    const actionResponse = await litzServer.fetch(
+      new Request("https://example.com/_litzjs/resource", {
+        body: actionRequest.body,
+        headers: actionRequest.headers,
+        method: "POST",
+      }),
+    );
+
+    expect(bigintSerializer.parse(await loaderResponse.text())).toEqual({
+      kind: "data",
+      data: { count: 9007199254740997n },
+      revalidate: [],
+    });
+    expect(bigintSerializer.parse(await actionResponse.text())).toEqual({
+      kind: "data",
+      data: { count: 9007199254740999n },
+      revalidate: [],
+    });
+  });
+
+  test("custom data serializer round-trips batched route loader data", async () => {
+    const litzServer = createServer({
+      dataSerializer: bigintSerializer,
+      manifest: {
+        routes: [
+          {
+            id: "dashboard.route",
+            path: "/dashboard",
+            route: {
+              options: {
+                layout: {
+                  id: "dashboard.layout",
+                  path: "/dashboard",
+                  options: {
+                    loader: async () => data({ count: 9007199254741001n }),
+                  },
+                },
+                loader: async () => data({ count: 9007199254741003n }),
+              },
+            },
+          },
+        ],
+      },
+    });
+    const batchRequest = createInternalActionRequestInit({
+      path: "/dashboard",
+      operation: "loader",
+      targets: ["dashboard.route", "dashboard.layout"],
+    });
+    const response = await litzServer.fetch(
+      new Request("https://example.com/_litzjs/route", {
+        body: batchRequest.body,
+        headers: batchRequest.headers,
+        method: "POST",
+      }),
+    );
+
+    expect(bigintSerializer.parse(await response.text())).toEqual({
+      kind: "batch",
+      results: [
+        {
+          status: 200,
+          body: {
+            kind: "data",
+            data: { count: 9007199254741003n },
+            revalidate: [],
+          },
+        },
+        {
+          status: 200,
+          body: {
+            kind: "data",
+            data: { count: 9007199254741001n },
+            revalidate: [],
+          },
+        },
+      ],
+    });
   });
 
   test("defineApp rejects duplicate registrations by path", () => {

--- a/tests/transport-security.test.ts
+++ b/tests/transport-security.test.ts
@@ -1,6 +1,48 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 
 import { createPublicResultHeaders } from "../src/client/result-headers";
+import {
+  configureDataSerializer,
+  parseActionResponse,
+  parseLoaderBatchResponse,
+  parseLoaderResponse,
+} from "../src/client/transport";
+
+const bigintSerializer = {
+  stringify(value: unknown): string {
+    return JSON.stringify(value, (_key, nestedValue) =>
+      typeof nestedValue === "bigint"
+        ? { __litzjsTestBigInt: nestedValue.toString() }
+        : nestedValue,
+    );
+  },
+  parse(text: string): unknown {
+    return JSON.parse(text, (_key, nestedValue) => {
+      if (
+        nestedValue &&
+        typeof nestedValue === "object" &&
+        "__litzjsTestBigInt" in nestedValue &&
+        typeof nestedValue.__litzjsTestBigInt === "string"
+      ) {
+        return BigInt(nestedValue.__litzjsTestBigInt);
+      }
+
+      return nestedValue;
+    }) as unknown;
+  },
+};
+
+function createTransportResponse(body: unknown): Response {
+  return new Response(bigintSerializer.stringify(body), {
+    headers: {
+      "content-type": "application/vnd.litzjs.result+json",
+    },
+  });
+}
+
+afterEach(() => {
+  configureDataSerializer(undefined);
+});
 
 describe("transport security", () => {
   test("does not expose arbitrary server headers to client hooks", async () => {
@@ -22,5 +64,92 @@ describe("transport security", () => {
     expect(result.get("x-litzjs-secret")).toBeNull();
     expect(result.get("authorization")).toBeNull();
     expect(result.get("x-internal-token")).toBeNull();
+  });
+
+  test("uses the configured serializer for loader data responses", async () => {
+    configureDataSerializer(bigintSerializer);
+
+    const result = await parseLoaderResponse(
+      createTransportResponse({
+        kind: "data",
+        data: { count: 9007199254740993n },
+      }),
+    );
+
+    expect(result.kind).toBe("data");
+    if (result.kind !== "data") {
+      throw new Error("Expected data result.");
+    }
+    expect(result.data).toEqual({ count: 9007199254740993n });
+  });
+
+  test("uses the configured serializer for action data responses", async () => {
+    configureDataSerializer(bigintSerializer);
+
+    const result = await parseActionResponse(
+      createTransportResponse({
+        kind: "data",
+        data: { count: 9007199254740995n },
+      }),
+    );
+
+    expect(result?.kind).toBe("data");
+    if (result?.kind !== "data") {
+      throw new Error("Expected data result.");
+    }
+    expect(result.data).toEqual({ count: 9007199254740995n });
+  });
+
+  test("uses the configured serializer for batched loader data responses", async () => {
+    configureDataSerializer(bigintSerializer);
+
+    const [result] = await parseLoaderBatchResponse(
+      createTransportResponse({
+        kind: "batch",
+        results: [
+          {
+            status: 200,
+            body: {
+              kind: "data",
+              data: { count: 9007199254740997n },
+            },
+          },
+        ],
+      }),
+    );
+
+    expect(result?.status).toBe("fulfilled");
+
+    if (result?.status !== "fulfilled") {
+      throw new Error("Expected fulfilled batch result.");
+    }
+
+    expect(result.value.kind).toBe("data");
+    if (result.value.kind !== "data") {
+      throw new Error("Expected data result.");
+    }
+    expect(result.value.data).toEqual({ count: 9007199254740997n });
+  });
+
+  test("keeps JSON as the default data serializer", async () => {
+    const result = await parseLoaderResponse(
+      new Response(
+        JSON.stringify({
+          kind: "data",
+          data: { count: 1 },
+        }),
+        {
+          headers: {
+            "content-type": "application/vnd.litzjs.result+json",
+          },
+        },
+      ),
+    );
+
+    expect(result.kind).toBe("data");
+    if (result.kind !== "data") {
+      throw new Error("Expected data result.");
+    }
+    expect(result.data).toEqual({ count: 1 });
   });
 });

--- a/www/src/routes/docs/api-reference.tsx
+++ b/www/src/routes/docs/api-reference.tsx
@@ -182,6 +182,15 @@ const response = await api.fetch({
         ],
       },
       {
+        name: "jsonDataSerializer",
+        signature: `const jsonDataSerializer: DataSerializer`,
+        summary:
+          "The default `data(...)` transport serializer, backed by `JSON.stringify` and `JSON.parse`.",
+        details: [
+          "Use it when composing a custom serializer that should delegate unsupported values back to Litz's default JSON behavior.",
+        ],
+      },
+      {
         name: "view",
         signature: `view<TNode extends React.ReactNode>(node: TNode, options?: { headers?: HeadersInit; revalidate?: string[] }): ViewResult<TNode>`,
         summary: "Returns a rendered React node payload instead of JSON data.",

--- a/www/src/routes/docs/api-reference.tsx
+++ b/www/src/routes/docs/api-reference.tsx
@@ -34,12 +34,13 @@ const litzCoreGroups: readonly ReferenceGroupSpec[] = [
     entries: [
       {
         name: "defineApp",
-        signature: `defineApp({ routes, resources, apiRoutes, clientLoading }): LitzApp`,
+        signature: `defineApp({ routes, resources, apiRoutes, clientLoading, dataSerializer }): LitzApp`,
         summary:
           "Registers the routes, resources, and API routes that participate in the application.",
         details: [
           "Registration is explicit: importing a file does not enroll it unless the exported definition is included in `defineApp(...)`.",
           '`clientLoading` defaults to `"lazy"` and can be overridden on route, layout, and resource definitions.',
+          "`dataSerializer` customizes the `data(...)` transport for route loaders/actions, resources, and batched loader responses. It does not apply to `view(...)` Flight responses.",
         ],
         example: {
           language: "ts",
@@ -177,6 +178,7 @@ const response = await api.fetch({
         summary: "Returns structured data for loaders or actions.",
         details: [
           "`revalidate` lets an action trigger route or resource reloads after the result settles.",
+          "`defineApp({ dataSerializer })` can customize transport encoding for the payload value while preserving the result envelope.",
         ],
       },
       {
@@ -1013,8 +1015,12 @@ const serverGroups: readonly ReferenceGroupSpec[] = [
   document?: Response | string | ((request: Request) => Promise<Response | string | null | undefined> | Response | string | null | undefined);
   notFound?: Response | string | ((request: Request) => Promise<Response | string | null | undefined> | Response | string | null | undefined);
   assets?: (request: Request) => Promise<Response | null | undefined> | Response | null | undefined;
+  dataSerializer?: DataSerializer;
 };`,
         summary: "Options accepted by `createServer(...)`.",
+        details: [
+          "`dataSerializer` is a server-only escape hatch. Prefer `defineApp({ dataSerializer })` when the same app is passed to `createServer` and `mountApp`.",
+        ],
       },
       {
         name: "createServer",


### PR DESCRIPTION
## Summary

Closes #169.

Adds a public `DataSerializer` contract for customizing the Litz `data(...)` result transport while keeping JSON as the default. The serializer can be configured on `defineApp({ dataSerializer })`, and `createServer({ dataSerializer })` is also available as a server-side escape hatch for direct manifest/server setups.

## What changed

- Added `DataSerializer` and default JSON serializer exports.
- Wired custom serialization through server-side route loader/action, resource loader/action, and batched route loader result envelopes.
- Wired client transport parsing through the configured serializer so existing hooks receive decoded values.
- Preserved `view(...)` / Flight responses outside the JSON result serializer path.
- Documented the serializer API in the README and API reference.
- Added a minor changeset.

## Root cause

Litz previously stringified every result envelope with `JSON.stringify(...)` and parsed every client payload with `JSON.parse(...)`, which meant non-JSON-native values such as `BigInt` could not round-trip across the data boundary.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun lint`
- `bun typecheck`
- `bun test`
- `bun run build`
