### PR TITLE
[codex] Restore dev server context parity

### DIFF
--- a/.changeset/dev-server-context-parity.md
+++ b/.changeset/dev-server-context-parity.md
@@ -1,0 +1,5 @@
+---
+"litzjs": patch
+---
+
+Restore Vite dev middleware parity with production server context and internal request validation.

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -485,13 +485,26 @@ export async function renderView(node, metadata = {}) {
           response,
           next,
           configuredBase,
+          { serverEntryPath },
         );
       });
       server.middlewares.use((request, response, next) => {
-        void handleLitzRouteRequest(server, routeManifest, request, response, next, configuredBase);
+        void handleLitzRouteRequest(
+          server,
+          routeManifest,
+          request,
+          response,
+          next,
+          configuredBase,
+          {
+            serverEntryPath,
+          },
+        );
       });
       server.middlewares.use((request, response, next) => {
-        void handleLitzApiRequest(server, apiManifest, request, response, next, configuredBase);
+        void handleLitzApiRequest(server, apiManifest, request, response, next, configuredBase, {
+          serverEntryPath,
+        });
       });
       server.middlewares.use((request, response, next) => {
         void handleLitzDocumentRequest(server, request, response, next, configuredBase);

--- a/src/vite/dev-middleware.ts
+++ b/src/vite/dev-middleware.ts
@@ -95,7 +95,7 @@ async function loadDevServerRuntimeOptions<TContext>(
   server: ViteDevServer,
   options: DevServerRuntimeOptions<TContext>,
 ): Promise<DevServerRuntimeOptions<TContext>> {
-  if (options.createContext || options.validateInternalRequest || !options.serverEntryPath) {
+  if (!options.serverEntryPath) {
     return options;
   }
 
@@ -103,7 +103,15 @@ async function loadDevServerRuntimeOptions<TContext>(
     default?: LitzRuntimeServer<TContext>;
   }>(server, toImportSpecifier(server.config.root, options.serverEntryPath));
 
-  return module.default?.__litzjsCreateServerOptions ?? {};
+  const serverOptions = module.default?.__litzjsCreateServerOptions;
+  const createContext = serverOptions?.createContext?.bind(serverOptions);
+  const validateInternalRequest = serverOptions?.validateInternalRequest?.bind(serverOptions);
+
+  return {
+    serverEntryPath: options.serverEntryPath,
+    createContext: options.createContext ?? createContext,
+    validateInternalRequest: options.validateInternalRequest ?? validateInternalRequest,
+  };
 }
 
 export async function handleLitzResourceRequest(

--- a/src/vite/dev-middleware.ts
+++ b/src/vite/dev-middleware.ts
@@ -6,6 +6,7 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 
 import type { ApiRouteMethod } from "../index";
+import type { CreateServerOptions, LitzRuntimeServer } from "../server";
 import type { DiscoveredApiRoute, DiscoveredResource, DiscoveredRoute } from "./types";
 
 import { resolveBasePathname } from "../base-path";
@@ -74,6 +75,12 @@ interface BatchedLoaderResponseEntry {
   };
 }
 
+interface DevServerRuntimeOptions<TContext = unknown> {
+  readonly serverEntryPath?: string | null;
+  readonly createContext?: CreateServerOptions<TContext>["createContext"];
+  readonly validateInternalRequest?: CreateServerOptions<TContext>["validateInternalRequest"];
+}
+
 function hasRunnableRscEnvironment(server: ViteDevServer): boolean {
   const env = server.environments.rsc as unknown as
     | {
@@ -84,6 +91,21 @@ function hasRunnableRscEnvironment(server: ViteDevServer): boolean {
   return typeof env?.runner === "object" && env.runner !== null;
 }
 
+async function loadDevServerRuntimeOptions<TContext>(
+  server: ViteDevServer,
+  options: DevServerRuntimeOptions<TContext>,
+): Promise<DevServerRuntimeOptions<TContext>> {
+  if (options.createContext || options.validateInternalRequest || !options.serverEntryPath) {
+    return options;
+  }
+
+  const module = await loadLitzServerModule<{
+    default?: LitzRuntimeServer<TContext>;
+  }>(server, toImportSpecifier(server.config.root, options.serverEntryPath));
+
+  return module.default?.__litzjsCreateServerOptions ?? {};
+}
+
 export async function handleLitzResourceRequest(
   server: ViteDevServer,
   manifest: DiscoveredResource[],
@@ -91,6 +113,7 @@ export async function handleLitzResourceRequest(
   response: ServerResponse,
   next: Connect.NextFunction,
   base = "/",
+  runtimeOptions: DevServerRuntimeOptions = {},
 ): Promise<void> {
   let viewId = "litzjs#view";
   const requestUrl = request.url ? new URL(request.url, "http://litzjs.local") : null;
@@ -119,6 +142,24 @@ export async function handleLitzResourceRequest(
 
     const resourcePath = body.path;
     const operation = body.operation ?? "loader";
+    const serverOptions = await loadDevServerRuntimeOptions(server, runtimeOptions);
+    const context = serverOptions.createContext
+      ? await serverOptions.createContext(internalRequest)
+      : undefined;
+    const validationResponse = await serverOptions.validateInternalRequest?.({
+      request: internalRequest,
+      kind: "resource",
+      operation,
+      path: resourcePath,
+      body,
+      context,
+    });
+
+    if (validationResponse) {
+      await writeFetchResponseToNode(response, validationResponse);
+      return;
+    }
+
     const entry = manifest.find((resource) => resource.path === resourcePath);
 
     if (!resourcePath || !entry) {
@@ -176,7 +217,7 @@ export async function handleLitzResourceRequest(
       request: normalizedRequest.request,
       params: normalizedRequest.params,
       signal,
-      context: undefined,
+      context,
       async execute(nextContext) {
         const input = await resolveValidatedInput({
           validation: resource.input,
@@ -224,6 +265,7 @@ export async function handleLitzRouteRequest(
   response: ServerResponse,
   next: Connect.NextFunction,
   base = "/",
+  runtimeOptions: DevServerRuntimeOptions = {},
 ): Promise<void> {
   let viewId = "litzjs#view";
   const requestUrl = request.url ? new URL(request.url, "http://litzjs.local") : null;
@@ -254,6 +296,24 @@ export async function handleLitzRouteRequest(
     const targetId = body.target;
     const targetIds = body.targets?.filter((value): value is string => typeof value === "string");
     const operation = body.operation ?? (pathname === "/_litzjs/action" ? "action" : "loader");
+    const serverOptions = await loadDevServerRuntimeOptions(server, runtimeOptions);
+    const context = serverOptions.createContext
+      ? await serverOptions.createContext(internalRequest)
+      : undefined;
+    const validationResponse = await serverOptions.validateInternalRequest?.({
+      request: internalRequest,
+      kind: "route",
+      operation,
+      path: routePath,
+      body,
+      context,
+    });
+
+    if (validationResponse) {
+      await writeFetchResponseToNode(response, validationResponse);
+      return;
+    }
+
     const entry = manifest.find((route) => route.path === routePath);
 
     if (!routePath || !entry) {
@@ -361,6 +421,7 @@ export async function handleLitzRouteRequest(
             target: batchTarget,
             normalizedRequest,
             signal,
+            context,
           }),
         ),
       );
@@ -397,6 +458,7 @@ export async function handleLitzRouteRequest(
       target,
       normalizedRequest,
       signal,
+      context,
     });
 
     await sendServerResult(server, response, result, viewId);
@@ -496,6 +558,7 @@ export async function handleLitzApiRequest(
   response: ServerResponse,
   next: Connect.NextFunction,
   base = "/",
+  runtimeOptions: DevServerRuntimeOptions = {},
 ): Promise<void> {
   const runnable = hasRunnableRscEnvironment(server);
 
@@ -571,6 +634,10 @@ export async function handleLitzApiRequest(
     }
 
     const apiRequest = await createNodeRequest(request, requestUrl);
+    const serverOptions = await loadDevServerRuntimeOptions(server, runtimeOptions);
+    const context = serverOptions.createContext
+      ? await serverOptions.createContext(apiRequest)
+      : undefined;
 
     const controller = new AbortController();
     request.once("close", () => controller.abort());
@@ -580,7 +647,7 @@ export async function handleLitzApiRequest(
       request: apiRequest,
       params: matchedParams ?? {},
       signal,
-      context: undefined,
+      context,
       async execute(nextContext) {
         const input = await resolveValidatedInput({
           validation: api?.input,
@@ -1087,6 +1154,7 @@ async function executeDevRouteTarget(options: {
     params: Record<string, string>;
   };
   signal: AbortSignal;
+  context: unknown;
 }): Promise<unknown> {
   const targetIndex = options.chain.findIndex((candidate) => candidate.id === options.target.id);
   const handler =
@@ -1119,7 +1187,7 @@ async function executeDevRouteTarget(options: {
     request: options.normalizedRequest.request,
     params,
     signal: options.signal,
-    context: undefined,
+    context: options.context,
     async execute(nextContext) {
       const input = await resolveValidatedInput({
         validation,

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -2061,6 +2061,85 @@ describe("dev server abort signal lifecycle", () => {
     expect(capturedContext).toEqual({ sessionId: "session-456" });
   });
 
+  test("merges inline dev validation with configured server entry context", async () => {
+    let loaderCalls = 0;
+    const litzServer = createServer({
+      createContext() {
+        return { sessionId: "session-789" };
+      },
+    });
+    const importModule = async (id: string) => {
+      if (id?.endsWith("/src/server.ts")) {
+        return { default: litzServer };
+      }
+
+      return {
+        route: {
+          id: "projects.show",
+          path: "/projects/:id",
+          loader({ context }: { context: { sessionId: string } }) {
+            loaderCalls += 1;
+            return {
+              kind: "data",
+              data: { sessionId: context.sessionId },
+            };
+          },
+        },
+      };
+    };
+    const server = {
+      ...createMockViteDevServer(importModule),
+      environments: {
+        rsc: {
+          pluginContainer: {
+            resolveId: async (id: string) => ({ id }),
+          },
+          runner: {
+            import: importModule,
+          },
+        },
+      },
+    } as unknown as ViteDevServer;
+    const request = createMockRequest({
+      url: "/_litzjs/route",
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        path: "/projects/:id",
+        target: "projects.show",
+        operation: "loader",
+        request: {
+          params: { id: "42" },
+        },
+      }),
+    });
+    const response = createMockResponse();
+    const next = mock(() => {});
+
+    await handleLitzRouteRequest(
+      server,
+      [{ id: "projects.show", path: "/projects/:id", modulePath: "src/routes/projects.ts" }],
+      request,
+      response,
+      next,
+      "/",
+      {
+        serverEntryPath: "src/server.ts",
+        validateInternalRequest({ context }) {
+          if ((context as { sessionId?: string } | undefined)?.sessionId !== "session-789") {
+            return new Response("Forbidden", { status: 403 });
+          }
+        },
+      },
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(response.getBody()).toBe(
+      JSON.stringify({ kind: "data", data: { sessionId: "session-789" }, revalidate: [] }),
+    );
+    expect(loaderCalls).toBe(1);
+  });
+
   test("validates dev route internal requests with configured server context", async () => {
     let loaderCalls = 0;
     const server = createMockViteDevServer(async () => ({

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -18,6 +18,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
 
+import { createServer } from "../src/server";
 import {
   buildLitzApp,
   discoverAllManifests,
@@ -1964,6 +1965,212 @@ describe("dev server abort signal lifecycle", () => {
     expect(response.getBody()).toBe(JSON.stringify({ params: { id: "42" } }));
     expect(capturedParams).toEqual({ id: "42" });
     expect(next).not.toHaveBeenCalled();
+  });
+
+  test("passes configured server context to dev API handlers", async () => {
+    let capturedContext: unknown;
+    const server = createMockViteDevServer(async () => ({
+      api: {
+        methods: {
+          GET({ context }: { context: unknown }) {
+            capturedContext = context;
+            return Response.json({ ok: true });
+          },
+        },
+      },
+    }));
+    const request = createMockRequest({
+      url: "/api/context",
+      method: "GET",
+    });
+    const response = createMockResponse();
+    const next = mock(() => {});
+
+    await handleLitzApiRequest(
+      server,
+      [{ path: "/api/context", modulePath: "src/api/context.ts" }],
+      request,
+      response,
+      next,
+      "/",
+      {
+        createContext() {
+          return { sessionId: "session-123" };
+        },
+      },
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(capturedContext).toEqual({ sessionId: "session-123" });
+  });
+
+  test("loads configured server entry context for dev API handlers", async () => {
+    let capturedContext: unknown;
+    const litzServer = createServer({
+      createContext() {
+        return { sessionId: "session-456" };
+      },
+    });
+    const importModule = async (id: string) => {
+      if (id?.endsWith("/src/server.ts")) {
+        return { default: litzServer };
+      }
+
+      return {
+        api: {
+          methods: {
+            GET({ context }: { context: unknown }) {
+              capturedContext = context;
+              return Response.json({ ok: true });
+            },
+          },
+        },
+      };
+    };
+    const server = {
+      ...createMockViteDevServer(importModule),
+      environments: {
+        rsc: {
+          pluginContainer: {
+            resolveId: async (id: string) => ({ id }),
+          },
+          runner: {
+            import: importModule,
+          },
+        },
+      },
+    } as unknown as ViteDevServer;
+    const request = createMockRequest({
+      url: "/api/context",
+      method: "GET",
+    });
+    const response = createMockResponse();
+    const next = mock(() => {});
+
+    await handleLitzApiRequest(
+      server,
+      [{ path: "/api/context", modulePath: "src/api/context.ts" }],
+      request,
+      response,
+      next,
+      "/",
+      { serverEntryPath: "src/server.ts" },
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(capturedContext).toEqual({ sessionId: "session-456" });
+  });
+
+  test("validates dev route internal requests with configured server context", async () => {
+    let loaderCalls = 0;
+    const server = createMockViteDevServer(async () => ({
+      route: {
+        id: "projects.show",
+        path: "/projects/:id",
+        loader({ context }: { context: { sessionId: string } }) {
+          loaderCalls += 1;
+          return {
+            kind: "data",
+            data: { sessionId: context.sessionId },
+          };
+        },
+      },
+    }));
+    const request = createMockRequest({
+      url: "/_litzjs/route",
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        path: "/projects/:id",
+        target: "projects.show",
+        operation: "loader",
+        request: {
+          params: { id: "42" },
+        },
+      }),
+    });
+    const response = createMockResponse();
+    const next = mock(() => {});
+
+    await handleLitzRouteRequest(
+      server,
+      [{ id: "projects.show", path: "/projects/:id", modulePath: "src/routes/projects.ts" }],
+      request,
+      response,
+      next,
+      "/",
+      {
+        createContext() {
+          return { sessionId: "session-123" };
+        },
+        validateInternalRequest({ context }) {
+          if ((context as { sessionId?: string } | undefined)?.sessionId !== "session-123") {
+            return new Response("Forbidden", { status: 403 });
+          }
+        },
+      },
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(response.getBody()).toBe(
+      JSON.stringify({ kind: "data", data: { sessionId: "session-123" }, revalidate: [] }),
+    );
+    expect(loaderCalls).toBe(1);
+  });
+
+  test("can reject dev resource internal requests with configured validation", async () => {
+    let loaderCalls = 0;
+    const server = createMockViteDevServer(async () => ({
+      resource: {
+        loader() {
+          loaderCalls += 1;
+          return {
+            kind: "data",
+            data: { ok: true },
+          };
+        },
+      },
+    }));
+    const request = createMockRequest({
+      url: "/_litzjs/resource",
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        path: "/resources/projects/:id",
+        operation: "loader",
+        request: {
+          params: { id: "42" },
+        },
+      }),
+    });
+    const response = createMockResponse();
+    const next = mock(() => {});
+
+    await handleLitzResourceRequest(
+      server,
+      [
+        {
+          path: "/resources/projects/:id",
+          modulePath: "src/routes/resources/projects.ts",
+          hasLoader: true,
+          hasAction: false,
+          hasComponent: false,
+        },
+      ],
+      request,
+      response,
+      next,
+      "/",
+      {
+        validateInternalRequest() {
+          return new Response("Forbidden", { status: 403 });
+        },
+      },
+    );
+
+    expect(response.statusCode).toBe(403);
+    expect(response.getBody()).toBe("Forbidden");
+    expect(loaderCalls).toBe(0);
   });
 
   test("uses GET handlers for HEAD API requests without returning a body", async () => {


### PR DESCRIPTION
## Summary

Fixes #162.

Restores Vite dev middleware parity with production server handling for custom server runtime hooks:

- Loads configured `createServer` options from the dev server entry when `litz({ server })` is configured.
- Passes `createContext` values into dev API, route, and resource middleware/handlers.
- Runs `validateInternalRequest` for dev internal route and resource requests before dispatching handlers, matching production behavior.
- Adds regression coverage for direct runtime options, configured server-entry loading, route validation with context, and resource validation rejection.
- Adds a patch changeset.

## Root Cause

Production requests route through `createServer`, which lazily creates request context and validates internal route/resource requests before handler dispatch. The Vite dev middleware loaded route/resource/API modules directly and always invoked middleware/handlers with `context: undefined`, while skipping the internal validation hook entirely.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun typecheck`
- `bun test tests/vite.test.ts`
- `bun test`
