### PR TITLE
fix: return 400 for malformed internal requests

### DIFF
--- a/.changeset/malformed-internal-requests.md
+++ b/.changeset/malformed-internal-requests.md
@@ -1,0 +1,5 @@
+---
+"litzjs": patch
+---
+
+Return safe 400 fault responses for malformed internal JSON bodies and request metadata headers.

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -23,6 +23,7 @@ import { cancelResponseBody } from "../response-body";
 import { createSearchParams, type SearchParamRecord } from "../search-params";
 import {
   isMalformedInternalRequestError,
+  MALFORMED_INTERNAL_REQUEST_MESSAGE,
   parseInternalRequestBody,
   type InternalRequestBody,
 } from "./internal-requests";
@@ -1187,7 +1188,7 @@ function createMalformedInternalRequestResponse(dataSerializer = jsonDataSeriali
     400,
     {
       kind: "fault",
-      message: "Malformed internal request.",
+      message: MALFORMED_INTERNAL_REQUEST_MESSAGE,
     },
     undefined,
     dataSerializer,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -21,7 +21,11 @@ import {
 } from "../path-matching";
 import { cancelResponseBody } from "../response-body";
 import { createSearchParams, type SearchParamRecord } from "../search-params";
-import { parseInternalRequestBody, type InternalRequestBody } from "./internal-requests";
+import {
+  isMalformedInternalRequestError,
+  parseInternalRequestBody,
+  type InternalRequestBody,
+} from "./internal-requests";
 import { createInternalHandlerHeaders } from "./request-headers";
 
 type Awaitable<T> = T | Promise<T>;
@@ -500,6 +504,10 @@ async function handleResourceRequest<TContext>(
 
     return createServerResultResponse(result, viewId, dataSerializer);
   } catch (error) {
+    if (isMalformedInternalRequestError(error)) {
+      return createMalformedInternalRequestResponse(dataSerializer);
+    }
+
     if (isServerResultLike(error)) {
       return createServerResultResponse(error, viewId, dataSerializer);
     }
@@ -652,6 +660,10 @@ async function handleRouteRequest<TContext>(
 
     return createServerResultResponse(result, viewId, dataSerializer);
   } catch (error) {
+    if (isMalformedInternalRequestError(error)) {
+      return createMalformedInternalRequestResponse(dataSerializer);
+    }
+
     if (isServerResultLike(error)) {
       return createServerResultResponse(error, viewId, dataSerializer);
     }
@@ -1164,6 +1176,18 @@ function createUnhandledFaultResponse(dataSerializer = jsonDataSerializer): Resp
     {
       kind: "fault",
       message: "Internal server error.",
+    },
+    undefined,
+    dataSerializer,
+  );
+}
+
+function createMalformedInternalRequestResponse(dataSerializer = jsonDataSerializer): Response {
+  return createLitzJsonResponse(
+    400,
+    {
+      kind: "fault",
+      message: "Malformed internal request.",
     },
     undefined,
     dataSerializer,

--- a/src/server/internal-requests.ts
+++ b/src/server/internal-requests.ts
@@ -13,7 +13,7 @@ export type {
 } from "../internal-transport";
 export { createInternalActionRequestInit, LITZ_RESULT_ACCEPT } from "../internal-transport";
 
-const MALFORMED_INTERNAL_REQUEST_MESSAGE = "Malformed internal request.";
+export const MALFORMED_INTERNAL_REQUEST_MESSAGE = "Malformed internal request.";
 
 export class MalformedInternalRequestError extends Error {
   constructor() {
@@ -57,7 +57,13 @@ export async function parseInternalRequestBody(request: Request): Promise<Intern
     return metadata;
   }
 
-  const formData = await request.formData();
+  let formData: FormData;
+
+  try {
+    formData = await request.formData();
+  } catch {
+    throw new MalformedInternalRequestError();
+  }
 
   return {
     ...metadata,

--- a/src/server/internal-requests.ts
+++ b/src/server/internal-requests.ts
@@ -13,11 +13,30 @@ export type {
 } from "../internal-transport";
 export { createInternalActionRequestInit, LITZ_RESULT_ACCEPT } from "../internal-transport";
 
+const MALFORMED_INTERNAL_REQUEST_MESSAGE = "Malformed internal request.";
+
+export class MalformedInternalRequestError extends Error {
+  constructor() {
+    super(MALFORMED_INTERNAL_REQUEST_MESSAGE);
+    this.name = "MalformedInternalRequestError";
+  }
+}
+
+export function isMalformedInternalRequestError(
+  error: unknown,
+): error is MalformedInternalRequestError {
+  return error instanceof MalformedInternalRequestError;
+}
+
 export async function parseInternalRequestBody(request: Request): Promise<InternalRequestBody> {
   const contentType = request.headers.get("content-type") ?? "";
 
   if (contentType.includes("application/json")) {
-    return (await request.json()) as InternalRequestBody;
+    try {
+      return (await request.json()) as InternalRequestBody;
+    } catch {
+      throw new MalformedInternalRequestError();
+    }
   }
 
   const metadataHeader = request.headers.get(INTERNAL_REQUEST_HEADER);
@@ -26,7 +45,13 @@ export async function parseInternalRequestBody(request: Request): Promise<Intern
     return {};
   }
 
-  const metadata = JSON.parse(metadataHeader) as InternalRequestMetadata;
+  let metadata: InternalRequestMetadata;
+
+  try {
+    metadata = JSON.parse(metadataHeader) as InternalRequestMetadata;
+  } catch {
+    throw new MalformedInternalRequestError();
+  }
 
   if (request.method === "GET" || request.method === "HEAD") {
     return metadata;

--- a/src/vite/dev-middleware.ts
+++ b/src/vite/dev-middleware.ts
@@ -25,7 +25,11 @@ import {
 } from "../path-matching";
 import { cancelResponseBody } from "../response-body";
 import { createSearchParams, type SearchParamRecord } from "../search-params";
-import { parseInternalRequestBody, type InternalRequestBody } from "../server/internal-requests";
+import {
+  isMalformedInternalRequestError,
+  parseInternalRequestBody,
+  type InternalRequestBody,
+} from "../server/internal-requests";
 import { createInternalHandlerHeaders } from "../server/request-headers";
 import { toImportSpecifier } from "./paths";
 import { LITZ_RSC_RENDERER_ID } from "./virtual-ids";
@@ -193,6 +197,11 @@ export async function handleLitzResourceRequest(
 
     await sendServerResult(server, response, result, viewId);
   } catch (error) {
+    if (isMalformedInternalRequestError(error)) {
+      sendMalformedInternalRequest(response);
+      return;
+    }
+
     if (isServerResultLike(error)) {
       await sendServerResult(server, response, error, viewId);
       return;
@@ -391,6 +400,11 @@ export async function handleLitzRouteRequest(
 
     await sendServerResult(server, response, result, viewId);
   } catch (error) {
+    if (isMalformedInternalRequestError(error)) {
+      sendMalformedInternalRequest(response);
+      return;
+    }
+
     if (isServerResultLike(error)) {
       await sendServerResult(server, response, error, viewId);
       return;
@@ -865,6 +879,13 @@ function sendBadRequest(response: ServerResponse): void {
   response.statusCode = 400;
   response.setHeader("content-type", "text/plain; charset=utf-8");
   response.end("Bad Request");
+}
+
+function sendMalformedInternalRequest(response: ServerResponse): void {
+  sendLitzJson(response, 400, {
+    kind: "fault",
+    message: "Malformed internal request.",
+  });
 }
 
 function applyHeaders(response: ServerResponse, headers?: HeadersInit): void {

--- a/src/vite/dev-middleware.ts
+++ b/src/vite/dev-middleware.ts
@@ -27,6 +27,7 @@ import { cancelResponseBody } from "../response-body";
 import { createSearchParams, type SearchParamRecord } from "../search-params";
 import {
   isMalformedInternalRequestError,
+  MALFORMED_INTERNAL_REQUEST_MESSAGE,
   parseInternalRequestBody,
   type InternalRequestBody,
 } from "../server/internal-requests";
@@ -884,7 +885,7 @@ function sendBadRequest(response: ServerResponse): void {
 function sendMalformedInternalRequest(response: ServerResponse): void {
   sendLitzJson(response, 400, {
     kind: "fault",
-    message: "Malformed internal request.",
+    message: MALFORMED_INTERNAL_REQUEST_MESSAGE,
   });
 }
 

--- a/tests/internal-requests.test.ts
+++ b/tests/internal-requests.test.ts
@@ -148,6 +148,29 @@ describe("internal action requests", () => {
     throw new Error("Expected malformed metadata header to be rejected");
   });
 
+  test("rejects malformed multipart bodies as malformed internal requests", async () => {
+    try {
+      await parseInternalRequestBody(
+        new Request("http://litz.local/_litzjs/action", {
+          method: "POST",
+          headers: {
+            "content-type": "multipart/form-data; boundary=litz-boundary",
+            "x-litzjs-request": JSON.stringify({
+              path: "/projects",
+              operation: "action",
+            }),
+          },
+          body: "--not-the-declared-boundary\r\n",
+        }),
+      );
+    } catch (error) {
+      expect(error).toBeInstanceOf(MalformedInternalRequestError);
+      return;
+    }
+
+    throw new Error("Expected malformed multipart body to be rejected");
+  });
+
   test("returns a safe 400 response for malformed internal JSON bodies", async () => {
     const server = createServer({
       manifest: {
@@ -202,6 +225,42 @@ describe("internal action requests", () => {
           "x-litzjs-request": '{"secret":"do-not-leak"',
         },
         body: new FormData(),
+      }),
+    );
+    const text = await response.text();
+
+    expect(response.status).toBe(400);
+    expect(text).toContain("Malformed internal request.");
+    expect(text).not.toContain("do-not-leak");
+  });
+
+  test("returns a safe 400 response for malformed multipart bodies", async () => {
+    const server = createServer({
+      manifest: {
+        routes: [
+          {
+            id: "projects",
+            path: "/projects",
+            route: {
+              action() {
+                return { kind: "data", data: { ok: true } };
+              },
+            },
+          },
+        ],
+      },
+    });
+    const response = await server.fetch(
+      new Request("https://app.example.com/_litzjs/action", {
+        method: "POST",
+        headers: {
+          "content-type": "multipart/form-data; boundary=litz-boundary",
+          "x-litzjs-request": JSON.stringify({
+            path: "/projects",
+            operation: "action",
+          }),
+        },
+        body: "--not-the-declared-boundary\r\nsecret=do-not-leak\r\n",
       }),
     );
     const text = await response.text();

--- a/tests/internal-requests.test.ts
+++ b/tests/internal-requests.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
 import { formJson } from "../src";
+import { createServer } from "../src/server";
 import {
   createInternalActionRequestInit,
+  MalformedInternalRequestError,
   parseInternalRequestBody,
 } from "../src/server/internal-requests";
 
@@ -106,5 +108,106 @@ describe("internal action requests", () => {
         },
       ),
     ).toThrow(/null/);
+  });
+
+  test("rejects malformed JSON bodies as malformed internal requests", async () => {
+    try {
+      await parseInternalRequestBody(
+        new Request("http://litz.local/_litzjs/resource", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: '{"secret":"do-not-leak"',
+        }),
+      );
+    } catch (error) {
+      expect(error).toBeInstanceOf(MalformedInternalRequestError);
+      return;
+    }
+
+    throw new Error("Expected malformed JSON body to be rejected");
+  });
+
+  test("rejects malformed internal metadata headers as malformed internal requests", async () => {
+    try {
+      await parseInternalRequestBody(
+        new Request("http://litz.local/_litzjs/action", {
+          method: "POST",
+          headers: {
+            "x-litzjs-request": '{"secret":"do-not-leak"',
+          },
+          body: new FormData(),
+        }),
+      );
+    } catch (error) {
+      expect(error).toBeInstanceOf(MalformedInternalRequestError);
+      return;
+    }
+
+    throw new Error("Expected malformed metadata header to be rejected");
+  });
+
+  test("returns a safe 400 response for malformed internal JSON bodies", async () => {
+    const server = createServer({
+      manifest: {
+        resources: [
+          {
+            path: "/projects",
+            resource: {
+              loader() {
+                return { kind: "data", data: { ok: true } };
+              },
+            },
+          },
+        ],
+      },
+    });
+    const response = await server.fetch(
+      new Request("https://app.example.com/_litzjs/resource", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: '{"secret":"do-not-leak"',
+      }),
+    );
+    const text = await response.text();
+
+    expect(response.status).toBe(400);
+    expect(text).toContain("Malformed internal request.");
+    expect(text).not.toContain("do-not-leak");
+  });
+
+  test("returns a safe 400 response for malformed internal metadata headers", async () => {
+    const server = createServer({
+      manifest: {
+        routes: [
+          {
+            id: "projects",
+            path: "/projects",
+            route: {
+              action() {
+                return { kind: "data", data: { ok: true } };
+              },
+            },
+          },
+        ],
+      },
+    });
+    const response = await server.fetch(
+      new Request("https://app.example.com/_litzjs/action", {
+        method: "POST",
+        headers: {
+          "x-litzjs-request": '{"secret":"do-not-leak"',
+        },
+        body: new FormData(),
+      }),
+    );
+    const text = await response.text();
+
+    expect(response.status).toBe(400);
+    expect(text).toContain("Malformed internal request.");
+    expect(text).not.toContain("do-not-leak");
   });
 });

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -2531,6 +2531,70 @@ describe("dev server error masking", () => {
     expect(response.getBody()).toContain("Resource does not define a loader.");
   });
 
+  test("returns safe bad requests for malformed internal JSON bodies", async () => {
+    const server = createMockViteDevServer(async () => ({}));
+    const request = createMockRequest({
+      url: "/_litzjs/resource",
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: '{"secret":"do-not-leak"',
+    });
+    const response = createMockResponse();
+    const next = mock(() => {});
+
+    await handleLitzResourceRequest(server, [], request, response, next);
+
+    expect(response.statusCode).toBe(400);
+    expect(response.getBody()).toContain("Malformed internal request.");
+    expect(response.getBody()).not.toContain("do-not-leak");
+  });
+
+  test("returns safe bad requests for malformed internal metadata headers", async () => {
+    const server = createMockViteDevServer(async () => ({}));
+    const request = createMockRequest({
+      url: "/_litzjs/route",
+      method: "POST",
+      headers: {
+        "x-litzjs-request": '{"secret":"do-not-leak"',
+      },
+      body: "",
+    });
+    const response = createMockResponse();
+    const next = mock(() => {});
+
+    await handleLitzRouteRequest(server, [], request, response, next);
+
+    expect(response.statusCode).toBe(400);
+    expect(response.getBody()).toContain("Malformed internal request.");
+    expect(response.getBody()).not.toContain("do-not-leak");
+  });
+
+  test("returns safe bad requests for malformed multipart internal bodies", async () => {
+    const server = createMockViteDevServer(async () => ({}));
+    const request = createMockRequest({
+      url: "/_litzjs/resource",
+      method: "POST",
+      headers: {
+        "content-type": "multipart/form-data; boundary=litz-boundary",
+        "x-litzjs-request": JSON.stringify({
+          path: "/resources/config",
+          operation: "loader",
+        }),
+      },
+      body: "--not-the-declared-boundary\r\nsecret=do-not-leak\r\n",
+    });
+    const response = createMockResponse();
+    const next = mock(() => {});
+
+    await handleLitzResourceRequest(server, [], request, response, next);
+
+    expect(response.statusCode).toBe(400);
+    expect(response.getBody()).toContain("Malformed internal request.");
+    expect(response.getBody()).not.toContain("do-not-leak");
+  });
+
   test("does not expose raw error messages from resource handlers", async () => {
     const sensitiveMessage = "ECONNREFUSED 127.0.0.1:5432 - password=hunter2";
     const server = createMockViteDevServer(async () => {


### PR DESCRIPTION
## Summary

- Convert malformed internal JSON bodies, malformed `x-litzjs-request` metadata headers, and malformed multipart form-data bodies into a typed bad-request parser error.
- Return safe `400` Litz fault responses from both production and dev internal route/resource handlers instead of noisy `500` faults.
- Share the malformed internal request response message from one exported constant so production and dev responses cannot drift.
- Add regression coverage for parser failures, production server responses, dev middleware responses, and no-leak assertions for malformed payload previews.
- Add a patch changeset for the fix.

Closes #161.

## Verification

- `bun test tests/internal-requests.test.ts tests/vite.test.ts`
- `bun fmt`
- `bun lint:fix`
- `bun typecheck`
- `bun test`