### PR TITLE
fix: support namespace import discovery

### DIFF
--- a/.changeset/namespace-import-discovery.md
+++ b/.changeset/namespace-import-discovery.md
@@ -1,0 +1,5 @@
+---
+"litzjs": patch
+---
+
+Support namespace imports when discovering route, layout, resource, and API route definitions.

--- a/src/vite/discovery.ts
+++ b/src/vite/discovery.ts
@@ -274,6 +274,7 @@ function hasObjectProperty(
 function resolveRouteLikeFactoryCall(
   expression: ts.Expression,
   bindings: ReadonlyMap<string, ts.Expression>,
+  factoryName: string,
   factoryNames: ReadonlySet<string>,
   factoryNamespaceNames: ReadonlySet<string>,
   seenBindings: Set<string>,
@@ -296,6 +297,7 @@ function resolveRouteLikeFactoryCall(
     return resolveRouteLikeFactoryCall(
       binding,
       bindings,
+      factoryName,
       factoryNames,
       factoryNamespaceNames,
       nextSeenBindings,
@@ -304,7 +306,7 @@ function resolveRouteLikeFactoryCall(
 
   if (
     ts.isCallExpression(unwrapped) &&
-    isRouteLikeFactoryCallee(unwrapped.expression, factoryNames, factoryNamespaceNames)
+    isRouteLikeFactoryCallee(unwrapped.expression, factoryName, factoryNames, factoryNamespaceNames)
   ) {
     const routeLikePath = getStringLiteralValue(unwrapped.arguments[0]);
 
@@ -328,6 +330,7 @@ function resolveRouteLikeFactoryCall(
     discoveredDefinition = resolveRouteLikeFactoryCall(
       child,
       bindings,
+      factoryName,
       factoryNames,
       factoryNamespaceNames,
       new Set(seenBindings),
@@ -341,6 +344,7 @@ function resolveRouteLikeFactoryCall(
 
 function isRouteLikeFactoryCallee(
   expression: ts.Expression,
+  factoryName: string,
   factoryNames: ReadonlySet<string>,
   factoryNamespaceNames: ReadonlySet<string>,
 ): boolean {
@@ -352,7 +356,7 @@ function isRouteLikeFactoryCallee(
     ts.isPropertyAccessExpression(expression) &&
     ts.isIdentifier(expression.expression) &&
     factoryNamespaceNames.has(expression.expression.text) &&
-    factoryNames.has(expression.name.text)
+    expression.name.text === factoryName
   ) {
     return true;
   }
@@ -418,6 +422,7 @@ function discoverExportedRouteLikeDefinition(
   const definition = resolveRouteLikeFactoryCall(
     ts.factory.createIdentifier(exportedBinding),
     bindings,
+    factoryName,
     factoryNames,
     importedFactoryNamespaceNames,
     new Set(),

--- a/src/vite/discovery.ts
+++ b/src/vite/discovery.ts
@@ -275,6 +275,7 @@ function resolveRouteLikeFactoryCall(
   expression: ts.Expression,
   bindings: ReadonlyMap<string, ts.Expression>,
   factoryNames: ReadonlySet<string>,
+  factoryNamespaceNames: ReadonlySet<string>,
   seenBindings: Set<string>,
 ): DiscoveredRouteLikeDefinition | null {
   const unwrapped = unwrapManifestExpression(expression);
@@ -292,13 +293,18 @@ function resolveRouteLikeFactoryCall(
 
     const nextSeenBindings = new Set(seenBindings);
     nextSeenBindings.add(unwrapped.text);
-    return resolveRouteLikeFactoryCall(binding, bindings, factoryNames, nextSeenBindings);
+    return resolveRouteLikeFactoryCall(
+      binding,
+      bindings,
+      factoryNames,
+      factoryNamespaceNames,
+      nextSeenBindings,
+    );
   }
 
   if (
     ts.isCallExpression(unwrapped) &&
-    ts.isIdentifier(unwrapped.expression) &&
-    factoryNames.has(unwrapped.expression.text)
+    isRouteLikeFactoryCallee(unwrapped.expression, factoryNames, factoryNamespaceNames)
   ) {
     const routeLikePath = getStringLiteralValue(unwrapped.arguments[0]);
 
@@ -323,6 +329,7 @@ function resolveRouteLikeFactoryCall(
       child,
       bindings,
       factoryNames,
+      factoryNamespaceNames,
       new Set(seenBindings),
     );
 
@@ -330,6 +337,27 @@ function resolveRouteLikeFactoryCall(
   });
 
   return discoveredDefinition;
+}
+
+function isRouteLikeFactoryCallee(
+  expression: ts.Expression,
+  factoryNames: ReadonlySet<string>,
+  factoryNamespaceNames: ReadonlySet<string>,
+): boolean {
+  if (ts.isIdentifier(expression)) {
+    return factoryNames.has(expression.text);
+  }
+
+  if (
+    ts.isPropertyAccessExpression(expression) &&
+    ts.isIdentifier(expression.expression) &&
+    factoryNamespaceNames.has(expression.expression.text) &&
+    factoryNames.has(expression.name.text)
+  ) {
+    return true;
+  }
+
+  return false;
 }
 
 function discoverExportedRouteLikeDefinition(
@@ -342,8 +370,9 @@ function discoverExportedRouteLikeDefinition(
   const bindings = new Map<string, ts.Expression>();
   const exportedBindings = new Map<string, string>();
   const importedFactoryNames = getImportedLitzFactoryNames(sourceFile, factoryName);
+  const importedFactoryNamespaceNames = getImportedLitzFactoryNamespaceNames(sourceFile);
   const factoryNames = new Set([factoryName, ...importedFactoryNames]);
-  const importsFactory = importedFactoryNames.size > 0;
+  const importsFactory = importedFactoryNames.size > 0 || importedFactoryNamespaceNames.size > 0;
 
   for (const statement of sourceFile.statements) {
     if (ts.isVariableStatement(statement)) {
@@ -390,6 +419,7 @@ function discoverExportedRouteLikeDefinition(
     ts.factory.createIdentifier(exportedBinding),
     bindings,
     factoryNames,
+    importedFactoryNamespaceNames,
     new Set(),
   );
 
@@ -398,6 +428,30 @@ function discoverExportedRouteLikeDefinition(
   }
 
   return definition;
+}
+
+function getImportedLitzFactoryNamespaceNames(sourceFile: ts.SourceFile): Set<string> {
+  const factoryNamespaceNames = new Set<string>();
+
+  for (const statement of sourceFile.statements) {
+    if (
+      !ts.isImportDeclaration(statement) ||
+      !ts.isStringLiteral(statement.moduleSpecifier) ||
+      statement.moduleSpecifier.text !== "litzjs"
+    ) {
+      continue;
+    }
+
+    const namedBindings = statement.importClause?.namedBindings;
+
+    if (!namedBindings || !ts.isNamespaceImport(namedBindings)) {
+      continue;
+    }
+
+    factoryNamespaceNames.add(namedBindings.name.text);
+  }
+
+  return factoryNamespaceNames;
 }
 
 function getImportedLitzFactoryNames(sourceFile: ts.SourceFile, factoryName: string): Set<string> {

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -3442,6 +3442,59 @@ describe("manifest discovery", () => {
       }
     });
 
+    test("discovers an exported route that uses a namespace import", async () => {
+      const root = createTempProject();
+
+      try {
+        const file = path.join(root, "src", "routes", "namespace-route.tsx");
+
+        writeFileSync(
+          file,
+          `import * as litz from "litzjs";\nexport const route = litz.defineRoute("/namespace", { component: Namespace });`,
+        );
+
+        const result = await discoverRouteFromFile(root, file);
+
+        expect(result).toEqual({
+          id: "/namespace",
+          path: "/namespace",
+          modulePath: "src/routes/namespace-route.tsx",
+          clientModulePath: null,
+        });
+      } finally {
+        rmSync(root, { force: true, recursive: true });
+      }
+    });
+
+    test("warns when a namespace route uses an unsupported dynamic path", async () => {
+      const root = createTempProject();
+      const warnings: string[] = [];
+      const originalWarn = console.warn;
+      console.warn = (message?: unknown) => {
+        warnings.push(String(message));
+      };
+
+      try {
+        const file = path.join(root, "src", "routes", "namespace-dynamic-path.tsx");
+
+        writeFileSync(
+          file,
+          `import * as litz from "litzjs";\nconst path = "/dynamic";\nexport const route = litz.defineRoute(path, { component: Dynamic });`,
+        );
+
+        const result = await discoverRouteFromFile(root, file);
+
+        expect(result).toBeNull();
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0]).toContain(
+          `exports "route", but the path could not be read from a static defineRoute call`,
+        );
+      } finally {
+        console.warn = originalWarn;
+        rmSync(root, { force: true, recursive: true });
+      }
+    });
+
     test("warns when an exported route uses an unsupported dynamic path", async () => {
       const root = createTempProject();
       const warnings: string[] = [];
@@ -3537,6 +3590,30 @@ describe("manifest discovery", () => {
           id: "/app",
           path: "/app",
           modulePath: "src/routes/app-layout.tsx",
+          clientModulePath: null,
+        });
+      } finally {
+        rmSync(root, { force: true, recursive: true });
+      }
+    });
+
+    test("discovers an exported layout that uses a namespace import", async () => {
+      const root = createTempProject();
+
+      try {
+        const file = path.join(root, "src", "routes", "namespace-layout.tsx");
+
+        writeFileSync(
+          file,
+          `import * as litz from "litzjs";\nexport const layout = litz.defineLayout("/namespace-layout", { component: NamespaceLayout });`,
+        );
+
+        const result = await discoverLayoutFromFile(root, file);
+
+        expect(result).toEqual({
+          id: "/namespace-layout",
+          path: "/namespace-layout",
+          modulePath: "src/routes/namespace-layout.tsx",
           clientModulePath: null,
         });
       } finally {
@@ -3668,6 +3745,39 @@ describe("manifest discovery", () => {
         rmSync(root, { force: true, recursive: true });
       }
     });
+
+    test("discovers a resource that uses an aliased namespace import", async () => {
+      const root = createTempProject();
+
+      try {
+        const file = path.join(root, "src", "routes", "resources", "namespace-resource.ts");
+
+        writeFileSync(
+          file,
+          [
+            `import * as framework from "litzjs";`,
+            `export const resource = framework.defineResource("/resource/namespace", {`,
+            `  loader: async () => {},`,
+            `  action: async () => {},`,
+            `  component: NamespaceResource,`,
+            `});`,
+          ].join("\n"),
+        );
+
+        const result = await discoverResourceFromFile(root, file);
+
+        expect(result).toEqual({
+          path: "/resource/namespace",
+          modulePath: "src/routes/resources/namespace-resource.ts",
+          clientModulePath: null,
+          hasLoader: true,
+          hasAction: true,
+          hasComponent: true,
+        });
+      } finally {
+        rmSync(root, { force: true, recursive: true });
+      }
+    });
   });
 
   describe("discoverApiRouteFromFile", () => {
@@ -3767,6 +3877,29 @@ describe("manifest discovery", () => {
         expect(result).toEqual({
           path: "/api/js-health",
           modulePath: "src/routes/api/health.mjs",
+          clientModulePath: null,
+        });
+      } finally {
+        rmSync(root, { force: true, recursive: true });
+      }
+    });
+
+    test("discovers an API route that uses an aliased namespace import", async () => {
+      const root = createTempProject();
+
+      try {
+        const file = path.join(root, "src", "routes", "api", "namespace-health.ts");
+
+        writeFileSync(
+          file,
+          `import * as framework from "litzjs";\nexport const api = framework.defineApiRoute("/api/namespace-health", { GET() { return Response.json({ ok: true }); } });`,
+        );
+
+        const result = await discoverApiRouteFromFile(root, file);
+
+        expect(result).toEqual({
+          path: "/api/namespace-health",
+          modulePath: "src/routes/api/namespace-health.ts",
           clientModulePath: null,
         });
       } finally {

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -3495,6 +3495,39 @@ describe("manifest discovery", () => {
       }
     });
 
+    test("does not treat named import aliases as namespace export names", async () => {
+      const root = createTempProject();
+      const warnings: string[] = [];
+      const originalWarn = console.warn;
+      console.warn = (message?: unknown) => {
+        warnings.push(String(message));
+      };
+
+      try {
+        const file = path.join(root, "src", "routes", "namespace-alias-property.tsx");
+
+        writeFileSync(
+          file,
+          [
+            `import * as litz from "litzjs";`,
+            `import { defineRoute as makeRoute } from "litzjs";`,
+            `export const route = litz.makeRoute("/invalid-namespace-alias", { component: Invalid });`,
+          ].join("\n"),
+        );
+
+        const result = await discoverRouteFromFile(root, file);
+
+        expect(result).toBeNull();
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0]).toContain(
+          `exports "route", but the path could not be read from a static defineRoute call`,
+        );
+      } finally {
+        console.warn = originalWarn;
+        rmSync(root, { force: true, recursive: true });
+      }
+    });
+
     test("warns when an exported route uses an unsupported dynamic path", async () => {
       const root = createTempProject();
       const warnings: string[] = [];


### PR DESCRIPTION
## Summary

Fixes #165.

This updates Vite manifest discovery so route-like factory calls are detected when they are accessed through a namespace import from `litzjs`, for example:

```ts
import * as litz from "litzjs";
export const route = litz.defineRoute("/", {});
```

## Changes

- Track `import * as ... from "litzjs"` namespace bindings during route-like discovery.
- Resolve factory callees from both named imports/aliases and namespace property access.
- Preserve unsupported dynamic path warnings for namespace-imported definitions.
- Add manifest discovery regression coverage for namespace-imported `defineRoute`, `defineLayout`, `defineResource`, and `defineApiRoute` calls, including aliased namespace imports.
- Add a patch changeset for the discovery behavior change.

## Verification

- `bun fmt`
- `bun lint:fix`
- `bun run test`
- `bun typecheck`
