### PR TITLE
[codex] fix resource action revalidation

### DIFF
--- a/.changeset/resource-action-revalidation.md
+++ b/.changeset/resource-action-revalidation.md
@@ -1,0 +1,5 @@
+---
+"litzjs": patch
+---
+
+Revalidate resource loader data after successful resource actions when submit options or action response headers request it.

--- a/src/client/resources.tsx
+++ b/src/client/resources.tsx
@@ -433,6 +433,10 @@ function useResourceRuntime(resourcePath: string, request?: ResourceRequest): Re
         return;
       }
 
+      if (result.kind === "redirect") {
+        return;
+      }
+
       if (result.kind === "error" || result.kind === "fault") {
         options?.onError?.(result);
         return;

--- a/src/client/resources.tsx
+++ b/src/client/resources.tsx
@@ -25,6 +25,7 @@ import { sortRecord } from "./sort-record";
 import {
   isRedirectSignal,
   isRouteLikeError,
+  getRevalidateTargets,
   parseActionResponse,
   parseLoaderResponse,
 } from "./transport";
@@ -437,9 +438,13 @@ function useResourceRuntime(resourcePath: string, request?: ResourceRequest): Re
         return;
       }
 
+      if (shouldRevalidateResourceAfterSubmit(resourcePath, result.headers, options?.revalidate)) {
+        await reloadImpl("revalidating");
+      }
+
       options?.onSuccess?.(result);
     },
-    [preparedRequest, resourcePath],
+    [preparedRequest, reloadImpl, resourcePath],
   );
 
   const reload = React.useCallback(() => {
@@ -482,6 +487,30 @@ function useResourceRuntime(resourcePath: string, request?: ResourceRequest): Re
       submit,
     ],
   );
+}
+
+function shouldRevalidateResourceAfterSubmit(
+  resourcePath: string,
+  headers: Headers,
+  revalidate: SubmitOptions["revalidate"],
+): boolean {
+  if (revalidate === false) {
+    return false;
+  }
+
+  if (revalidate === true) {
+    return true;
+  }
+
+  const targets = new Set(getRevalidateTargets(headers));
+
+  if (Array.isArray(revalidate)) {
+    for (const target of revalidate) {
+      targets.add(target);
+    }
+  }
+
+  return targets.has(resourcePath);
 }
 
 async function performPreparedResourceRequest(

--- a/tests/resource-runtime.test.tsx
+++ b/tests/resource-runtime.test.tsx
@@ -399,6 +399,221 @@ describe("resource runtime", () => {
     ]);
   });
 
