### PR TITLE
[codex] Fix resource action redirects with base paths

### DIFF
--- a/.changeset/resource-action-base-redirects.md
+++ b/.changeset/resource-action-base-redirects.md
@@ -1,0 +1,5 @@
+---
+"litzjs": patch
+---
+
+Apply the configured client base URL to resource action redirects.

--- a/src/client/resources.tsx
+++ b/src/client/resources.tsx
@@ -19,7 +19,7 @@ import {
   type SearchParamRecord,
 } from "../search-params";
 import { isAbortError } from "./abort-error";
-import { resolveClientTransportPath } from "./base-url";
+import { resolveClientHref, resolveClientTransportPath } from "./base-url";
 import { applySearchParams } from "./navigation";
 import { sortRecord } from "./sort-record";
 import {
@@ -903,11 +903,13 @@ function performClientRedirect(href: string, replace: boolean): void {
     return;
   }
 
+  const resolvedHref = resolveClientHref(href);
+
   if (replace) {
-    window.history.replaceState(null, "", href);
+    window.history.replaceState(null, "", resolvedHref);
   } else {
-    window.history.pushState(null, "", href);
+    window.history.pushState(null, "", resolvedHref);
   }
 
-  window.dispatchEvent(new PopStateEvent("popstate"));
+  window.dispatchEvent(new window.PopStateEvent("popstate"));
 }

--- a/tests/resource-runtime.test.tsx
+++ b/tests/resource-runtime.test.tsx
@@ -540,6 +540,55 @@ describe("resource runtime", () => {
     expect(requestUrls).toEqual(["/app/_litzjs/resource"]);
   });
 
+  test("applies the configured client base to resource action redirects", async () => {
+    configureClientBaseUrl("/app/");
+
+    const visitedPaths: string[] = [];
+    window.addEventListener("popstate", () => {
+      visitedPaths.push(
+        `${window.location.pathname}${window.location.search}${window.location.hash}`,
+      );
+    });
+
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      const metadata = headers.get("x-litzjs-request");
+
+      if (metadata) {
+        return Response.json({
+          kind: "redirect",
+          location: "/dashboard?from=resource#stats",
+          replace: false,
+        });
+      }
+
+      return Response.json({
+        kind: "data",
+        data: { id: "user-redirect", count: 1 },
+      });
+    }) as typeof fetch;
+
+    await act(async () => {
+      root?.render(<accountResource.Component params={{ id: "user-redirect" }} />);
+      await flushDom();
+    });
+
+    const button = document.querySelector("button");
+    expect(button).not.toBeNull();
+
+    await act(async () => {
+      (document.querySelector("form") as HTMLFormElement).requestSubmit(
+        button as HTMLButtonElement,
+      );
+      await flushDom();
+    });
+
+    expect(visitedPaths).toEqual(["/app/dashboard?from=resource#stats"]);
+    expect(window.location.pathname).toBe("/app/dashboard");
+    expect(window.location.search).toBe("?from=resource");
+    expect(window.location.hash).toBe("#stats");
+  });
+
   test("resource store preserves entries across unmount/remount cycles", async () => {
     let loaderCalls = 0;
 


### PR DESCRIPTION
## Summary

Fixes #158.

Resource action redirects now resolve their target through the same client href base-path helper used by route navigation before writing to browser history. This applies configured client base URLs to root-relative destinations while preserving the existing push versus replace behavior.

## Root Cause

Resource actions bypassed the normal client navigation path and wrote the raw redirect location directly into `window.history`. With `configureClientBaseUrl("/app/")`, a resource action returning `redirect("/dashboard")` therefore navigated to `/dashboard` instead of `/app/dashboard`.

## Changes

- Resolve resource redirect hrefs with `resolveClientHref(...)` before `pushState` or `replaceState`.
- Dispatch the `popstate` event from `window.PopStateEvent`, matching the browser global and test DOM environment.
- Add a regression test for `configureClientBaseUrl("/app/")` plus a root-relative resource action redirect.
- Add a patch changeset for the bug fix.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun test tests/resource-runtime.test.tsx`
- `bun run test`
- `bun typecheck`
