### PR TITLE
[codex] Reject duplicate manifest paths

### DIFF
--- a/.changeset/duplicate-manifest-paths.md
+++ b/.changeset/duplicate-manifest-paths.md
@@ -1,0 +1,5 @@
+---
+"litzjs": patch
+---
+
+Fail manifest discovery when routes, resources, or API routes define duplicate paths, including the files involved in the diagnostic.

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -32,6 +32,7 @@ import {
   handleLitzRouteRequest,
 } from "./vite/dev-middleware";
 import {
+  assertNoDuplicateManifestPaths,
   discoverAllManifests,
   discoverApiRouteFromFile,
   discoverLayoutFromFile,
@@ -379,6 +380,7 @@ export async function renderView(node, metadata = {}) {
           const result = updateManifestEntry(routeManifest, entry, file, (items) =>
             sortByPathSpecificity(items),
           );
+          assertNoDuplicateManifestPaths("route", result.manifest);
           routeManifest = result.manifest;
           changed = changed || result.changed;
 
@@ -395,6 +397,7 @@ export async function renderView(node, metadata = {}) {
           if (manifestGeneration !== generation) return;
 
           const result = updateManifestEntry(resourceManifest, entry, file);
+          assertNoDuplicateManifestPaths("resource", result.manifest);
           resourceManifest = result.manifest;
           changed = changed || result.changed;
         }
@@ -406,6 +409,7 @@ export async function renderView(node, metadata = {}) {
           const result = updateManifestEntry(apiManifest, entry, file, (items) =>
             sortByPathSpecificity(items),
           );
+          assertNoDuplicateManifestPaths("API route", result.manifest);
           apiManifest = result.manifest;
           changed = changed || result.changed;
         }

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -388,6 +388,7 @@ export async function renderView(node, metadata = {}) {
           if (manifestGeneration !== generation) return;
 
           const layoutResult = updateManifestEntry(layoutManifest, layoutEntry, file);
+          assertNoDuplicateManifestPaths("layout", layoutResult.manifest);
           layoutManifest = layoutResult.manifest;
           changed = changed || layoutResult.changed;
         }

--- a/src/vite/discovery.ts
+++ b/src/vite/discovery.ts
@@ -33,6 +33,7 @@ export async function discoverAllManifests(
     ]);
 
   assertNoDuplicateManifestPaths("route", nextRouteManifest);
+  assertNoDuplicateManifestPaths("layout", nextLayoutManifest);
   assertNoDuplicateManifestPaths("resource", nextResourceManifest);
   assertNoDuplicateManifestPaths("API route", nextApiManifest);
 

--- a/src/vite/discovery.ts
+++ b/src/vite/discovery.ts
@@ -32,6 +32,10 @@ export async function discoverAllManifests(
       discoverApiRoutes(root, apiPatterns),
     ]);
 
