### PR TITLE
fix: add API HEAD fallback and Allow headers

### DIFF
--- a/.changeset/head-api-allow-headers.md
+++ b/.changeset/head-api-allow-headers.md
@@ -1,0 +1,5 @@
+---
+"litzjs": patch
+---
+
+Add HEAD fallback for API GET handlers and include Allow headers on method-not-allowed responses.

--- a/src/http-methods.ts
+++ b/src/http-methods.ts
@@ -1,0 +1,18 @@
+export function createAllowedMethodsHeader(
+  methods: Partial<Record<string, unknown>> | undefined,
+): string | undefined {
+  if (!methods) {
+    return undefined;
+  }
+
+  const allowed = Object.keys(methods)
+    .filter((method) => method !== "ALL")
+    .sort();
+
+  if (methods.GET && !methods.HEAD) {
+    allowed.push("HEAD");
+    allowed.sort();
+  }
+
+  return allowed.length > 0 ? allowed.join(", ") : undefined;
+}

--- a/src/response-body.ts
+++ b/src/response-body.ts
@@ -1,0 +1,7 @@
+export function cancelResponseBody(response: Response): void {
+  try {
+    void response.body?.cancel();
+  } catch {
+    // The stream may already be locked by another reader.
+  }
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -396,6 +396,25 @@ function toHeadResponseIfNeeded(request: Request, response: Response): Response 
   });
 }
 
