### PR TITLE
[codex] Fix cancellable coalesced intent prefetch

### DIFF
--- a/.changeset/cancellable-intent-prefetch.md
+++ b/.changeset/cancellable-intent-prefetch.md
@@ -1,0 +1,5 @@
+---
+"litzjs": patch
+---
+
+Coalesce intent link prefetches and abort in-flight data prefetches when intent ends.

--- a/src/client/link.tsx
+++ b/src/client/link.tsx
@@ -34,14 +34,27 @@ export function createLinkComponent(dependencies: {
       prefetchData = false,
       onClick,
       onMouseEnter,
+      onMouseLeave,
       onFocus,
+      onBlur,
       onTouchStart,
+      onTouchEnd,
+      onTouchCancel,
       target,
       download,
       rel,
       ...rest
     } = props;
     const browserHref = resolveClientHref(href);
+    const intentPrefetchRef = React.useRef<{
+      readonly key: string;
+      readonly controller: AbortController;
+    } | null>(null);
+    const intentStateRef = React.useRef({
+      hover: false,
+      focus: false,
+      touch: false,
+    });
 
     React.useEffect(() => {
       if (prefetch !== "render") {
@@ -62,6 +75,52 @@ export function createLinkComponent(dependencies: {
       };
     }, [browserHref, dependencies, download, prefetch, prefetchData, target]);
 
+    React.useEffect(() => {
+      return () => {
+        intentPrefetchRef.current?.controller.abort();
+        intentPrefetchRef.current = null;
+      };
+    }, [browserHref, download, prefetch, prefetchData, target]);
+
+    function abortIntentPrefetchIfIdle(): void {
+      const intentState = intentStateRef.current;
+
+      if (intentState.hover || intentState.focus || intentState.touch) {
+        return;
+      }
+
+      intentPrefetchRef.current?.controller.abort();
+      intentPrefetchRef.current = null;
+    }
+
+    function startIntentPrefetch(): void {
+      if (prefetch !== "intent") {
+        return;
+      }
+
+      const key = JSON.stringify([browserHref, target ?? null, download ?? null, prefetchData]);
+      const currentPrefetch = intentPrefetchRef.current;
+
+      if (currentPrefetch?.key === key && !currentPrefetch.controller.signal.aborted) {
+        return;
+      }
+
+      currentPrefetch?.controller.abort();
+
+      const controller = new AbortController();
+      intentPrefetchRef.current = {
+        key,
+        controller,
+      };
+
+      dependencies.prefetchRouteForHref(browserHref, {
+        target,
+        download,
+        includeData: prefetchData,
+        signal: controller.signal,
+      });
+    }
+
     return React.createElement("a", {
       ...rest,
       href: browserHref,
@@ -75,15 +134,13 @@ export function createLinkComponent(dependencies: {
           return;
         }
 
-        if (prefetch !== "intent") {
-          return;
-        }
-
-        dependencies.prefetchRouteForHref(browserHref, {
-          target,
-          download,
-          includeData: prefetchData,
-        });
+        intentStateRef.current.hover = true;
+        startIntentPrefetch();
+      },
+      onMouseLeave(event: React.MouseEvent<HTMLAnchorElement>) {
+        onMouseLeave?.(event);
+        intentStateRef.current.hover = false;
+        abortIntentPrefetchIfIdle();
       },
       onFocus(event: React.FocusEvent<HTMLAnchorElement>) {
         onFocus?.(event);
@@ -92,15 +149,13 @@ export function createLinkComponent(dependencies: {
           return;
         }
 
-        if (prefetch !== "intent") {
-          return;
-        }
-
-        dependencies.prefetchRouteForHref(browserHref, {
-          target,
-          download,
-          includeData: prefetchData,
-        });
+        intentStateRef.current.focus = true;
+        startIntentPrefetch();
+      },
+      onBlur(event: React.FocusEvent<HTMLAnchorElement>) {
+        onBlur?.(event);
+        intentStateRef.current.focus = false;
+        abortIntentPrefetchIfIdle();
       },
       onTouchStart(event: React.TouchEvent<HTMLAnchorElement>) {
         onTouchStart?.(event);
@@ -109,15 +164,18 @@ export function createLinkComponent(dependencies: {
           return;
         }
 
-        if (prefetch !== "intent") {
-          return;
-        }
-
-        dependencies.prefetchRouteForHref(browserHref, {
-          target,
-          download,
-          includeData: prefetchData,
-        });
+        intentStateRef.current.touch = true;
+        startIntentPrefetch();
+      },
+      onTouchEnd(event: React.TouchEvent<HTMLAnchorElement>) {
+        onTouchEnd?.(event);
+        intentStateRef.current.touch = false;
+        abortIntentPrefetchIfIdle();
+      },
+      onTouchCancel(event: React.TouchEvent<HTMLAnchorElement>) {
+        onTouchCancel?.(event);
+        intentStateRef.current.touch = false;
+        abortIntentPrefetchIfIdle();
       },
       onClick(event: React.MouseEvent<HTMLAnchorElement>) {
         onClick?.(event);

--- a/src/client/link.tsx
+++ b/src/client/link.tsx
@@ -46,6 +46,12 @@ export function createLinkComponent(dependencies: {
       ...rest
     } = props;
     const browserHref = resolveClientHref(href);
+    const intentPrefetchKey = JSON.stringify([
+      browserHref,
+      target ?? null,
+      download ?? null,
+      prefetchData,
+    ]);
     const intentPrefetchRef = React.useRef<{
       readonly key: string;
       readonly controller: AbortController;
@@ -75,13 +81,6 @@ export function createLinkComponent(dependencies: {
       };
     }, [browserHref, dependencies, download, prefetch, prefetchData, target]);
 
-    React.useEffect(() => {
-      return () => {
-        intentPrefetchRef.current?.controller.abort();
-        intentPrefetchRef.current = null;
-      };
-    }, [browserHref, download, prefetch, prefetchData, target]);
-
     function abortIntentPrefetchIfIdle(): void {
       const intentState = intentStateRef.current;
 
@@ -98,10 +97,12 @@ export function createLinkComponent(dependencies: {
         return;
       }
 
-      const key = JSON.stringify([browserHref, target ?? null, download ?? null, prefetchData]);
       const currentPrefetch = intentPrefetchRef.current;
 
-      if (currentPrefetch?.key === key && !currentPrefetch.controller.signal.aborted) {
+      if (
+        currentPrefetch?.key === intentPrefetchKey &&
+        !currentPrefetch.controller.signal.aborted
+      ) {
         return;
       }
 
@@ -109,7 +110,7 @@ export function createLinkComponent(dependencies: {
 
       const controller = new AbortController();
       intentPrefetchRef.current = {
-        key,
+        key: intentPrefetchKey,
         controller,
       };
 
@@ -120,6 +121,19 @@ export function createLinkComponent(dependencies: {
         signal: controller.signal,
       });
     }
+
+    React.useEffect(() => {
+      const intentState = intentStateRef.current;
+
+      if (intentState.hover || intentState.focus || intentState.touch) {
+        startIntentPrefetch();
+      }
+
+      return () => {
+        intentPrefetchRef.current?.controller.abort();
+        intentPrefetchRef.current = null;
+      };
+    }, [intentPrefetchKey, prefetch]);
 
     return React.createElement("a", {
       ...rest,

--- a/tests/link-runtime.test.tsx
+++ b/tests/link-runtime.test.tsx
@@ -38,8 +38,9 @@ describe("link runtime", () => {
     root = null;
   });
 
-  test("prefetch intent warms same-origin routes without navigating", async () => {
+  test("prefetch intent coalesces duplicate events for the same route", async () => {
     const prefetchCalls: string[] = [];
+    const receivedSignals: AbortSignal[] = [];
 
     function App() {
       const RuntimeLink = React.useMemo(
@@ -63,6 +64,9 @@ describe("link runtime", () => {
                 })
               ) {
                 prefetchCalls.push(href);
+                if (options?.signal) {
+                  receivedSignals.push(options.signal);
+                }
               }
             },
           }),
@@ -86,8 +90,69 @@ describe("link runtime", () => {
       await flushDom();
     });
 
-    expect(prefetchCalls).toEqual(["/next", "/next", "/next"]);
+    expect(prefetchCalls).toEqual(["/next"]);
+    expect(receivedSignals).toHaveLength(1);
+    expect(receivedSignals[0]?.aborted).toBe(false);
     expect(window.location.href).toBe("https://example.com/current");
+  });
+
+  test("prefetch intent aborts in-flight data work when hover and focus end", async () => {
+    const receivedSignals: AbortSignal[] = [];
+
+    function App() {
+      const RuntimeLink = React.useMemo(
+        () =>
+          createLinkComponent({
+            useNavigate() {
+              return () => {
+                throw new Error("Intent prefetch should not navigate.");
+              };
+            },
+            prefetchRouteForHref(_href, options) {
+              if (options?.signal) {
+                receivedSignals.push(options.signal);
+              }
+            },
+          }),
+        [],
+      );
+
+      return (
+        <RuntimeLink href="/next" prefetchData>
+          Open next route
+        </RuntimeLink>
+      );
+    }
+
+    await act(async () => {
+      root?.render(<App />);
+      await flushDom();
+    });
+
+    const link = container?.getElementsByTagName("a")[0] ?? null;
+
+    await act(async () => {
+      link?.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+      link?.dispatchEvent(new Event("focusin", { bubbles: true }));
+      await flushDom();
+    });
+
+    expect(receivedSignals).toHaveLength(1);
+    expect(receivedSignals[0]?.aborted).toBe(false);
+
+    await act(async () => {
+      link?.dispatchEvent(new MouseEvent("mouseout", { bubbles: true }));
+      await flushDom();
+    });
+
+    expect(receivedSignals[0]?.aborted).toBe(false);
+
+    await act(async () => {
+      link?.dispatchEvent(new Event("focusout", { bubbles: true }));
+      await flushDom();
+    });
+
+    expect(receivedSignals[0]?.aborted).toBe(true);
   });
 
   test("external links do not prefetch or navigate through the client runtime", async () => {

--- a/tests/link-runtime.test.tsx
+++ b/tests/link-runtime.test.tsx
@@ -155,6 +155,70 @@ describe("link runtime", () => {
     expect(receivedSignals[0]?.aborted).toBe(true);
   });
 
+  test("prefetch intent restarts active intent work when the href changes", async () => {
+    const prefetchCalls: string[] = [];
+    const receivedSignals: AbortSignal[] = [];
+
+    function App() {
+      const [href, setHref] = React.useState("/next");
+      const RuntimeLink = React.useMemo(
+        () =>
+          createLinkComponent({
+            useNavigate() {
+              return () => {
+                throw new Error("Intent prefetch should not navigate.");
+              };
+            },
+            prefetchRouteForHref(nextHref, options) {
+              prefetchCalls.push(nextHref);
+
+              if (options?.signal) {
+                receivedSignals.push(options.signal);
+              }
+            },
+          }),
+        [],
+      );
+
+      return (
+        <>
+          <button id="change-href" onClick={() => setHref("/updated")} type="button">
+            Change href
+          </button>
+          <RuntimeLink href={href} prefetchData>
+            Open next route
+          </RuntimeLink>
+        </>
+      );
+    }
+
+    await act(async () => {
+      root?.render(<App />);
+      await flushDom();
+    });
+
+    const link = container?.getElementsByTagName("a")[0] ?? null;
+
+    await act(async () => {
+      link?.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+      await flushDom();
+    });
+
+    expect(prefetchCalls).toEqual(["/next"]);
+    expect(receivedSignals).toHaveLength(1);
+    expect(receivedSignals[0]?.aborted).toBe(false);
+
+    await act(async () => {
+      (document.getElementById("change-href") as HTMLButtonElement | null)?.click();
+      await flushDom();
+    });
+
+    expect(prefetchCalls).toEqual(["/next", "/updated"]);
+    expect(receivedSignals).toHaveLength(2);
+    expect(receivedSignals[0]?.aborted).toBe(true);
+    expect(receivedSignals[1]?.aborted).toBe(false);
+  });
+
   test("external links do not prefetch or navigate through the client runtime", async () => {
     function App() {
       const [prefetchCalls, setPrefetchCalls] = React.useState<string[]>([]);


### PR DESCRIPTION
## Summary

Closes #164.

This changes `<Link prefetch="intent">` so hover, focus, and touch-start events for the same href/options share a single in-flight prefetch instead of repeatedly starting duplicate work. Intent prefetch now creates an `AbortController` and passes its signal through to `prefetchRouteForHref`, matching the cancellation path already used by render prefetch.

The link tracks active intent sources independently, so leaving hover does not abort while focus is still active. Once hover, focus, and touch intent have all ended, the active controller is aborted and cleared. Render-prefetch behavior remains separate and unchanged.

## Root Cause

Intent prefetch directly called `prefetchRouteForHref` from each event handler without retaining any in-flight state or `AbortSignal`. Brief hovers, focus transitions, and touch starts could therefore duplicate route-module/loader-data work and leave loader-data requests running after intent disappeared.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`

## Changeset

Added `.changeset/cancellable-intent-prefetch.md` for the patch-level behavior fix.