+  assertNoDuplicateManifestPaths("route", nextRouteManifest);
+  assertNoDuplicateManifestPaths("resource", nextResourceManifest);
+  assertNoDuplicateManifestPaths("API route", nextApiManifest);
+
   return {
     routeManifest: sortByPathSpecificity(nextRouteManifest),
     layoutManifest: nextLayoutManifest,
@@ -46,6 +50,44 @@ export function isClientBoundaryModule(file: string): boolean {
 
 export function isRouteLikeModuleFile(file: string): boolean {
   return /\.(ts|tsx|js|jsx)$/.test(file);
+}
+
+export function assertNoDuplicateManifestPaths(
+  kind: string,
+  entries: readonly { readonly path: string; readonly modulePath: string }[],
+): void {
+  const entriesByPath = new Map<string, string[]>();
+
+  for (const entry of entries) {
+    const modulePaths = entriesByPath.get(entry.path);
+
+    if (modulePaths) {
+      modulePaths.push(entry.modulePath);
+    } else {
+      entriesByPath.set(entry.path, [entry.modulePath]);
+    }
+  }
+
+  const duplicates = [...entriesByPath.entries()].filter(
+    ([, modulePaths]) => modulePaths.length > 1,
+  );
+
+  if (duplicates.length === 0) {
+    return;
+  }
+
+  const details = duplicates
+    .map(([manifestPath, modulePaths]) => {
+      const files = [...modulePaths]
+        .sort((a, b) => a.localeCompare(b))
+        .map((modulePath) => `    - ${modulePath}`)
+        .join("\n");
+
+      return `  ${manifestPath}\n${files}`;
+    })
+    .join("\n");
+
+  throw new Error(`[litzjs] Duplicate ${kind} paths discovered:\n${details}`);
 }
 
 function resolveClientBoundaryModule(root: string, file: string): string | null {

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -1026,6 +1026,101 @@ describe("dev server hot updates", () => {
     }
   });
 
+  test("dev watcher reports duplicate layout paths introduced by file changes", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "litz-duplicate-layout-watch-"));
+    const errors: string[] = [];
+    const originalError = console.error;
+    console.error = (message?: unknown, error?: unknown) => {
+      errors.push(
+        [message, error instanceof Error ? error.message : error].filter(Boolean).join(" "),
+      );
+    };
+
+    try {
+      mkdirSync(path.join(root, "src"), { recursive: true });
+      writeFileSync(path.join(root, "src", "main.tsx"), "export {};\n", "utf8");
+      mkdirSync(path.join(root, "src", "routes"), { recursive: true });
+      writeFileSync(
+        path.join(root, "src", "routes", "first-layout.tsx"),
+        'import { defineLayout } from "litzjs";\nexport const layout = defineLayout("/app", { component() { return null; } });\n',
+        "utf8",
+      );
+      const secondLayoutFile = path.join(root, "src", "routes", "second-layout.tsx");
+      writeFileSync(
+        secondLayoutFile,
+        'import { defineLayout } from "litzjs";\nexport const layout = defineLayout("/settings", { component() { return null; } });\n',
+        "utf8",
+      );
+
+      const plugin = (litz() as Plugin[]).find((candidate) => candidate.name === "litzjs/vite");
+
+      if (!plugin?.configResolved || !plugin.configureServer) {
+        throw new Error("Expected litzjs/vite dev-server hooks to be available.");
+      }
+
+      const configResolved =
+        typeof plugin.configResolved === "function"
+          ? plugin.configResolved
+          : plugin.configResolved.handler;
+      const configureServer =
+        typeof plugin.configureServer === "function"
+          ? plugin.configureServer
+          : plugin.configureServer.handler;
+      const watcherHandlers = new Map<string, (file: string) => void>();
+
+      await configResolved.call(
+        {} as never,
+        {
+          root,
+          command: "serve",
+          build: {
+            outDir: "dist",
+          },
+        } as never,
+      );
+
+      await configureServer.call(
+        {} as never,
+        {
+          watcher: {
+            on(event: string, handler: (file: string) => void) {
+              watcherHandlers.set(event, handler);
+            },
+          },
+          middlewares: {
+            use() {},
+          },
+          moduleGraph: {
+            getModuleById() {
+              return undefined;
+            },
+            invalidateModule() {},
+          },
+          ws: {
+            send() {},
+          },
+        } as never,
+      );
+
+      writeFileSync(
+        secondLayoutFile,
+        'import { defineLayout } from "litzjs";\nexport const layout = defineLayout("/app", { component() { return null; } });\n',
+        "utf8",
+      );
+
+      watcherHandlers.get("change")?.(secondLayoutFile);
+      await new Promise((resolve) => setTimeout(resolve, 25));
+
+      expect(errors.join("\n")).toContain("[litzjs] error refreshing file manifest:");
+      expect(errors.join("\n")).toContain("Duplicate layout paths discovered");
+      expect(errors.join("\n")).toContain("src/routes/first-layout.tsx");
+      expect(errors.join("\n")).toContain("src/routes/second-layout.tsx");
+    } finally {
+      console.error = originalError;
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   test("returns client modules for projected route updates in the client environment", async () => {
     const root = mkdtempSync(path.join(tmpdir(), "litz-hot-update-"));
 
@@ -3746,6 +3841,49 @@ describe("manifest discovery", () => {
             "  /duplicate",
             "    - src/routes/first.tsx",
             "    - src/routes/second.tsx",
+          ].join("\n"),
+        );
+      } finally {
+        rmSync(root, { force: true, recursive: true });
+      }
+    });
+
+    test("rejects duplicate layout paths with the files involved", async () => {
+      const root = createTempProject();
+
+      try {
+        writeFileSync(
+          path.join(root, "src", "routes", "first-layout.tsx"),
+          `import { defineLayout } from "litzjs";\nexport const layout = defineLayout("/duplicate-layout", { component: FirstLayout });`,
+        );
+        writeFileSync(
+          path.join(root, "src", "routes", "second-layout.tsx"),
+          `import { defineLayout } from "litzjs";\nexport const layout = defineLayout("/duplicate-layout", { component: SecondLayout });`,
+        );
+        let error: unknown;
+
+        try {
+          await discoverAllManifests(
+            root,
+            [
+              "src/routes/**/*.{ts,tsx}",
+              "!src/routes/api/**/*.{ts,tsx}",
+              "!src/routes/resources/**/*.{ts,tsx}",
+            ],
+            ["src/routes/resources/**/*.{ts,tsx}"],
+            ["src/routes/api/**/*.{ts,tsx}"],
+          );
+        } catch (caughtError) {
+          error = caughtError;
+        }
+
+        expect(error).toBeInstanceOf(Error);
+        expect(error instanceof Error ? error.message : "").toContain(
+          [
+            "Duplicate layout paths discovered:",
+            "  /duplicate-layout",
+            "    - src/routes/first-layout.tsx",
+            "    - src/routes/second-layout.tsx",
           ].join("\n"),
         );
       } finally {

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -931,6 +931,101 @@ describe("dev server hot updates", () => {
     }
   });
 
+  test("dev watcher reports duplicate route paths introduced by file changes", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "litz-duplicate-route-watch-"));
+    const errors: string[] = [];
+    const originalError = console.error;
+    console.error = (message?: unknown, error?: unknown) => {
+      errors.push(
+        [message, error instanceof Error ? error.message : error].filter(Boolean).join(" "),
+      );
+    };
+
+    try {
+      mkdirSync(path.join(root, "src"), { recursive: true });
+      writeFileSync(path.join(root, "src", "main.tsx"), "export {};\n", "utf8");
+      mkdirSync(path.join(root, "src", "routes"), { recursive: true });
+      writeFileSync(
+        path.join(root, "src", "routes", "first.tsx"),
+        'import { defineRoute } from "litzjs";\nexport const route = defineRoute("/first", { component() { return null; } });\n',
+        "utf8",
+      );
+      const secondRouteFile = path.join(root, "src", "routes", "second.tsx");
+      writeFileSync(
+        secondRouteFile,
+        'import { defineRoute } from "litzjs";\nexport const route = defineRoute("/second", { component() { return null; } });\n',
+        "utf8",
+      );
+
+      const plugin = (litz() as Plugin[]).find((candidate) => candidate.name === "litzjs/vite");
+
+      if (!plugin?.configResolved || !plugin.configureServer) {
+        throw new Error("Expected litzjs/vite dev-server hooks to be available.");
+      }
+
+      const configResolved =
+        typeof plugin.configResolved === "function"
+          ? plugin.configResolved
+          : plugin.configResolved.handler;
+      const configureServer =
+        typeof plugin.configureServer === "function"
+          ? plugin.configureServer
+          : plugin.configureServer.handler;
+      const watcherHandlers = new Map<string, (file: string) => void>();
+
+      await configResolved.call(
+        {} as never,
+        {
+          root,
+          command: "serve",
+          build: {
+            outDir: "dist",
+          },
+        } as never,
+      );
+
+      await configureServer.call(
+        {} as never,
+        {
+          watcher: {
+            on(event: string, handler: (file: string) => void) {
+              watcherHandlers.set(event, handler);
+            },
+          },
+          middlewares: {
+            use() {},
+          },
+          moduleGraph: {
+            getModuleById() {
+              return undefined;
+            },
+            invalidateModule() {},
+          },
+          ws: {
+            send() {},
+          },
+        } as never,
+      );
+
+      writeFileSync(
+        secondRouteFile,
+        'import { defineRoute } from "litzjs";\nexport const route = defineRoute("/first", { component() { return null; } });\n',
+        "utf8",
+      );
+
+      watcherHandlers.get("change")?.(secondRouteFile);
+      await new Promise((resolve) => setTimeout(resolve, 25));
+
+      expect(errors.join("\n")).toContain("[litzjs] error refreshing file manifest:");
+      expect(errors.join("\n")).toContain("Duplicate route paths discovered");
+      expect(errors.join("\n")).toContain("src/routes/first.tsx");
+      expect(errors.join("\n")).toContain("src/routes/second.tsx");
+    } finally {
+      console.error = originalError;
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   test("returns client modules for projected route updates in the client environment", async () => {
     const root = mkdtempSync(path.join(tmpdir(), "litz-hot-update-"));
 
@@ -3615,6 +3710,137 @@ describe("manifest discovery", () => {
   });
 
   describe("discoverAllManifests", () => {
+    test("rejects duplicate route paths with the files involved", async () => {
+      const root = createTempProject();
+
+      try {
+        writeFileSync(
+          path.join(root, "src", "routes", "first.tsx"),
+          `import { defineRoute } from "litzjs";\nexport const route = defineRoute("/duplicate", { component: First });`,
+        );
+        writeFileSync(
+          path.join(root, "src", "routes", "second.tsx"),
+          `import { defineRoute } from "litzjs";\nexport const route = defineRoute("/duplicate", { component: Second });`,
+        );
+        let error: unknown;
+
+        try {
+          await discoverAllManifests(
+            root,
+            [
+              "src/routes/**/*.{ts,tsx}",
+              "!src/routes/api/**/*.{ts,tsx}",
+              "!src/routes/resources/**/*.{ts,tsx}",
+            ],
+            ["src/routes/resources/**/*.{ts,tsx}"],
+            ["src/routes/api/**/*.{ts,tsx}"],
+          );
+        } catch (caughtError) {
+          error = caughtError;
+        }
+
+        expect(error).toBeInstanceOf(Error);
+        expect(error instanceof Error ? error.message : "").toContain(
+          [
+            "Duplicate route paths discovered:",
+            "  /duplicate",
+            "    - src/routes/first.tsx",
+            "    - src/routes/second.tsx",
+          ].join("\n"),
+        );
+      } finally {
+        rmSync(root, { force: true, recursive: true });
+      }
+    });
+
+    test("rejects duplicate resource paths with the files involved", async () => {
+      const root = createTempProject();
+
+      try {
+        writeFileSync(
+          path.join(root, "src", "routes", "resources", "first.ts"),
+          `import { defineResource } from "litzjs";\nexport const resource = defineResource("/resource/duplicate", { loader: async () => {} });`,
+        );
+        writeFileSync(
+          path.join(root, "src", "routes", "resources", "second.ts"),
+          `import { defineResource } from "litzjs";\nexport const resource = defineResource("/resource/duplicate", { loader: async () => {} });`,
+        );
+
+        let error: unknown;
+
+        try {
+          await discoverAllManifests(
+            root,
+            [
+              "src/routes/**/*.{ts,tsx}",
+              "!src/routes/api/**/*.{ts,tsx}",
+              "!src/routes/resources/**/*.{ts,tsx}",
+            ],
+            ["src/routes/resources/**/*.{ts,tsx}"],
+            ["src/routes/api/**/*.{ts,tsx}"],
+          );
+        } catch (caughtError) {
+          error = caughtError;
+        }
+
+        expect(error).toBeInstanceOf(Error);
+        expect(error instanceof Error ? error.message : "").toContain(
+          [
+            "Duplicate resource paths discovered:",
+            "  /resource/duplicate",
+            "    - src/routes/resources/first.ts",
+            "    - src/routes/resources/second.ts",
+          ].join("\n"),
+        );
+      } finally {
+        rmSync(root, { force: true, recursive: true });
+      }
+    });
+
+    test("rejects duplicate API route paths with the files involved", async () => {
+      const root = createTempProject();
+
+      try {
+        writeFileSync(
+          path.join(root, "src", "routes", "api", "first.ts"),
+          `import { defineApiRoute } from "litzjs";\nexport const api = defineApiRoute("/api/duplicate", { GET() { return Response.json({ ok: true }); } });`,
+        );
+        writeFileSync(
+          path.join(root, "src", "routes", "api", "second.ts"),
+          `import { defineApiRoute } from "litzjs";\nexport const api = defineApiRoute("/api/duplicate", { GET() { return Response.json({ ok: true }); } });`,
+        );
+
+        let error: unknown;
+
+        try {
+          await discoverAllManifests(
+            root,
+            [
+              "src/routes/**/*.{ts,tsx}",
+              "!src/routes/api/**/*.{ts,tsx}",
+              "!src/routes/resources/**/*.{ts,tsx}",
+            ],
+            ["src/routes/resources/**/*.{ts,tsx}"],
+            ["src/routes/api/**/*.{ts,tsx}"],
+          );
+        } catch (caughtError) {
+          error = caughtError;
+        }
+
+        expect(error).toBeInstanceOf(Error);
+        expect(error instanceof Error ? error.message : "").toContain(
+          [
+            "Duplicate API route paths discovered:",
+            "  /api/duplicate",
+            "    - src/routes/api/first.ts",
+            "    - src/routes/api/second.ts",
+          ].join("\n"),
+        );
+      } finally {
+        rmSync(root, { force: true, recursive: true });
+      }
+    });
+
     test("discovers .js and .jsx route-like modules with the default patterns", async () => {
       const root = createTempProject();
 


### PR DESCRIPTION
## Summary

Closes #163.

This PR makes manifest discovery fail fast when duplicate paths are discovered across any single manifest category:

- routes
- resources
- API routes

The diagnostic includes the duplicated path and the module paths involved, so duplicate definitions can be fixed before client and server runtime matching disagree about which file wins.

## Behavior

Full manifest discovery now validates duplicate route, resource, and API route paths before returning manifests. Dev watcher single-file refreshes reuse the same validation after applying a candidate update, so duplicates introduced during development are reported through the existing manifest refresh error path instead of silently updating runtime manifests.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`

## Changeset

Included `.changeset/duplicate-manifest-paths.md` as a patch changeset.