+function createAllowedMethodsHeader(
+  methods: Partial<Record<ApiRouteMethod, unknown>> | undefined,
+): string | undefined {
+  if (!methods) {
+    return undefined;
+  }
+
+  const allowed = Object.keys(methods)
+    .filter((method) => method !== "ALL")
+    .sort();
+
+  if (methods.GET && !methods.HEAD) {
+    allowed.push("HEAD");
+    allowed.sort();
+  }
+
+  return allowed.length > 0 ? allowed.join(", ") : undefined;
+}
+
 async function handleResourceRequest<TContext>(
   request: Request,
   resources: ResourceModule[],
@@ -409,7 +428,12 @@ async function handleResourceRequest<TContext>(
 
   try {
     if (request.method !== "POST") {
-      return new Response("Method Not Allowed", { status: 405 });
+      return new Response("Method Not Allowed", {
+        status: 405,
+        headers: {
+          allow: "POST",
+        },
+      });
     }
 
     const body = await parseInternalRequestBody(request);
@@ -514,7 +538,12 @@ async function handleRouteRequest<TContext>(
 
   try {
     if (request.method !== "POST") {
-      return new Response("Method Not Allowed", { status: 405 });
+      return new Response("Method Not Allowed", {
+        status: 405,
+        headers: {
+          allow: "POST",
+        },
+      });
     }
 
     const body = await parseInternalRequestBody(request);
@@ -674,17 +703,29 @@ async function handleApiRequest<TContext>(
     }
 
     const method = request.method.toUpperCase() as Exclude<ApiRouteMethod, "ALL">;
-    const handler = matched.entry.api.methods[method] ?? matched.entry.api.methods.ALL;
+    const handler =
+      matched.entry.api.methods[method] ??
+      (method === "HEAD" ? matched.entry.api.methods.GET : undefined) ??
+      matched.entry.api.methods.ALL;
     const middleware = matched.entry.api.middleware ?? [];
 
     if (!handler) {
-      return new Response("Method Not Allowed", { status: 405 });
+      const allow = createAllowedMethodsHeader(matched.entry.api.methods);
+
+      return new Response("Method Not Allowed", {
+        status: 405,
+        headers: allow
+          ? {
+              allow,
+            }
+          : undefined,
+      });
     }
 
     const signal = request.signal;
     const context = await getContext();
 
-    return await runMiddlewareChain({
+    const response = await runMiddlewareChain({
       middleware,
       request,
       params,
@@ -708,13 +749,15 @@ async function handleApiRequest<TContext>(
         });
       },
     });
+
+    return toHeadResponseIfNeeded(request, response);
   } catch (error) {
     if (error instanceof Response) {
-      return error;
+      return toHeadResponseIfNeeded(request, error);
     }
 
     if (isServerResultLike(error)) {
-      return createApiResponseFromResult(error);
+      return toHeadResponseIfNeeded(request, createApiResponseFromResult(error));
     }
 
     throw error;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2,6 +2,7 @@ import type { ApiRouteMethod, LitzApp } from "../index";
 
 import { normalizeBasePath, resolveBasePathname } from "../base-path";
 import { jsonDataSerializer, type DataSerializer } from "../data-serializer";
+import { createAllowedMethodsHeader } from "../http-methods";
 import {
   createBodylessResponse,
   createApiResponseFromResult,
@@ -18,6 +19,7 @@ import {
   sortByPathSpecificity,
   trimPathSegments,
 } from "../path-matching";
+import { cancelResponseBody } from "../response-body";
 import { createSearchParams, type SearchParamRecord } from "../search-params";
 import { parseInternalRequestBody, type InternalRequestBody } from "./internal-requests";
 import { createInternalHandlerHeaders } from "./request-headers";
@@ -389,30 +391,13 @@ function toHeadResponseIfNeeded(request: Request, response: Response): Response 
     return response;
   }
 
+  cancelResponseBody(response);
+
   return new Response(null, {
     status: response.status,
     statusText: response.statusText,
     headers: response.headers,
   });
-}
-
-function createAllowedMethodsHeader(
-  methods: Partial<Record<ApiRouteMethod, unknown>> | undefined,
-): string | undefined {
-  if (!methods) {
-    return undefined;
-  }
-
-  const allowed = Object.keys(methods)
-    .filter((method) => method !== "ALL")
-    .sort();
-
-  if (methods.GET && !methods.HEAD) {
-    allowed.push("HEAD");
-    allowed.sort();
-  }
-
-  return allowed.length > 0 ? allowed.join(", ") : undefined;
 }
 
 async function handleResourceRequest<TContext>(

--- a/src/vite/dev-middleware.ts
+++ b/src/vite/dev-middleware.ts
@@ -101,6 +101,7 @@ export async function handleLitzResourceRequest(
 
   if (request.method !== "POST") {
     response.statusCode = 405;
+    response.setHeader("allow", "POST");
     response.end("Method Not Allowed");
     return;
   }
@@ -228,6 +229,7 @@ export async function handleLitzRouteRequest(
 
   if (request.method !== "POST") {
     response.statusCode = 405;
+    response.setHeader("allow", "POST");
     response.end("Method Not Allowed");
     return;
   }
@@ -533,11 +535,20 @@ export async function handleLitzApiRequest(
     const api = module.api;
 
     const method = (request.method ?? "GET").toUpperCase() as Exclude<ApiRouteMethod, "ALL">;
-    const handler = api?.methods?.[method] ?? api?.methods?.ALL;
+    const handler =
+      api?.methods?.[method] ??
+      (method === "HEAD" ? api?.methods?.GET : undefined) ??
+      api?.methods?.ALL;
     const matchedParams = matchPathname(matched.path, pathname);
 
     if (!handler) {
       response.statusCode = 405;
+      const allow = createAllowedMethodsHeader(api?.methods);
+
+      if (allow) {
+        response.setHeader("allow", allow);
+      }
+
       response.end("Method Not Allowed");
       return;
     }
@@ -572,15 +583,19 @@ export async function handleLitzApiRequest(
       },
     });
 
-    await writeFetchResponseToNode(response, apiResponse);
+    await writeFetchResponseToNode(response, apiResponse, request.method === "HEAD");
   } catch (error) {
     if (error instanceof Response) {
-      await writeFetchResponseToNode(response, error);
+      await writeFetchResponseToNode(response, error, request.method === "HEAD");
       return;
     }
 
     if (isServerResultLike(error)) {
-      await writeFetchResponseToNode(response, createApiResponseFromResult(error));
+      await writeFetchResponseToNode(
+        response,
+        createApiResponseFromResult(error),
+        request.method === "HEAD",
+      );
       return;
     }
 
@@ -873,6 +888,7 @@ function applyRevalidateHeader(response: ServerResponse, revalidate?: string[]):
 async function writeFetchResponseToNode(
   response: ServerResponse,
   fetchResponse: Response,
+  omitBody = false,
 ): Promise<void> {
   response.statusCode = fetchResponse.status;
 
@@ -880,7 +896,7 @@ async function writeFetchResponseToNode(
     response.setHeader(key, value);
   });
 
-  if (!fetchResponse.body) {
+  if (omitBody || !fetchResponse.body) {
     response.end();
     return;
   }
@@ -898,6 +914,25 @@ async function writeFetchResponseToNode(
   }
 
   response.end();
+}
+
+function createAllowedMethodsHeader(
+  methods: Partial<Record<ApiRouteMethod, unknown>> | undefined,
+): string | undefined {
+  if (!methods) {
+    return undefined;
+  }
+
+  const allowed = Object.keys(methods)
+    .filter((method) => method !== "ALL")
+    .sort();
+
+  if (methods.GET && !methods.HEAD) {
+    allowed.push("HEAD");
+    allowed.sort();
+  }
+
+  return allowed.length > 0 ? allowed.join(", ") : undefined;
 }
 
 // ── Path & Route Matching ────────────────────────────────────────────────────

--- a/src/vite/dev-middleware.ts
+++ b/src/vite/dev-middleware.ts
@@ -9,6 +9,7 @@ import type { ApiRouteMethod } from "../index";
 import type { DiscoveredApiRoute, DiscoveredResource, DiscoveredRoute } from "./types";
 
 import { resolveBasePathname } from "../base-path";
+import { createAllowedMethodsHeader } from "../http-methods";
 import {
   createApiResponseFromResult,
   isBodyForbiddenStatus,
@@ -22,6 +23,7 @@ import {
   interpolatePath,
   matchPathname,
 } from "../path-matching";
+import { cancelResponseBody } from "../response-body";
 import { createSearchParams, type SearchParamRecord } from "../search-params";
 import { parseInternalRequestBody, type InternalRequestBody } from "../server/internal-requests";
 import { createInternalHandlerHeaders } from "../server/request-headers";
@@ -896,7 +898,13 @@ async function writeFetchResponseToNode(
     response.setHeader(key, value);
   });
 
-  if (omitBody || !fetchResponse.body) {
+  if (omitBody) {
+    cancelResponseBody(fetchResponse);
+    response.end();
+    return;
+  }
+
+  if (!fetchResponse.body) {
     response.end();
     return;
   }
@@ -914,25 +922,6 @@ async function writeFetchResponseToNode(
   }
 
   response.end();
-}
-
-function createAllowedMethodsHeader(
-  methods: Partial<Record<ApiRouteMethod, unknown>> | undefined,
-): string | undefined {
-  if (!methods) {
-    return undefined;
-  }
-
-  const allowed = Object.keys(methods)
-    .filter((method) => method !== "ALL")
-    .sort();
-
-  if (methods.GET && !methods.HEAD) {
-    allowed.push("HEAD");
-    allowed.sort();
-  }
-
-  return allowed.length > 0 ? allowed.join(", ") : undefined;
 }
 
 // ── Path & Route Matching ────────────────────────────────────────────────────

--- a/tests/server-api-route-order.test.ts
+++ b/tests/server-api-route-order.test.ts
@@ -72,4 +72,97 @@ describe("createServer API route ordering", () => {
     expect(response.status).toBe(200);
     expect(body.route).toBe("static");
   });
+
+  test("uses GET handlers for HEAD API requests without returning a body", async () => {
+    let method = "";
+    const server = createServer({
+      manifest: {
+        apiRoutes: [
+          {
+            path: "/api/status",
+            api: {
+              methods: {
+                GET({ request }) {
+                  method = request.method;
+
+                  return new Response("ready", {
+                    headers: {
+                      "x-status": "ready",
+                    },
+                  });
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const response = await server.fetch(
+      new Request("https://example.com/api/status", {
+        method: "HEAD",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-status")).toBe("ready");
+    expect(await response.text()).toBe("");
+    expect(method).toBe("HEAD");
+  });
+
+  test("includes Allow headers on API method-not-allowed responses", async () => {
+    const server = createServer({
+      manifest: {
+        apiRoutes: [
+          {
+            path: "/api/status",
+            api: {
+              methods: {
+                GET() {
+                  return new Response("ready");
+                },
+                POST() {
+                  return new Response("updated");
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const response = await server.fetch(
+      new Request("https://example.com/api/status", {
+        method: "DELETE",
+      }),
+    );
+
+    expect(response.status).toBe(405);
+    expect(response.headers.get("allow")).toBe("GET, HEAD, POST");
+  });
+
+  test("includes Allow headers on internal endpoint method-not-allowed responses", async () => {
+    const server = createServer({
+      manifest: {
+        routes: [],
+        resources: [],
+      },
+    });
+
+    const routeResponse = await server.fetch(
+      new Request("https://example.com/_litzjs/route", {
+        method: "GET",
+      }),
+    );
+    const resourceResponse = await server.fetch(
+      new Request("https://example.com/_litzjs/resource", {
+        method: "GET",
+      }),
+    );
+
+    expect(routeResponse.status).toBe(405);
+    expect(routeResponse.headers.get("allow")).toBe("POST");
+    expect(resourceResponse.status).toBe(405);
+    expect(resourceResponse.headers.get("allow")).toBe("POST");
+  });
 });

--- a/tests/server-api-route-order.test.ts
+++ b/tests/server-api-route-order.test.ts
@@ -75,6 +75,7 @@ describe("createServer API route ordering", () => {
 
   test("uses GET handlers for HEAD API requests without returning a body", async () => {
     let method = "";
+    let cancelled = false;
     const server = createServer({
       manifest: {
         apiRoutes: [
@@ -85,11 +86,18 @@ describe("createServer API route ordering", () => {
                 GET({ request }) {
                   method = request.method;
 
-                  return new Response("ready", {
-                    headers: {
-                      "x-status": "ready",
+                  return new Response(
+                    new ReadableStream({
+                      cancel() {
+                        cancelled = true;
+                      },
+                    }),
+                    {
+                      headers: {
+                        "x-status": "ready",
+                      },
                     },
-                  });
+                  );
                 },
               },
             },
@@ -108,6 +116,7 @@ describe("createServer API route ordering", () => {
     expect(response.headers.get("x-status")).toBe("ready");
     expect(await response.text()).toBe("");
     expect(method).toBe("HEAD");
+    expect(cancelled).toBe(true);
   });
 
   test("includes Allow headers on API method-not-allowed responses", async () => {

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -1966,6 +1966,99 @@ describe("dev server abort signal lifecycle", () => {
     expect(next).not.toHaveBeenCalled();
   });
 
+  test("uses GET handlers for HEAD API requests without returning a body", async () => {
+    let method = "";
+    const server = createMockViteDevServer(async () => ({
+      api: {
+        methods: {
+          GET({ request }: { request: Request }) {
+            method = request.method;
+
+            return new Response("ready", {
+              headers: {
+                "x-status": "ready",
+              },
+            });
+          },
+        },
+      },
+    }));
+    const request = createMockRequest({
+      url: "/api/status",
+      method: "HEAD",
+    });
+    const response = createMockResponse();
+    const next = mock(() => {});
+
+    await handleLitzApiRequest(
+      server,
+      [{ path: "/api/status", modulePath: "src/api/status.ts" }],
+      request,
+      response,
+      next,
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(response.getHeaderValue("x-status")).toBe("ready");
+    expect(response.getBody()).toBe("");
+    expect(method).toBe("HEAD");
+  });
+
+  test("includes Allow headers on API method-not-allowed responses", async () => {
+    const server = createMockViteDevServer(async () => ({
+      api: {
+        methods: {
+          GET() {
+            return new Response("ready");
+          },
+          POST() {
+            return new Response("updated");
+          },
+        },
+      },
+    }));
+    const request = createMockRequest({
+      url: "/api/status",
+      method: "DELETE",
+    });
+    const response = createMockResponse();
+    const next = mock(() => {});
+
+    await handleLitzApiRequest(
+      server,
+      [{ path: "/api/status", modulePath: "src/api/status.ts" }],
+      request,
+      response,
+      next,
+    );
+
+    expect(response.statusCode).toBe(405);
+    expect(response.getHeaderValue("allow")).toBe("GET, HEAD, POST");
+  });
+
+  test("includes Allow headers on internal endpoint method-not-allowed responses", async () => {
+    const server = createMockViteDevServer(async () => ({}));
+    const routeRequest = createMockRequest({
+      url: "/_litzjs/route",
+      method: "GET",
+    });
+    const routeResponse = createMockResponse();
+    const resourceRequest = createMockRequest({
+      url: "/_litzjs/resource",
+      method: "GET",
+    });
+    const resourceResponse = createMockResponse();
+    const next = mock(() => {});
+
+    await handleLitzRouteRequest(server, [], routeRequest, routeResponse, next);
+    await handleLitzResourceRequest(server, [], resourceRequest, resourceResponse, next);
+
+    expect(routeResponse.statusCode).toBe(405);
+    expect(routeResponse.getHeaderValue("allow")).toBe("POST");
+    expect(resourceResponse.statusCode).toBe(405);
+    expect(resourceResponse.getHeaderValue("allow")).toBe("POST");
+  });
+
   test("rebuilds repeated query params for internal resource requests", async () => {
     let capturedTags: string[] = [];
     let capturedHref = "";

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -1968,17 +1968,25 @@ describe("dev server abort signal lifecycle", () => {
 
   test("uses GET handlers for HEAD API requests without returning a body", async () => {
     let method = "";
+    let cancelled = false;
     const server = createMockViteDevServer(async () => ({
       api: {
         methods: {
           GET({ request }: { request: Request }) {
             method = request.method;
 
-            return new Response("ready", {
-              headers: {
-                "x-status": "ready",
+            return new Response(
+              new ReadableStream({
+                cancel() {
+                  cancelled = true;
+                },
+              }),
+              {
+                headers: {
+                  "x-status": "ready",
+                },
               },
-            });
+            );
           },
         },
       },
@@ -2002,6 +2010,7 @@ describe("dev server abort signal lifecycle", () => {
     expect(response.getHeaderValue("x-status")).toBe("ready");
     expect(response.getBody()).toBe("");
     expect(method).toBe("HEAD");
+    expect(cancelled).toBe(true);
   });
 
   test("includes Allow headers on API method-not-allowed responses", async () => {


### PR DESCRIPTION
## Summary

Closes #160.

This updates API route dispatch in both production server handling and Vite dev middleware so `HEAD` requests fall back to `GET` handlers when no explicit `HEAD` handler exists. The dispatch now preserves response status and headers while suppressing response bodies for `HEAD`, including normal handler returns and thrown `Response` / server-result paths.

It also adds accurate `Allow` headers for method-not-allowed responses:

- API 405 responses now list declared methods and include implicit `HEAD` when `GET` is declared.
- Internal route/resource endpoint 405 responses now return `Allow: POST` in production and dev.

Regression coverage was added for production `createServer` dispatch and Vite dev middleware behavior, and a patch changeset is included.

## Testing

- `bun fmt`
- `bun lint:fix`
- `bun lint`
- `bun test`
- `bun typecheck`