+  test("resource actions honor revalidate: true before calling onSuccess", async () => {
+    const events: string[] = [];
+    let loaderCalls = 0;
+    let actionCalls = 0;
+
+    const revalidateResource = defineResource("/resource/revalidate-true/:id", {
+      component: function RevalidateResource() {
+        const details = revalidateResource.useData() as { count: number } | null;
+        const submit = revalidateResource.useSubmit({
+          revalidate: true,
+          onSuccess() {
+            events.push(
+              `success:${document.querySelector(".revalidate-count")?.getAttribute("data-value")}`,
+            );
+          },
+        });
+
+        return (
+          <section>
+            <div className="revalidate-count" data-value={details?.count ?? -1} />
+            <button
+              type="button"
+              className="revalidate-submit"
+              onClick={() => {
+                void submit({ increment: "1" });
+              }}
+            >
+              Submit
+            </button>
+          </section>
+        );
+      },
+      loader: server(async () => data({ count: 1 })),
+      action: server(async () => data({ count: 2 })),
+    });
+
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+
+      if (headers.has("x-litzjs-request")) {
+        actionCalls += 1;
+        return Response.json({
+          kind: "data",
+          data: { count: 2 },
+        });
+      }
+
+      loaderCalls += 1;
+      return Response.json({
+        kind: "data",
+        data: { count: loaderCalls === 1 ? 1 : 3 },
+      });
+    }) as typeof fetch;
+
+    await act(async () => {
+      root?.render(<revalidateResource.Component params={{ id: "user-true" }} />);
+      await flushDom();
+    });
+
+    await act(async () => {
+      (document.querySelector(".revalidate-submit") as HTMLButtonElement).click();
+      await flushDom();
+    });
+
+    expect(actionCalls).toBe(1);
+    expect(loaderCalls).toBe(2);
+    expect(document.querySelector(".revalidate-count")?.getAttribute("data-value")).toBe("3");
+    expect(events).toEqual(["success:3"]);
+  });
+
+  test("resource actions honor revalidate: false by keeping action data until onSuccess", async () => {
+    const events: string[] = [];
+    let loaderCalls = 0;
+    let actionCalls = 0;
+
+    const revalidateResource = defineResource("/resource/revalidate-false/:id", {
+      component: function RevalidateResource() {
+        const details = revalidateResource.useData() as { count: number } | null;
+        const submit = revalidateResource.useSubmit({
+          revalidate: false,
+          onSuccess() {
+            events.push(
+              `success:${document.querySelector(".revalidate-count")?.getAttribute("data-value")}`,
+            );
+          },
+        });
+
+        return (
+          <section>
+            <div className="revalidate-count" data-value={details?.count ?? -1} />
+            <button
+              type="button"
+              className="revalidate-submit"
+              onClick={() => {
+                void submit({ increment: "1" });
+              }}
+            >
+              Submit
+            </button>
+          </section>
+        );
+      },
+      loader: server(async () => data({ count: 1 })),
+      action: server(async () => data({ count: 2 })),
+    });
+
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+
+      if (headers.has("x-litzjs-request")) {
+        actionCalls += 1;
+        return Response.json(
+          {
+            kind: "data",
+            data: { count: 2 },
+          },
+          {
+            headers: {
+              "x-litzjs-revalidate": "/resource/revalidate-false/:id",
+            },
+          },
+        );
+      }
+
+      loaderCalls += 1;
+      return Response.json({
+        kind: "data",
+        data: { count: loaderCalls === 1 ? 1 : 3 },
+      });
+    }) as typeof fetch;
+
+    await act(async () => {
+      root?.render(<revalidateResource.Component params={{ id: "user-false" }} />);
+      await flushDom();
+    });
+
+    await act(async () => {
+      (document.querySelector(".revalidate-submit") as HTMLButtonElement).click();
+      await flushDom();
+    });
+
+    expect(actionCalls).toBe(1);
+    expect(loaderCalls).toBe(1);
+    expect(document.querySelector(".revalidate-count")?.getAttribute("data-value")).toBe("2");
+    expect(events).toEqual(["success:2"]);
+  });
+
+  test("resource actions revalidate when server targets the resource path", async () => {
+    let loaderCalls = 0;
+    let actionCalls = 0;
+
+    const revalidateResource = defineResource("/resource/revalidate-header/:id", {
+      component: function RevalidateResource() {
+        const details = revalidateResource.useData() as { count: number } | null;
+        const submit = revalidateResource.useSubmit();
+
+        return (
+          <section>
+            <div className="revalidate-count" data-value={details?.count ?? -1} />
+            <button
+              type="button"
+              className="revalidate-submit"
+              onClick={() => {
+                void submit({ increment: "1" });
+              }}
+            >
+              Submit
+            </button>
+          </section>
+        );
+      },
+      loader: server(async () => data({ count: 1 })),
+      action: server(async () => data({ count: 2 })),
+    });
+
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+
+      if (headers.has("x-litzjs-request")) {
+        actionCalls += 1;
+        return Response.json(
+          {
+            kind: "data",
+            data: { count: 2 },
+          },
+          {
+            headers: {
+              "x-litzjs-revalidate": "/resource/other/:id, /resource/revalidate-header/:id",
+            },
+          },
+        );
+      }
+
+      loaderCalls += 1;
+      return Response.json({
+        kind: "data",
+        data: { count: loaderCalls === 1 ? 1 : 3 },
+      });
+    }) as typeof fetch;
+
+    await act(async () => {
+      root?.render(<revalidateResource.Component params={{ id: "user-header" }} />);
+      await flushDom();
+    });
+
+    await act(async () => {
+      (document.querySelector(".revalidate-submit") as HTMLButtonElement).click();
+      await flushDom();
+    });
+
+    expect(actionCalls).toBe(1);
+    expect(loaderCalls).toBe(2);
+    expect(document.querySelector(".revalidate-count")?.getAttribute("data-value")).toBe("3");
+  });
+
   test("resource component cache uses the latest component implementation after HMR", async () => {
     globalThis.fetch = (async () =>
       Response.json({

--- a/tests/resource-runtime.test.tsx
+++ b/tests/resource-runtime.test.tsx
@@ -614,6 +614,87 @@ describe("resource runtime", () => {
     expect(document.querySelector(".revalidate-count")?.getAttribute("data-value")).toBe("3");
   });
 
+  test("resource action redirects skip revalidation and success callbacks", async () => {
+    const events: string[] = [];
+    const visitedPaths: string[] = [];
+    let loaderCalls = 0;
+    let actionCalls = 0;
+
+    window.addEventListener("popstate", () => {
+      visitedPaths.push(`${window.location.pathname}${window.location.search}`);
+    });
+
+    const redirectResource = defineResource("/resource/revalidate-redirect/:id", {
+      component: function RedirectResource() {
+        const details = redirectResource.useData() as { count: number } | null;
+        const submit = redirectResource.useSubmit({
+          revalidate: true,
+          onSuccess() {
+            events.push("success");
+          },
+        });
+
+        return (
+          <section>
+            <div className="redirect-count" data-value={details?.count ?? -1} />
+            <button
+              type="button"
+              className="redirect-submit"
+              onClick={() => {
+                void submit({ increment: "1" });
+              }}
+            >
+              Submit
+            </button>
+          </section>
+        );
+      },
+      loader: server(async () => data({ count: 1 })),
+      action: server(async () => data({ count: 2 })),
+    });
+
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+
+      if (headers.has("x-litzjs-request")) {
+        actionCalls += 1;
+        return Response.json(
+          {
+            kind: "redirect",
+            location: "/dashboard?redirected=1",
+            replace: false,
+          },
+          {
+            headers: {
+              "x-litzjs-revalidate": "/resource/revalidate-redirect/:id",
+            },
+          },
+        );
+      }
+
+      loaderCalls += 1;
+      return Response.json({
+        kind: "data",
+        data: { count: loaderCalls === 1 ? 1 : 3 },
+      });
+    }) as typeof fetch;
+
+    await act(async () => {
+      root?.render(<redirectResource.Component params={{ id: "user-redirect" }} />);
+      await flushDom();
+    });
+
+    await act(async () => {
+      (document.querySelector(".redirect-submit") as HTMLButtonElement).click();
+      await flushDom();
+    });
+
+    expect(actionCalls).toBe(1);
+    expect(loaderCalls).toBe(1);
+    expect(events).toEqual([]);
+    expect(visitedPaths).toEqual(["/dashboard?redirected=1"]);
+  });
+
   test("resource component cache uses the latest component implementation after HMR", async () => {
     globalThis.fetch = (async () =>
       Response.json({


### PR DESCRIPTION
Closes #159.

## What changed

Resource action submits now evaluate `SubmitOptions.revalidate` and `x-litzjs-revalidate` response headers after successful action results. When revalidation is requested for the active resource, the resource loader is reloaded in `revalidating` mode before `onSuccess` runs.

## Why

Route actions already supported this flow, but resource actions returned success immediately after mutations. That meant resource components could keep stale loader data even when callers passed `revalidate: true` or the server result targeted the resource for revalidation.

## Impact

Resource-backed mutations now keep loader data fresh consistently with route submits. `revalidate: false` still suppresses reloads, including when the server sends revalidation targets, and errors continue to call `onError` without triggering loader revalidation.

## Validation

- `bun test tests/resource-runtime.test.tsx`
- `bun fmt`
- `bun lint:fix`
- `bun lint`
- `bun typecheck`
- `bun run test`

## Changeset

Included `.changeset/resource-action-revalidation.md` as a patch release note.
