### PR TITLE
[codex] Fix batched route loader partial failures

### DIFF
--- a/.changeset/partial-loader-batches.md
+++ b/.changeset/partial-loader-batches.md
@@ -1,0 +1,5 @@
+---
+"litzjs": patch
+---
+
+Avoid rerunning successful sibling route loaders when a batched loader request partially fails.

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -577,7 +577,7 @@ async function handleRouteRequest<TContext>(
         batchTargets.push(batchTarget);
       }
 
-      const batchResults = await Promise.all(
+      const batchResults = await Promise.allSettled(
         batchTargets.map((batchTarget) =>
           executeRouteTarget({
             route,
@@ -593,19 +593,9 @@ async function handleRouteRequest<TContext>(
       const results: BatchedLoaderResponseEntry[] = [];
 
       for (const batchResult of batchResults) {
-        const serializedResult = createBatchedLoaderResponseEntry(batchResult);
-
-        if (!serializedResult) {
-          return createLitzJsonResponse(
-            409,
-            {
-              kind: "fault",
-              message: "Batched route loaders do not support view results.",
-            },
-            undefined,
-            dataSerializer,
-          );
-        }
+        const serializedResult = createSettledBatchedLoaderResponseEntry(batchResult, (error) =>
+          reportError?.(error, getLoadedContext?.()),
+        );
 
         results.push(serializedResult);
       }
@@ -956,6 +946,42 @@ function createBatchedLoaderResponseEntry(result: unknown): BatchedLoaderRespons
         },
       };
   }
+}
+
+function createSettledBatchedLoaderResponseEntry(
+  result: PromiseSettledResult<unknown>,
+  reportError?: (error: unknown) => void,
+): BatchedLoaderResponseEntry {
+  if (result.status === "rejected") {
+    if (isServerResultLike(result.reason)) {
+      return createBatchedLoaderResponseEntry(result.reason) ?? createUnsupportedViewBatchFault();
+    }
+
+    reportError?.(result.reason);
+    return createUnhandledBatchedLoaderFault();
+  }
+
+  return createBatchedLoaderResponseEntry(result.value) ?? createUnsupportedViewBatchFault();
+}
+
+function createUnsupportedViewBatchFault(): BatchedLoaderResponseEntry {
+  return {
+    status: 409,
+    body: {
+      kind: "fault",
+      message: "Batched route loaders do not support view results.",
+    },
+  };
+}
+
+function createUnhandledBatchedLoaderFault(): BatchedLoaderResponseEntry {
+  return {
+    status: 500,
+    body: {
+      kind: "fault",
+      message: "Internal server error.",
+    },
+  };
 }
 
 async function createServerResultResponse(

--- a/src/vite/dev-middleware.ts
+++ b/src/vite/dev-middleware.ts
@@ -1215,7 +1215,7 @@ function createUnhandledBatchedLoaderFault(): BatchedLoaderResponseEntry {
     status: 500,
     body: {
       kind: "fault",
-      message: "Route request failed.",
+      message: "Internal server error.",
     },
   };
 }

--- a/src/vite/dev-middleware.ts
+++ b/src/vite/dev-middleware.ts
@@ -338,7 +338,7 @@ export async function handleLitzRouteRequest(
         batchTargets.push(batchTarget);
       }
 
-      const batchResults = await Promise.all(
+      const batchResults = await Promise.allSettled(
         batchTargets.map((batchTarget) =>
           executeDevRouteTarget({
             route,
@@ -353,15 +353,7 @@ export async function handleLitzRouteRequest(
       const results: BatchedLoaderResponseEntry[] = [];
 
       for (const batchResult of batchResults) {
-        const serializedResult = createDevBatchedLoaderResponseEntry(batchResult);
-
-        if (!serializedResult) {
-          sendLitzJson(response, 409, {
-            kind: "fault",
-            message: "Batched route loaders do not support view results.",
-          });
-          return;
-        }
+        const serializedResult = createSettledDevBatchedLoaderResponseEntry(server, batchResult);
 
         results.push(serializedResult);
       }
@@ -1187,6 +1179,45 @@ function createDevBatchedLoaderResponseEntry(result: unknown): BatchedLoaderResp
         },
       };
   }
+}
+
+function createSettledDevBatchedLoaderResponseEntry(
+  server: ViteDevServer,
+  result: PromiseSettledResult<unknown>,
+): BatchedLoaderResponseEntry {
+  if (result.status === "rejected") {
+    if (isServerResultLike(result.reason)) {
+      return (
+        createDevBatchedLoaderResponseEntry(result.reason) ?? createUnsupportedViewBatchFault()
+      );
+    }
+
+    server.ssrFixStacktrace(result.reason as Error);
+    console.error(result.reason);
+    return createUnhandledBatchedLoaderFault();
+  }
+
+  return createDevBatchedLoaderResponseEntry(result.value) ?? createUnsupportedViewBatchFault();
+}
+
+function createUnsupportedViewBatchFault(): BatchedLoaderResponseEntry {
+  return {
+    status: 409,
+    body: {
+      kind: "fault",
+      message: "Batched route loaders do not support view results.",
+    },
+  };
+}
+
+function createUnhandledBatchedLoaderFault(): BatchedLoaderResponseEntry {
+  return {
+    status: 500,
+    body: {
+      kind: "fault",
+      message: "Route request failed.",
+    },
+  };
 }
 
 /**

--- a/tests/server-security.test.ts
+++ b/tests/server-security.test.ts
@@ -741,6 +741,101 @@ describe("server security", () => {
     });
   });
 
+  test("serializes partial batched route loader failures without rerunning successful siblings", async () => {
+    let layoutCalls = 0;
+    let routeCalls = 0;
+
+    const server = createServer({
+      manifest: {
+        routes: [
+          {
+            id: "projects.show",
+            path: "/projects/:id",
+            route: {
+              loader() {
+                routeCalls += 1;
+                throw new Error("route loader failed");
+              },
+              options: {
+                layout: {
+                  id: "projects.layout",
+                  path: "/projects",
+                  options: {
+                    loader() {
+                      layoutCalls += 1;
+
+                      return {
+                        kind: "data",
+                        data: {
+                          source: "layout",
+                        },
+                      };
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const response = await server.fetch(
+      new Request("https://app.example.com/_litzjs/route", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          path: "/projects/:id",
+          targets: ["projects.layout", "projects.show"],
+          operation: "loader",
+          request: {
+            params: { id: "42" },
+          },
+        }),
+      }),
+    );
+    const body = (await response.json()) as {
+      kind: "batch";
+      results: Array<{
+        status: number;
+        body: {
+          kind: "data" | "fault";
+          data?: {
+            source: string;
+          };
+          message?: string;
+          revalidate?: string[];
+        };
+      }>;
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.kind).toBe("batch");
+    expect(layoutCalls).toBe(1);
+    expect(routeCalls).toBe(1);
+    expect(body.results).toEqual([
+      {
+        status: 200,
+        body: {
+          kind: "data",
+          data: {
+            source: "layout",
+          },
+          revalidate: [],
+        },
+      },
+      {
+        status: 500,
+        body: {
+          kind: "fault",
+          message: "Internal server error.",
+        },
+      },
+    ]);
+  });
+
   test("executes batched internal route loader requests concurrently", async () => {
     const startedTargets: string[] = [];
     const routeDeferred = createDeferred<string>();


### PR DESCRIPTION
Closes #156.

## What changed

Batched route loader execution now settles each requested target independently in both the production server handler and Vite dev middleware. A failed loader, thrown Litz result, redirect, or unsupported view result is serialized into that target's batch entry instead of aborting the entire batch response.

## Why

The previous `Promise.all` batch flow rejected the whole request when one target failed. The client then fell back to individual loader requests, which could rerun sibling loaders that had already completed successfully. That created duplicate side-effect risk and unnecessary network work.

## Impact

Successful sibling route loaders are no longer retried when another loader in the same batch fails. Production and dev behavior remain aligned, and unexpected server exceptions are still masked as per-target faults while supported route result failures are preserved for the client runtime.

## Validation

- `bun test tests/server-security.test.ts tests/loader-fetch.test.ts`
- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`
- `bun lint`
