### PR TITLE
[codex] Preserve dev API params with base path

### DIFF
--- a/.changeset/dev-api-base-params.md
+++ b/.changeset/dev-api-base-params.md
@@ -1,0 +1,5 @@
+---
+"litzjs": patch
+---
+
+Preserve dynamic API route params for base-prefixed requests in the Vite dev middleware.

--- a/src/vite/dev-middleware.ts
+++ b/src/vite/dev-middleware.ts
@@ -534,7 +534,7 @@ export async function handleLitzApiRequest(
 
     const method = (request.method ?? "GET").toUpperCase() as Exclude<ApiRouteMethod, "ALL">;
     const handler = api?.methods?.[method] ?? api?.methods?.ALL;
-    const matchedParams = matchPathname(matched.path, requestUrl.pathname);
+    const matchedParams = matchPathname(matched.path, pathname);
 
     if (!handler) {
       response.statusCode = 405;

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -1932,6 +1932,40 @@ describe("dev server abort signal lifecycle", () => {
     expect(capturedHref).toBe("http://litzjs.local/app/api/test");
   });
 
+  test("preserves params for base-prefixed dynamic API requests", async () => {
+    let capturedParams: Record<string, string> | undefined;
+    const server = createMockViteDevServer(async () => ({
+      api: {
+        methods: {
+          GET({ params }: { params: Record<string, string> }) {
+            capturedParams = params;
+            return Response.json({ params });
+          },
+        },
+      },
+    }));
+    const request = createMockRequest({
+      url: "/app/api/users/42",
+      method: "GET",
+    });
+    const response = createMockResponse();
+    const next = mock(() => {});
+
+    await handleLitzApiRequest(
+      server,
+      [{ path: "/api/users/:id", modulePath: "src/api/users/[id].ts" }],
+      request,
+      response,
+      next,
+      "/app/",
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(response.getBody()).toBe(JSON.stringify({ params: { id: "42" } }));
+    expect(capturedParams).toEqual({ id: "42" });
+    expect(next).not.toHaveBeenCalled();
+  });
+
   test("rebuilds repeated query params for internal resource requests", async () => {
     let capturedTags: string[] = [];
     let capturedHref = "";


### PR DESCRIPTION
## Summary

Fixes #157.

This updates the Vite dev API middleware so dynamic API route params are extracted from the same base-stripped pathname used for route matching. With `base: "/app/"`, a request like `/app/api/users/42` now matches `/api/users/:id` and passes `{ id: "42" }` to the handler, aligning dev behavior with production.

## Root Cause

The dev middleware stripped the configured Vite base before matching API routes, but then called `matchPathname` against the original request pathname. That meant `/api/users/:id` could match the stripped path while param extraction ran against `/app/api/users/42`, producing `{}`.

## Changes

- Use the base-stripped `pathname` for dev API param extraction.
- Add a regression test for a base-prefixed dynamic API request.
- Add a patch changeset for the bugfix.

## Validation

- `bun test tests/vite.test.ts --test-name-pattern "preserves params for base-prefixed dynamic API requests"`
- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`
